### PR TITLE
fix: Session not found — use stateless ADT sessions by default

### DIFF
--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -141,6 +141,11 @@ func NewServer(cfg *Config) *Server {
 	}
 	opts = append(opts, adt.WithSafety(safety))
 
+	// Use stateless sessions by default. Stateful sessions cause sap-contextid
+	// cookies to leak across ADT endpoints, resulting in "Session not found" errors
+	// on systems with aggressive ICF session management (e.g., EDZ).
+	opts = append(opts, adt.WithSessionType(adt.SessionStateless))
+
 	adtClient := adt.NewClient(cfg.BaseURL, cfg.Username, cfg.Password, opts...)
 
 	// Set terminal ID for debugger operations

--- a/pkg/adt/config.go
+++ b/pkg/adt/config.go
@@ -215,8 +215,6 @@ func WithTerminalID(terminalID string) Option {
 
 // NewHTTPClient creates an http.Client configured for the given Config.
 func (c *Config) NewHTTPClient() *http.Client {
-	jar, _ := cookiejar.New(nil)
-
 	transport := &http.Transport{
 		Proxy: http.ProxyFromEnvironment, // Honor HTTP_PROXY/HTTPS_PROXY env vars
 		TLSClientConfig: &tls.Config{
@@ -224,9 +222,16 @@ func (c *Config) NewHTTPClient() *http.Client {
 		},
 	}
 
-	return &http.Client{
-		Jar:       jar,
+	client := &http.Client{
 		Transport: transport,
 		Timeout:   c.Timeout,
 	}
+
+	// Always use cookie jar — needed for CSRF token correlation (sap-XSRF cookie)
+	// and MYSAPSSO2 session continuity between CSRF fetch and data request.
+	// The X-sap-adt-sessiontype header controls whether sap-contextid is issued.
+	jar, _ := cookiejar.New(nil)
+	client.Jar = jar
+
+	return client
 }

--- a/pkg/adt/http.go
+++ b/pkg/adt/http.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/http/cookiejar"
 	"net/url"
 	"strings"
 	"sync"
@@ -166,6 +167,12 @@ func (t *Transport) Request(ctx context.Context, path string, opts *RequestOptio
 			// Clear cached CSRF token and session ID
 			t.setCSRFToken("")
 			t.setSessionID("")
+			// Clear stale cookies by replacing the cookie jar (but keep the
+			// same http.Client and Transport to preserve TCP connections)
+			if client, ok := t.httpClient.(*http.Client); ok {
+				jar, _ := cookiejar.New(nil)
+				client.Jar = jar
+			}
 			// Fetch new CSRF token (this establishes a new session)
 			if err := t.fetchCSRFToken(ctx); err != nil {
 				return nil, fmt.Errorf("refreshing session after timeout: %w", err)
@@ -180,6 +187,10 @@ func (t *Transport) Request(ctx context.Context, path string, opts *RequestOptio
 		if resp.StatusCode == http.StatusUnauthorized {
 			t.setCSRFToken("")
 			t.setSessionID("")
+			if client, ok := t.httpClient.(*http.Client); ok {
+				jar, _ := cookiejar.New(nil)
+				client.Jar = jar
+			}
 			if err := t.fetchCSRFToken(ctx); err != nil {
 				// Return both errors: re-auth failure wraps the original 401 context
 				// so callers can see which endpoint triggered the expiry.
@@ -367,11 +378,15 @@ func (t *Transport) setDefaultHeaders(req *http.Request, opts *RequestOptions) {
 		req.Header.Set(k, v)
 	}
 
-	// Set session header based on session type
+	// Set session header based on session type.
+	// Default to stateless to prevent sap-contextid cross-endpoint conflicts.
+	// When no session type is configured, SAP ICF may return sap-contextid from
+	// one endpoint (e.g., /core/discovery) which then causes "Session not found"
+	// errors when sent to a different endpoint (e.g., /datapreview/freestyle).
 	switch t.config.SessionType {
 	case SessionStateful:
 		req.Header.Set("X-sap-adt-sessiontype", "stateful")
-	case SessionStateless:
+	default:
 		req.Header.Set("X-sap-adt-sessiontype", "stateless")
 	}
 }
@@ -447,7 +462,8 @@ func (e *APIError) IsSessionExpired() bool {
 	msg := strings.ToLower(e.Message)
 	return strings.Contains(msg, "icmenosession") ||
 		strings.Contains(msg, "session timed out") ||
-		strings.Contains(msg, "session no longer exists")
+		strings.Contains(msg, "session no longer exists") ||
+		strings.Contains(msg, "session not found")
 }
 
 // IsNotFoundError checks if an error is an API 404 Not Found error.


### PR DESCRIPTION
## Summary

- Default `SessionType` was `SessionStateful`, causing SAP ICF to return `sap-contextid` cookies bound to the first ADT endpoint (`/core/discovery`)
- Subsequent requests to different endpoints (`/datapreview/freestyle`) failed with **400 "Session not found"** because EDZ looked for the context ID in the wrong handler pool
- All POST-based operations (RunQuery, GetTableContents) were broken; GET operations (SearchObject, GetSource) worked because they skip CSRF

## Changes

- `server.go`: Set `WithSessionType(SessionStateless)` — prevents `sap-contextid` while keeping `MYSAPSSO2` + `sap-XSRF` for CSRF
- `http.go`: `IsSessionExpired()` now matches `"session not found"` (EDZ's actual error text)
- `http.go`: Session recovery clears cookie jar via replacement to discard stale cookies
- `http.go`: `setDefaultHeaders` defaults to `X-sap-adt-sessiontype: stateless`
- `config.go`: Cookie jar always created regardless of session type (needed for CSRF correlation)

## Test plan

- [ ] RunQuery works on first call (no prior session)
- [ ] GetTableContents works on first call
- [ ] SearchObject still works
- [ ] GetSource still works
- [ ] Sequential tool calls work without session errors
- [ ] Stateful sessions (debugger) still work when explicitly configured