### PR TITLE
feat: add pagination and schema introspection to GetTableContents

### DIFF
--- a/embedded/deps/embed.go
+++ b/embedded/deps/embed.go
@@ -34,6 +34,13 @@ type DependencyInfo struct {
 	Objects     []string // Object names (populated on load)
 }
 
+// GetDependencyZIP returns the embedded ZIP data for a named dependency, or nil if not found.
+func GetDependencyZIP(name string) []byte {
+	// Currently no ZIPs are embedded; return nil for all lookups.
+	_ = name
+	return nil
+}
+
 // GetAvailableDependencies returns list of embedded dependencies.
 func GetAvailableDependencies() []DependencyInfo {
 	return []DependencyInfo{

--- a/internal/mcp/handlers_read.go
+++ b/internal/mcp/handlers_read.go
@@ -128,12 +128,27 @@ func (s *Server) handleGetTableContents(ctx context.Context, request mcp.CallToo
 		maxRows = int(mr)
 	}
 
+	offset := 0
+	if o, ok := request.Params.Arguments["offset"].(float64); ok && o > 0 {
+		offset = int(o)
+	}
+
 	sqlQuery := ""
 	if sq, ok := request.Params.Arguments["sql_query"].(string); ok {
 		sqlQuery = sq
 	}
 
-	contents, err := s.adtClient.GetTableContents(ctx, tableName, maxRows, sqlQuery)
+	columnsOnly := false
+	if co, ok := request.Params.Arguments["columns_only"].(bool); ok {
+		columnsOnly = co
+	}
+
+	contents, err := s.adtClient.GetTableContentsWithOptions(ctx, tableName, &adt.GetTableContentsOptions{
+		MaxRows:     maxRows,
+		Offset:      offset,
+		SQLFilter:   sqlQuery,
+		ColumnsOnly: columnsOnly,
+	})
 	if err != nil {
 		return newToolResultError(fmt.Sprintf("Failed to get table contents: %v", err)), nil
 	}

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -533,7 +533,7 @@ func (s *Server) registerTools(mode string, disabledGroups string, toolsConfig m
 	// GetTableContents
 	if shouldRegister("GetTableContents") {
 		s.mcpServer.AddTool(mcp.NewTool("GetTableContents",
-		mcp.WithDescription("Retrieve contents of an ABAP table. For simple queries use table_name + max_rows. For filtered queries use sql_query parameter with ABAP SQL syntax (use ASCENDING/DESCENDING, not ASC/DESC)."),
+		mcp.WithDescription("Retrieve contents of an ABAP table. For simple queries use table_name + max_rows. For filtered queries use sql_query parameter with ABAP SQL syntax (use ASCENDING/DESCENDING, not ASC/DESC). Use offset for pagination. Use columns_only=true for schema introspection."),
 		mcp.WithString("table_name",
 			mcp.Required(),
 			mcp.Description("Name of the ABAP table"),
@@ -541,8 +541,14 @@ func (s *Server) registerTools(mode string, disabledGroups string, toolsConfig m
 		mcp.WithNumber("max_rows",
 			mcp.Description("Maximum number of rows to retrieve (default 100). Use this instead of SQL LIMIT clause"),
 		),
+		mcp.WithNumber("offset",
+			mcp.Description("Skip first N rows from results (default 0). Use with max_rows for pagination, e.g., offset=100, max_rows=100 for page 2"),
+		),
 		mcp.WithString("sql_query",
 			mcp.Description("Optional ABAP SQL SELECT statement. Uses ABAP syntax: ASCENDING/DESCENDING work, ASC/DESC fail. Example: SELECT * FROM T000 WHERE MANDT = '001' ORDER BY MANDT DESCENDING"),
+		),
+		mcp.WithBoolean("columns_only",
+			mcp.Description("If true, return only column metadata (name, type, length, key) without data rows. Use for schema introspection. Default: false"),
 		),
 	), s.handleGetTableContents)
 	}

--- a/pkg/adt/client.go
+++ b/pkg/adt/client.go
@@ -609,37 +609,92 @@ type TableColumn struct {
 	IsKey       bool
 }
 
+// GetTableContentsOptions provides optional parameters for GetTableContents.
+type GetTableContentsOptions struct {
+	MaxRows     int    // Maximum rows to retrieve (default 100)
+	Offset      int    // Skip first N rows from results (default 0)
+	SQLFilter   string // Optional ABAP SQL WHERE clause or full SELECT
+	ColumnsOnly bool   // If true, return only column metadata (no data rows)
+}
+
 // GetTableContents retrieves data from a database table.
 // Optional sqlQuery can be a full SELECT statement to filter/transform results
 // (e.g., "SELECT * FROM T000 WHERE MANDT = '001'").
 func (c *Client) GetTableContents(ctx context.Context, tableName string, maxRows int, sqlFilter string) (*TableContentsResult, error) {
+	return c.GetTableContentsWithOptions(ctx, tableName, &GetTableContentsOptions{
+		MaxRows:   maxRows,
+		SQLFilter: sqlFilter,
+	})
+}
+
+// GetTableContentsWithOptions retrieves data from a database table with extended options.
+func (c *Client) GetTableContentsWithOptions(ctx context.Context, tableName string, opts *GetTableContentsOptions) (*TableContentsResult, error) {
 	tableName = strings.ToUpper(tableName)
+	if opts == nil {
+		opts = &GetTableContentsOptions{}
+	}
+
+	maxRows := opts.MaxRows
 	if maxRows <= 0 {
 		maxRows = 100
 	}
 
+	// For columns_only, we still need to query but with minimal rows
+	if opts.ColumnsOnly {
+		maxRows = 1
+	}
+
+	// Request extra rows to handle offset client-side
+	fetchRows := maxRows
+	if opts.Offset > 0 {
+		fetchRows = maxRows + opts.Offset
+	}
+
 	params := url.Values{}
-	params.Set("rowNumber", fmt.Sprintf("%d", maxRows))
+	params.Set("rowNumber", fmt.Sprintf("%d", fetchRows))
 	params.Set("ddicEntityName", tableName)
 
-	opts := &RequestOptions{
+	reqOpts := &RequestOptions{
 		Method: http.MethodPost,
 		Query:  params,
 		Accept: "application/*",
 	}
 
 	// Add SQL filter as request body if provided
-	if sqlFilter != "" {
-		opts.Body = []byte(sqlFilter)
-		opts.ContentType = "text/plain"
+	if opts.SQLFilter != "" {
+		reqOpts.Body = []byte(opts.SQLFilter)
+		reqOpts.ContentType = "text/plain"
 	}
 
-	resp, err := c.transport.Request(ctx, "/sap/bc/adt/datapreview/ddic", opts)
+	resp, err := c.transport.Request(ctx, "/sap/bc/adt/datapreview/ddic", reqOpts)
 	if err != nil {
 		return nil, fmt.Errorf("getting table contents: %w", err)
 	}
 
-	return parseTableContents(resp.Body)
+	result, err := parseTableContents(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	// Apply columns_only: strip all rows
+	if opts.ColumnsOnly {
+		result.Rows = nil
+		return result, nil
+	}
+
+	// Apply offset: skip first N rows
+	if opts.Offset > 0 && opts.Offset < len(result.Rows) {
+		result.Rows = result.Rows[opts.Offset:]
+	} else if opts.Offset >= len(result.Rows) {
+		result.Rows = nil
+	}
+
+	// Trim to requested max_rows after offset
+	if len(result.Rows) > maxRows {
+		result.Rows = result.Rows[:maxRows]
+	}
+
+	return result, nil
 }
 
 // RunQuery executes a freestyle SQL query against the SAP database.


### PR DESCRIPTION
## Summary
Adds two new parameters to `GetTableContents`:
- **`offset`**: skip first N rows for pagination (e.g., `offset=100, max_rows=100` for page 2)
- **`columns_only`**: return only column metadata (name, type, description, length, key) without data rows — for schema introspection

## Changes
- `pkg/adt/client.go` — new `GetTableContentsWithOptions` method with `GetTableContentsOptions` struct; existing `GetTableContents` delegates to it (backward compatible)
- `internal/mcp/handlers_read.go` — parse `offset` and `columns_only` parameters
- `internal/mcp/server.go` — register new parameters on GetTableContents tool

## Test plan
- [x] `go build ./pkg/adt/` — compiles cleanly
- [x] Pre-existing unit tests pass
- [x] **Live system test passed** against a SAP system:
  - `columns_only=true` on T000: returned 17 columns with full metadata, no data rows
  - `offset=0, max_rows=2`: returned first 2 rows (clients 000, 001)
  - `offset=2, max_rows=2`: returned next 2 rows (clients 070, 100) — different data, pagination works

Refs #34