### PR TITLE
fix: packageExists fails for local packages with $ in name

### DIFF
--- a/pkg/adt/crud.go
+++ b/pkg/adt/crud.go
@@ -284,16 +284,10 @@ func isLockConflictError(err error) bool {
 
 // packageExists checks if a package exists in the system.
 // Returns true if package exists, false otherwise.
-// Uses direct packages API which returns 404 for non-existing packages.
+// Uses GetPackage (nodestructure API) which passes the package name as a query
+// parameter, avoiding URL path encoding issues with $ in local package names.
 func (c *Client) packageExists(ctx context.Context, packageName string) bool {
-	packageName = strings.ToUpper(packageName)
-	url := fmt.Sprintf("/sap/bc/adt/packages/%s", strings.ToLower(packageName))
-
-	_, err := c.transport.Request(ctx, url, &RequestOptions{
-		Method: http.MethodGet,
-		Accept: "application/vnd.sap.adt.packages.v1+xml",
-	})
-
+	_, err := c.GetPackage(ctx, packageName)
 	return err == nil
 }
 


### PR DESCRIPTION
## Summary
- `packageExists()` used a direct GET to `/sap/bc/adt/packages/$TMP` which caused URL path encoding issues with the `$` character, making the check always return false for local packages
- This blocked `CreateObject` for classes, interfaces, etc. even when the target package existed
- Replaced with a call to `GetPackage()` which uses the nodestructure API and passes the package name as a query parameter, avoiding the issue entirely

## Test plan
- [ ] Verify `CreateObject` succeeds for classes/interfaces in `$TMP`
- [ ] Verify `CreateObject` succeeds for classes/interfaces in `$Z...` local packages
- [ ] Verify `CreateObject` still rejects non-existent packages
- [ ] Unit tests pass (`go test ./...`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)