### PR TITLE
feat: add SetMessages tool for message class write support (SE91)

### DIFF
--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -406,6 +406,7 @@ func (s *Server) registerTools(mode string, disabledGroups string, toolsConfig m
 		"GetVariants":      true, // List report variants
 		"GetTextElements":  true, // Get program text elements
 		"SetTextElements":  true, // Set program text elements
+		"SetMessages":      true, // Add/update/delete messages in message class (SE91)
 
 		// Install/Setup tools
 		"InstallZADTVSP":   true, // Deploy ZADT_VSP WebSocket handler to SAP
@@ -618,6 +619,23 @@ func (s *Server) registerTools(mode string, disabledGroups string, toolsConfig m
 		), s.handleGetMessages)
 	}
 
+	// SetMessages - Add/update/delete messages in a message class (SE91)
+	if shouldRegister("SetMessages") {
+		s.mcpServer.AddTool(mcp.NewTool("SetMessages",
+			mcp.WithDescription("Add, update, or delete messages in an ABAP message class (SE91). Performs Lock → Read → Modify → Write → Unlock → Activate workflow. Set message text to empty string to delete a message."),
+			mcp.WithString("message_class",
+				mcp.Required(),
+				mcp.Description("Name of the message class (e.g., 'ZRAY_00')"),
+			),
+			mcp.WithString("messages",
+				mcp.Required(),
+				mcp.Description("JSON object of message number to text (e.g., '{\"001\":\"Hello &1\",\"002\":\"World\"}'. Set text to empty string to delete a message.)"),
+			),
+			mcp.WithString("transport",
+				mcp.Description("Transport request number (optional for $TMP)"),
+			),
+		), s.handleSetMessages)
+	}
 
 	// GetTransaction
 	if shouldRegister("GetTransaction") {

--- a/pkg/adt/client_test.go
+++ b/pkg/adt/client_test.go
@@ -227,3 +227,181 @@ func TestParseSRVBMetadata(t *testing.T) {
 		t.Errorf("expected service def name 'Z_RAP_TRAVEL', got '%s'", result.ServiceDefName)
 	}
 }
+
+func TestModifyMessageClassXML_AddMessage(t *testing.T) {
+	// Test with namespace-prefixed XML (typical SAP format)
+	xmlInput := `<?xml version="1.0" encoding="utf-8"?>
+<mc:messageClass xmlns:mc="http://www.sap.com/adt/MessageClass" mc:name="ZTEST_MC" mc:description="Test Message Class">
+<mc:messages mc:msgno="001" mc:msgtext="Hello &amp;1"/>
+<mc:messages mc:msgno="002" mc:msgtext="World &amp;1 &amp;2"/>
+</mc:messageClass>`
+
+	result, updated, deleted, err := modifyMessageClassXML([]byte(xmlInput), map[string]string{
+		"003": "New message",
+	}, map[string]string{"003": "LOCK123"})
+	if err != nil {
+		t.Fatalf("modifyMessageClassXML failed: %v", err)
+	}
+
+	xmlStr := string(result)
+	if !strings.Contains(xmlStr, `mc:msgno="003"`) {
+		t.Error("Output missing new message 003")
+	}
+	if !strings.Contains(xmlStr, `mc:msgtext="New message"`) {
+		t.Error("Output missing new message text")
+	}
+	if !strings.Contains(xmlStr, `mc:lockhandle="LOCK123"`) {
+		t.Error("Output missing lockhandle on new message")
+	}
+	if !strings.Contains(xmlStr, `mc:msgno="001"`) {
+		t.Error("Output missing existing message 001")
+	}
+	if len(updated) != 1 || updated["003"] != "New message" {
+		t.Errorf("updated = %v, want {003: New message}", updated)
+	}
+	if len(deleted) != 0 {
+		t.Errorf("deleted = %v, want empty", deleted)
+	}
+}
+
+func TestModifyMessageClassXML_UpdateMessage(t *testing.T) {
+	xmlInput := `<?xml version="1.0" encoding="utf-8"?>
+<mc:messageClass xmlns:mc="http://www.sap.com/adt/MessageClass" mc:name="ZMC" mc:description="Test">
+<mc:messages mc:msgno="001" mc:msgtext="Old text"/>
+</mc:messageClass>`
+
+	result, updated, _, err := modifyMessageClassXML([]byte(xmlInput), map[string]string{
+		"001": "New text",
+	}, nil)
+	if err != nil {
+		t.Fatalf("modifyMessageClassXML failed: %v", err)
+	}
+
+	xmlStr := string(result)
+	if strings.Contains(xmlStr, "Old text") {
+		t.Error("Output still contains old text")
+	}
+	if !strings.Contains(xmlStr, `mc:msgtext="New text"`) {
+		t.Errorf("Output missing updated text. Got:\n%s", xmlStr)
+	}
+	if len(updated) != 1 || updated["001"] != "New text" {
+		t.Errorf("updated = %v, want {001: New text}", updated)
+	}
+}
+
+func TestModifyMessageClassXML_DeleteMessage(t *testing.T) {
+	xmlInput := `<?xml version="1.0" encoding="utf-8"?>
+<mc:messageClass xmlns:mc="http://www.sap.com/adt/MessageClass" mc:name="ZMC" mc:description="Test">
+<mc:messages mc:msgno="001" mc:msgtext="Keep"/>
+<mc:messages mc:msgno="002" mc:msgtext="Delete me"/>
+</mc:messageClass>`
+
+	result, _, deleted, err := modifyMessageClassXML([]byte(xmlInput), map[string]string{
+		"002": "",
+	}, nil)
+	if err != nil {
+		t.Fatalf("modifyMessageClassXML failed: %v", err)
+	}
+
+	xmlStr := string(result)
+	if strings.Contains(xmlStr, "Delete me") {
+		t.Error("Output still contains deleted message")
+	}
+	if !strings.Contains(xmlStr, `mc:msgno="001"`) {
+		t.Error("Output missing kept message 001")
+	}
+	if len(deleted) != 1 || deleted[0] != "002" {
+		t.Errorf("deleted = %v, want [002]", deleted)
+	}
+}
+
+func TestModifyMessageClassXML_DeleteMessageWithChildren(t *testing.T) {
+	// Test deleting a message that has child elements (atom:link) - paired closing tag
+	xmlInput := `<?xml version="1.0" encoding="utf-8"?>
+<mc:messageClass xmlns:mc="http://www.sap.com/adt/MessageClass" mc:name="ZMC" mc:description="Test">
+<mc:messages mc:msgno="001" mc:msgtext="Keep">
+  <atom:link href="/sap/bc/adt/messageclass/zmc/messages/001" rel="http://www.sap.com/adt/relations/source" type="text/plain"/>
+</mc:messages>
+<mc:messages mc:msgno="002" mc:msgtext="Delete me">
+  <atom:link href="/sap/bc/adt/messageclass/zmc/messages/002" rel="http://www.sap.com/adt/relations/source" type="text/plain"/>
+</mc:messages>
+</mc:messageClass>`
+
+	result, _, deleted, err := modifyMessageClassXML([]byte(xmlInput), map[string]string{
+		"002": "",
+	}, nil)
+	if err != nil {
+		t.Fatalf("modifyMessageClassXML failed: %v", err)
+	}
+
+	xmlStr := string(result)
+	if strings.Contains(xmlStr, "Delete me") {
+		t.Errorf("Output still contains deleted message. Got:\n%s", xmlStr)
+	}
+	if strings.Contains(xmlStr, "messages/002") {
+		t.Errorf("Output still contains deleted message's atom:link. Got:\n%s", xmlStr)
+	}
+	if !strings.Contains(xmlStr, `mc:msgno="001"`) {
+		t.Error("Output missing kept message 001")
+	}
+	if !strings.Contains(xmlStr, "messages/001") {
+		t.Error("Output missing kept message's atom:link")
+	}
+	if len(deleted) != 1 || deleted[0] != "002" {
+		t.Errorf("deleted = %v, want [002]", deleted)
+	}
+}
+
+func TestModifyMessageClassXML_NoNamespace(t *testing.T) {
+	// Test with non-namespaced XML
+	xmlInput := `<?xml version="1.0" encoding="utf-8"?>
+<messageClass name="ZMC_SIMPLE" description="Simple">
+<messages msgno="010" msgtext="Test"/>
+</messageClass>`
+
+	result, updated, _, err := modifyMessageClassXML([]byte(xmlInput), map[string]string{
+		"010": "Updated",
+		"020": "New",
+	}, map[string]string{"020": "LOCK456"})
+	if err != nil {
+		t.Fatalf("modifyMessageClassXML failed: %v", err)
+	}
+
+	xmlStr := string(result)
+	if !strings.Contains(xmlStr, `msgtext="Updated"`) {
+		t.Errorf("Output missing updated text. Got:\n%s", xmlStr)
+	}
+	if !strings.Contains(xmlStr, `msgno="020"`) {
+		t.Errorf("Output missing new message 020. Got:\n%s", xmlStr)
+	}
+	if len(updated) != 2 {
+		t.Errorf("updated count = %d, want 2", len(updated))
+	}
+}
+
+func TestModifyMessageClassXML_EscapeSpecialChars(t *testing.T) {
+	xmlInput := `<?xml version="1.0" encoding="utf-8"?>
+<messageClass name="ZMC" description="Test">
+</messageClass>`
+
+	result, _, _, err := modifyMessageClassXML([]byte(xmlInput), map[string]string{
+		"001": `Value with "quotes" & <angles>`,
+	}, map[string]string{"001": "LOCKESC"})
+	if err != nil {
+		t.Fatalf("modifyMessageClassXML failed: %v", err)
+	}
+
+	xmlStr := string(result)
+	if !strings.Contains(xmlStr, "&amp;") {
+		t.Error("& not escaped")
+	}
+	if !strings.Contains(xmlStr, "&lt;") {
+		t.Error("< not escaped")
+	}
+	if !strings.Contains(xmlStr, "&gt;") {
+		t.Error("> not escaped")
+	}
+	if !strings.Contains(xmlStr, "&quot;") {
+		t.Error("\" not escaped")
+	}
+}


### PR DESCRIPTION
## Summary
- New `SetMessages` MCP tool for adding, updating, and deleting messages in ABAP message classes
- Raw XML round-tripping preserves SAP's exact namespace format (mc:, adtcore:, atom:)
- Workflow: Lock → Read → Modify → PUT → Unlock → Activate
- Per-message lock with object lock handle fallback for session compatibility
- 6 unit tests covering add, update, delete (self-closing + paired elements), no-namespace, XML escaping

## Test plan
- [x] Update existing message - verified on `/IIE/CM_ROME_USRADM`
- [x] Add new message - verified with message 999
- [x] Delete message - verified removal and activation
- [x] Combined operations (update + add + delete in one call)
- [x] Cleanup/restore original state
- [x] Unit tests pass (`go test ./...`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)