### PR TITLE
fix: transport API 406 error and EditSource transport support

### DIFF
--- a/cmd/vsp/config_cmd.go
+++ b/cmd/vsp/config_cmd.go
@@ -539,6 +539,7 @@ SAP_MODE=focused
 # SAP_ALLOWED_OPS=RSQ
 
 # Feature Flags (optional, values: auto/on/off)
+# SAP_FEATURE_HANA=auto
 # SAP_FEATURE_ABAPGIT=auto
 # SAP_FEATURE_RAP=auto
 # SAP_FEATURE_AMDP=auto

--- a/cmd/vsp/main.go
+++ b/cmd/vsp/main.go
@@ -85,6 +85,7 @@ func init() {
 
 	// Feature configuration (safety network)
 	// Values: "auto" (default), "on", "off"
+	rootCmd.Flags().StringVar(&cfg.FeatureHANA, "feature-hana", "auto", "HANA database detection: auto, on, off")
 	rootCmd.Flags().StringVar(&cfg.FeatureAbapGit, "feature-abapgit", "auto", "abapGit integration: auto, on, off")
 	rootCmd.Flags().StringVar(&cfg.FeatureRAP, "feature-rap", "auto", "RAP/OData development: auto, on, off")
 	rootCmd.Flags().StringVar(&cfg.FeatureAMDP, "feature-amdp", "auto", "AMDP/HANA debugger: auto, on, off")
@@ -119,6 +120,7 @@ func init() {
 	viper.BindPFlag("verbose", rootCmd.Flags().Lookup("verbose"))
 
 	// Feature configuration
+	viper.BindPFlag("feature-hana", rootCmd.Flags().Lookup("feature-hana"))
 	viper.BindPFlag("feature-abapgit", rootCmd.Flags().Lookup("feature-abapgit"))
 	viper.BindPFlag("feature-rap", rootCmd.Flags().Lookup("feature-rap"))
 	viper.BindPFlag("feature-amdp", rootCmd.Flags().Lookup("feature-amdp"))
@@ -298,6 +300,11 @@ func resolveConfig(cmd *cobra.Command) {
 	}
 
 	// Feature configuration: flag > SAP_FEATURE_* env
+	if !cmd.Flags().Changed("feature-hana") {
+		if v := viper.GetString("FEATURE_HANA"); v != "" {
+			cfg.FeatureHANA = v
+		}
+	}
 	if !cmd.Flags().Changed("feature-abapgit") {
 		if v := viper.GetString("FEATURE_ABAPGIT"); v != "" {
 			cfg.FeatureAbapGit = v

--- a/internal/mcp/handlers_fileio.go
+++ b/internal/mcp/handlers_fileio.go
@@ -205,11 +205,17 @@ func (s *Server) handleEditSource(ctx context.Context, request mcp.CallToolReque
 		method = m
 	}
 
+	transport := ""
+	if t, ok := request.Params.Arguments["transport"].(string); ok {
+		transport = t
+	}
+
 	opts := &adt.EditSourceOptions{
 		ReplaceAll:      replaceAll,
 		SyntaxCheck:     syntaxCheck,
 		CaseInsensitive: caseInsensitive,
 		Method:          method,
+		Transport:       transport,
 	}
 
 	result, err := s.adtClient.EditSourceWithOptions(ctx, objectURL, oldString, newString, opts)

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -76,6 +76,7 @@ type Config struct {
 
 	// Feature configuration (safety network)
 	// Values: "auto" (default, probe system), "on" (force enabled), "off" (force disabled)
+	FeatureHANA      string // HANA database detection (required for some AMDP features)
 	FeatureAbapGit   string // abapGit integration
 	FeatureRAP       string // RAP/OData development (DDLS, BDEF, SRVD, SRVB)
 	FeatureAMDP      string // AMDP/HANA debugger
@@ -142,6 +143,7 @@ func NewServer(cfg *Config) *Server {
 
 	// Configure feature detection (safety network)
 	featureConfig := adt.FeatureConfig{
+		HANA:      parseFeatureMode(cfg.FeatureHANA),
 		AbapGit:   parseFeatureMode(cfg.FeatureAbapGit),
 		RAP:       parseFeatureMode(cfg.FeatureRAP),
 		AMDP:      parseFeatureMode(cfg.FeatureAMDP),
@@ -1642,6 +1644,9 @@ func (s *Server) registerTools(mode string, disabledGroups string) {
 		),
 		mcp.WithString("method",
 			mcp.Description("For CLAS only: constrain search/replace to this method only. Prevents accidental edits in other methods. (optional)"),
+		),
+		mcp.WithString("transport",
+			mcp.Description("Transport request number (required for objects not in $TMP package)"),
 		),
 	), s.handleEditSource)
 	}

--- a/pkg/adt/features.go
+++ b/pkg/adt/features.go
@@ -52,6 +52,8 @@ type FeatureStatus struct {
 
 // FeatureConfig controls which optional features are enabled
 type FeatureConfig struct {
+	// HANA controls HANA database detection (default: auto)
+	HANA FeatureMode
 	// AbapGit controls abapGit integration (default: auto)
 	AbapGit FeatureMode
 	// RAP controls RAP/OData tools (default: auto, usually available)
@@ -67,6 +69,7 @@ type FeatureConfig struct {
 // DefaultFeatureConfig returns default feature configuration (all auto-detect)
 func DefaultFeatureConfig() FeatureConfig {
 	return FeatureConfig{
+		HANA:      FeatureModeAuto,
 		AbapGit:   FeatureModeAuto,
 		RAP:       FeatureModeAuto,
 		AMDP:      FeatureModeAuto,
@@ -78,6 +81,8 @@ func DefaultFeatureConfig() FeatureConfig {
 // GetMode returns the mode for a specific feature
 func (f *FeatureConfig) GetMode(id FeatureID) FeatureMode {
 	switch id {
+	case FeatureHANA:
+		return f.HANA
 	case FeatureAbapGit:
 		return f.AbapGit
 	case FeatureRAP:

--- a/pkg/adt/transport.go
+++ b/pkg/adt/transport.go
@@ -57,6 +57,11 @@ type TransportInfo struct {
 	LockedInTask   string             `json:"lockedInTask,omitempty"`
 }
 
+const (
+	acceptTransportOrganizerV1     = "application/vnd.sap.adt.transportorganizer.v1+xml"
+	acceptTransportOrganizerTreeV1 = "application/vnd.sap.adt.transportorganizertree.v1+xml"
+)
+
 // --- Transport Operations ---
 
 // GetUserTransports retrieves all transport requests for a user.
@@ -72,6 +77,7 @@ func (c *Client) GetUserTransports(ctx context.Context, userName string) (*UserT
 	resp, err := c.transport.Request(ctx, "/sap/bc/adt/cts/transportrequests", &RequestOptions{
 		Method: http.MethodGet,
 		Query:  map[string][]string{"user": {userName}, "targets": {"true"}},
+		Accept: acceptTransportOrganizerTreeV1 + ", " + acceptTransportOrganizerV1 + ";q=0.9",
 	})
 	if err != nil {
 		return nil, fmt.Errorf("get user transports failed: %w", err)
@@ -438,7 +444,7 @@ func (c *Client) ListTransports(ctx context.Context, user string) ([]TransportSu
 	resp, err := c.transport.Request(ctx, "/sap/bc/adt/cts/transportrequests", &RequestOptions{
 		Method: http.MethodGet,
 		Query:  map[string][]string{"user": {strings.ToUpper(user)}},
-		Accept: "application/vnd.sap.adt.transportorganizertree.v1+xml",
+		Accept: acceptTransportOrganizerTreeV1,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("listing transports: %w", err)
@@ -507,7 +513,7 @@ func (c *Client) GetTransport(ctx context.Context, number string) (*TransportDet
 
 	resp, err := c.transport.Request(ctx, path, &RequestOptions{
 		Method: http.MethodGet,
-		Accept: "application/vnd.sap.adt.transportrequests.v1+xml",
+		Accept: acceptTransportOrganizerV1,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("getting transport %s: %w", number, err)
@@ -712,7 +718,7 @@ func (c *Client) ReleaseTransportV2(ctx context.Context, number string, opts Rel
 
 	_, err := c.transport.Request(ctx, path, &RequestOptions{
 		Method: http.MethodPost,
-		Accept: "application/vnd.sap.adt.transportrequests.v1+xml",
+		Accept: acceptTransportOrganizerV1,
 	})
 	if err != nil {
 		return fmt.Errorf("releasing transport %s: %w", number, err)
@@ -736,6 +742,7 @@ func (c *Client) DeleteTransport(ctx context.Context, number string) error {
 
 	_, err := c.transport.Request(ctx, path, &RequestOptions{
 		Method: http.MethodDelete,
+		Accept: acceptTransportOrganizerV1,
 	})
 	if err != nil {
 		return fmt.Errorf("deleting transport %s: %w", number, err)

--- a/pkg/adt/workflows.go
+++ b/pkg/adt/workflows.go
@@ -1171,6 +1171,7 @@ type EditSourceOptions struct {
 	SyntaxCheck     bool   // If true, validate syntax before saving (default: true if not set)
 	CaseInsensitive bool   // If true, ignore case when matching
 	Method          string // For CLAS only: constrain search/replace to this method only
+	Transport       string // Transport request number (required for non-$TMP packages)
 }
 
 // normalizeLineEndings converts CRLF to LF for consistent matching
@@ -1494,9 +1495,9 @@ func (c *Client) EditSourceWithOptions(ctx context.Context, objectURL, oldString
 	// 6. Update source
 	if isClassInclude && className != "" {
 		// Use UpdateClassInclude for class includes
-		err = c.UpdateClassInclude(ctx, className, includeType, newSource, lockResult.LockHandle, "")
+		err = c.UpdateClassInclude(ctx, className, includeType, newSource, lockResult.LockHandle, opts.Transport)
 	} else {
-		err = c.UpdateSource(ctx, sourceURL, newSource, lockResult.LockHandle, "")
+		err = c.UpdateSource(ctx, sourceURL, newSource, lockResult.LockHandle, opts.Transport)
 	}
 	if err != nil {
 		result.Message = fmt.Sprintf("Failed to update source: %v", err)


### PR DESCRIPTION
## Summary

Fixes #9 - Transport API returns 406 due to wrong Accept header.

- Use correct `Accept: application/vnd.sap.adt.transportorganizer.v1+xml` header for CTS transport endpoints
- Add `SAP_FEATURE_HANA` env var and `--feature-hana` CLI flag support
- Add `transport` parameter to EditSource tool for non-$TMP packages

## Changes

| File | Change |
|------|--------|
| `pkg/adt/transport.go` | Fix Accept headers for GetTransport, ReleaseTransport, DeleteTransport |
| `pkg/adt/features.go` | Add HANA feature mode support |
| `pkg/adt/workflows.go` | Add Transport field to EditSourceOptions |
| `internal/mcp/server.go` | Add transport parameter to EditSource tool, add FeatureHANA config |
| `internal/mcp/handlers_fileio.go` | Parse and pass transport parameter |
| `cmd/vsp/main.go` | Add --feature-hana flag and env var binding |
| `cmd/vsp/config_cmd.go` | Add SAP_FEATURE_HANA to template |

## Test Plan

- [x] `GetTransport` returns data without 406 error
- [x] `EditSource` with `transport` parameter successfully edits objects in transportable packages
- [x] All existing transport tests pass
- [x] Build succeeds