### PR TITLE
Fix: Exporting function module source code to local files

### DIFF
--- a/internal/mcp/handlers_fileio.go
+++ b/internal/mcp/handlers_fileio.go
@@ -72,6 +72,16 @@ func (s *Server) handleSaveToFile(ctx context.Context, request mcp.CallToolReque
 		includeStr = strings.ToLower(inc)
 	}
 
+	// Check for parent/function_group parameter (required for FUNC type)
+	parentName := ""
+	if p, ok := request.Params.Arguments["parent"].(string); ok {
+		parentName = p
+	} else if p, ok := request.Params.Arguments["function_group"].(string); ok {
+		parentName = p
+	} else if p, ok := request.Params.Arguments["parentName"].(string); ok {
+		parentName = p
+	}
+
 	// Parse object type - support both short (PROG) and full (PROG/P) format
 	var objType adt.CreatableObjectType
 	switch strings.ToUpper(objTypeStr) {
@@ -122,7 +132,7 @@ func (s *Server) handleSaveToFile(ctx context.Context, request mcp.CallToolReque
 		return mcp.NewToolResultText(string(output)), nil
 	}
 
-	result, err := s.adtClient.SaveToFile(ctx, objType, objectName, outputPath)
+	result, err := s.adtClient.SaveToFile(ctx, objType, objectName, parentName, outputPath)
 	if err != nil {
 		return newToolResultError(fmt.Sprintf("SaveToFile failed: %v", err)), nil
 	}

--- a/pkg/adt/namespace_test.go
+++ b/pkg/adt/namespace_test.go
@@ -241,7 +241,7 @@ func TestNamespace_ExportToFile(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			result, err := client.SaveToFile(ctx, tc.objType, tc.name, tmpDir)
+			result, err := client.SaveToFile(ctx, tc.objType, tc.name, "", tmpDir)
 			if err != nil {
 				t.Fatalf("SaveToFile(%s, %s) failed: %v", tc.objType, tc.name, err)
 			}
@@ -378,7 +378,7 @@ func TestNamespace_RoundTrip(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			// 1. Export
-			exportResult, err := client.SaveToFile(ctx, tc.objType, tc.name, tmpDir)
+			exportResult, err := client.SaveToFile(ctx, tc.objType, tc.name, "", tmpDir)
 			if err != nil || !exportResult.Success {
 				t.Fatalf("Export failed: %v - %s", err, exportResult.Message)
 			}

--- a/pkg/adt/workflows.go
+++ b/pkg/adt/workflows.go
@@ -1011,7 +1011,7 @@ type SaveToFileResult struct {
 // Workflow: GetSource → WriteFile
 //
 // The file extension is automatically determined based on object type.
-func (c *Client) SaveToFile(ctx context.Context, objType CreatableObjectType, objectName, outputPath string) (*SaveToFileResult, error) {
+func (c *Client) SaveToFile(ctx context.Context, objType CreatableObjectType, objectName, parentName, outputPath string) (*SaveToFileResult, error) {
 	result := &SaveToFileResult{
 		ObjectName: objectName,
 		ObjectType: string(objType),
@@ -1028,6 +1028,8 @@ func (c *Client) SaveToFile(ctx context.Context, objType CreatableObjectType, ob
 		ext = ".intf.abap"
 	case ObjectTypeFunctionGroup:
 		ext = ".fugr.abap"
+	case ObjectTypeFunctionMod:
+		ext = ".func.abap"
 	case ObjectTypeInclude:
 		ext = ".abap"
 	// RAP object types (using ABAPGit-compatible extensions)
@@ -1056,7 +1058,7 @@ func (c *Client) SaveToFile(ctx context.Context, objType CreatableObjectType, ob
 	}
 
 	// 3. Get object source
-	objectURL, err := c.buildObjectURL(objType, objectName)
+	objectURL, err := c.buildObjectURLWithParent(objType, objectName, parentName)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/dsl/import.go
+++ b/pkg/dsl/import.go
@@ -499,7 +499,7 @@ func (b *ExportBuilder) exportObject(ctx context.Context, obj ExportObject) Expo
 	if obj.Type == adt.ObjectTypeClass && obj.IncludeType != "" && obj.IncludeType != adt.ClassIncludeMain {
 		saveResult, err = b.client.SaveClassIncludeToFile(ctx, obj.Name, obj.IncludeType, b.outputDir)
 	} else {
-		saveResult, err = b.client.SaveToFile(ctx, obj.Type, obj.Name, b.outputDir)
+		saveResult, err = b.client.SaveToFile(ctx, obj.Type, obj.Name, "", b.outputDir)
 	}
 
 	if err != nil {


### PR DESCRIPTION
This fixes the ExportToFile tool, where exporting a function module results in the error "SaveToFile failed: function module requires parent function group name".

**Steps to reproduce:**

Tool input:
```
{
  "function_group": "ZFUGR",
  "object_name": "ZFM",
  "object_type": "FUNC",
  "output_dir": "/home/dominik/playground/abap"
}
```
Tool output:
`"SaveToFile failed: function module requires parent function group name"`

✅ I tested that this fix works
✅ I ran all unit tests successfully