### PR TITLE
fix: add missing GetDependencyZIP function to fix build

### DIFF
--- a/embedded/deps/embed.go
+++ b/embedded/deps/embed.go
@@ -34,6 +34,13 @@ type DependencyInfo struct {
 	Objects     []string // Object names (populated on load)
 }
 
+// GetDependencyZIP returns the embedded ZIP data for a named dependency, or nil if not found.
+func GetDependencyZIP(name string) []byte {
+	// Currently no ZIPs are embedded; return nil for all lookups.
+	_ = name
+	return nil
+}
+
 // GetAvailableDependencies returns list of embedded dependencies.
 func GetAvailableDependencies() []DependencyInfo {
 	return []DependencyInfo{


### PR DESCRIPTION
## Summary
- `handlers_deploy.go:64` calls `deps.GetDependencyZIP(source)` but the function was never defined in `embedded/deps/embed.go`, breaking the build on all platforms.
- Adds a stub that returns `nil` since no dependency ZIPs are currently embedded (all dependencies have `Available: false`).

## Test plan
- [x] `go build ./cmd/vsp` completes successfully
- [x] Existing behavior unchanged (no ZIPs were embedded before)

Fixes #28