### PR TITLE
fix: add missing `items` to DebuggerGetVariables array schema (#24)

### DIFF
--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -1039,6 +1039,7 @@ func (s *Server) registerTools(mode string, disabledGroups string, toolsConfig m
 			mcp.WithDescription("Get variable values during a debug session. Use '@ROOT' to get top-level variables, or specific variable IDs to get their values."),
 			mcp.WithArray("variable_ids",
 				mcp.Description("Variable IDs to retrieve (e.g., ['@ROOT'] for top-level, or specific IDs like ['LV_COUNT', 'LS_DATA'])"),
+				mcp.Items(map[string]interface{}{"type": "string"}),
 			),
 		), s.handleDebuggerGetVariables)
 	}


### PR DESCRIPTION
## Summary

Adds the missing `mcp.Items(map[string]interface{}{"type": "string"})` to the `variable_ids` array parameter on the `DebuggerGetVariables` tool registration.

This is a one-line fix for #24.

## Problem

The `DebuggerGetVariables` tool declares `variable_ids` as a JSON Schema `array` but omits the required `items` property. This produces invalid JSON Schema:

```json
{
  "variable_ids": {
    "type": "array",
    "description": "Variable IDs to retrieve ..."
  }
}
```

Per the [JSON Schema specification](https://json-schema.org/understanding-json-schema/reference/array#items), an `array` type **must** include `items` to describe the element type. Without it, OpenAI and any strict JSON Schema validator reject the **entire** tool set with a 400 error — breaking all tools, not just the debugger.

## Fix

```diff
 mcp.WithArray("variable_ids",
     mcp.Description("Variable IDs to retrieve (e.g., ['@ROOT'] for top-level, or specific IDs like ['LV_COUNT', 'LS_DATA'])"),
+    mcp.Items(map[string]interface{}{"type": "string"}),
 ),
```

This matches the pattern already used by all other array parameters in the codebase (`GrepObjects.object_urls`, `GrepPackages.packages`, `GrepPackages.object_types` in `handlers_codeintel.go`).

## Audit

I audited all `WithArray` calls in the codebase. Results:

| File | Parameter | Has `Items`? |
|------|-----------|:---:|
| `internal/mcp/server.go` | `DebuggerGetVariables.variable_ids` | **no** (fixed in this PR) |
| `internal/mcp/handlers_codeintel.go` | `GrepObjects.object_urls` | yes |
| `internal/mcp/handlers_codeintel.go` | `GrepPackages.packages` | yes |
| `internal/mcp/handlers_codeintel.go` | `GrepPackages.object_types` | yes |

`DebuggerGetVariables` was the **only** affected tool.

## Verification

- `go build ./...` — compiles cleanly
- `go test ./...` — all unit tests pass (including `internal/mcp` package tests)

```
ok  	github.com/oisee/vibing-steampunk/internal/mcp	0.355s
ok  	github.com/oisee/vibing-steampunk/pkg/adt	0.550s
ok  	github.com/oisee/vibing-steampunk/pkg/cache	0.345s
ok  	github.com/oisee/vibing-steampunk/pkg/config	0.504s
ok  	github.com/oisee/vibing-steampunk/pkg/dsl	0.665s
ok  	github.com/oisee/vibing-steampunk/pkg/scripting	0.505s
```

## Disclosure

This fix was identified, implemented, and audited with the assistance of an AI (Claude). The root-cause analysis from #24 was used as the starting point. The AI verified the fix compiles and passes all existing tests, and audited the full codebase for similar issues.

Fixes #24

Made with [Cursor](https://cursor.com)