### PR TITLE
feat: add ADT refactoring and quick fix tools (5 tools, 33 tests)

### DIFF
--- a/internal/mcp/handlers_refactoring.go
+++ b/internal/mcp/handlers_refactoring.go
@@ -1,0 +1,223 @@
+// Package mcp provides the MCP server implementation for ABAP ADT tools.
+// handlers_refactoring.go contains handlers for ADT refactoring operations
+// (Rename, Extract Method, Quick Fix, ATC QuickFix).
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/mark3labs/mcp-go/mcp"
+)
+
+// --- Refactoring Handlers ---
+
+func (s *Server) handleRenameRefactoring(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	objectURI, _ := request.Params.Arguments["object_uri"].(string)
+	step, _ := request.Params.Arguments["step"].(string)
+	newName, _ := request.Params.Arguments["new_name"].(string)
+	source, _ := request.Params.Arguments["source"].(string)
+
+	if objectURI == "" || step == "" || newName == "" {
+		return newToolResultError("object_uri, step, and new_name are required"), nil
+	}
+
+	line := 1
+	col := 1
+	if l, ok := request.Params.Arguments["line"].(float64); ok {
+		line = int(l)
+	}
+	if c, ok := request.Params.Arguments["column"].(float64); ok {
+		col = int(c)
+	}
+
+	switch step {
+	case "evaluate":
+		if source == "" {
+			return newToolResultError("source is required for evaluate step"), nil
+		}
+		result, err := s.adtClient.RenameEvaluate(ctx, objectURI, line, col, source, newName)
+		if err != nil {
+			return newToolResultError(fmt.Sprintf("RenameRefactoring evaluate failed: %v", err)), nil
+		}
+		output, _ := json.MarshalIndent(result, "", "  ")
+		return mcp.NewToolResultText(string(output)), nil
+
+	case "preview":
+		if source == "" {
+			return newToolResultError("source is required for preview step"), nil
+		}
+		result, err := s.adtClient.RenamePreview(ctx, objectURI, line, col, source, newName)
+		if err != nil {
+			return newToolResultError(fmt.Sprintf("RenameRefactoring preview failed: %v", err)), nil
+		}
+		output, _ := json.MarshalIndent(result, "", "  ")
+		return mcp.NewToolResultText(string(output)), nil
+
+	case "execute":
+		if source == "" {
+			return newToolResultError("source is required for execute step"), nil
+		}
+		result, err := s.adtClient.RenameExecute(ctx, objectURI, line, col, source, newName)
+		if err != nil {
+			return newToolResultError(fmt.Sprintf("RenameRefactoring execute failed: %v", err)), nil
+		}
+		output, _ := json.MarshalIndent(result, "", "  ")
+		return mcp.NewToolResultText(string(output)), nil
+
+	default:
+		return newToolResultError(fmt.Sprintf("invalid step '%s': must be evaluate, preview, or execute", step)), nil
+	}
+}
+
+func (s *Server) handleExtractMethod(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	objectURI, _ := request.Params.Arguments["object_uri"].(string)
+	step, _ := request.Params.Arguments["step"].(string)
+	methodName, _ := request.Params.Arguments["method_name"].(string)
+	source, _ := request.Params.Arguments["source"].(string)
+
+	if objectURI == "" || step == "" || methodName == "" {
+		return newToolResultError("object_uri, step, and method_name are required"), nil
+	}
+	if source == "" {
+		return newToolResultError("source is required"), nil
+	}
+
+	startLine := 1
+	startCol := 1
+	endLine := 1
+	endCol := 1
+	if v, ok := request.Params.Arguments["start_line"].(float64); ok {
+		startLine = int(v)
+	}
+	if v, ok := request.Params.Arguments["start_col"].(float64); ok {
+		startCol = int(v)
+	}
+	if v, ok := request.Params.Arguments["end_line"].(float64); ok {
+		endLine = int(v)
+	}
+	if v, ok := request.Params.Arguments["end_col"].(float64); ok {
+		endCol = int(v)
+	}
+
+	switch step {
+	case "evaluate":
+		result, err := s.adtClient.ExtractMethodEvaluate(ctx, objectURI, startLine, startCol, endLine, endCol, source, methodName)
+		if err != nil {
+			return newToolResultError(fmt.Sprintf("ExtractMethod evaluate failed: %v", err)), nil
+		}
+		output, _ := json.MarshalIndent(result, "", "  ")
+		return mcp.NewToolResultText(string(output)), nil
+
+	case "preview":
+		result, err := s.adtClient.ExtractMethodPreview(ctx, objectURI, startLine, startCol, endLine, endCol, source, methodName)
+		if err != nil {
+			return newToolResultError(fmt.Sprintf("ExtractMethod preview failed: %v", err)), nil
+		}
+		output, _ := json.MarshalIndent(result, "", "  ")
+		return mcp.NewToolResultText(string(output)), nil
+
+	case "execute":
+		result, err := s.adtClient.ExtractMethodExecute(ctx, objectURI, startLine, startCol, endLine, endCol, source, methodName)
+		if err != nil {
+			return newToolResultError(fmt.Sprintf("ExtractMethod execute failed: %v", err)), nil
+		}
+		output, _ := json.MarshalIndent(result, "", "  ")
+		return mcp.NewToolResultText(string(output)), nil
+
+	default:
+		return newToolResultError(fmt.Sprintf("invalid step '%s': must be evaluate, preview, or execute", step)), nil
+	}
+}
+
+// --- Quick Fix Handlers ---
+
+func (s *Server) handleGetQuickFixProposals(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	objectURI, _ := request.Params.Arguments["object_uri"].(string)
+	source, _ := request.Params.Arguments["source"].(string)
+
+	if objectURI == "" || source == "" {
+		return newToolResultError("object_uri and source are required"), nil
+	}
+
+	line := 1
+	col := 1
+	if l, ok := request.Params.Arguments["line"].(float64); ok {
+		line = int(l)
+	}
+	if c, ok := request.Params.Arguments["column"].(float64); ok {
+		col = int(c)
+	}
+
+	result, err := s.adtClient.GetQuickFixProposals(ctx, objectURI, line, col, source)
+	if err != nil {
+		return newToolResultError(fmt.Sprintf("GetQuickFixProposals failed: %v", err)), nil
+	}
+
+	output, _ := json.MarshalIndent(result, "", "  ")
+	return mcp.NewToolResultText(string(output)), nil
+}
+
+func (s *Server) handleApplyQuickFix(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	objectURI, _ := request.Params.Arguments["object_uri"].(string)
+	proposalID, _ := request.Params.Arguments["proposal_id"].(string)
+	source, _ := request.Params.Arguments["source"].(string)
+
+	if objectURI == "" || proposalID == "" || source == "" {
+		return newToolResultError("object_uri, proposal_id, and source are required"), nil
+	}
+
+	line := 1
+	col := 1
+	if l, ok := request.Params.Arguments["line"].(float64); ok {
+		line = int(l)
+	}
+	if c, ok := request.Params.Arguments["column"].(float64); ok {
+		col = int(c)
+	}
+
+	result, err := s.adtClient.ApplyQuickFix(ctx, objectURI, proposalID, line, col, source)
+	if err != nil {
+		return newToolResultError(fmt.Sprintf("ApplyQuickFix failed: %v", err)), nil
+	}
+
+	output, _ := json.MarshalIndent(result, "", "  ")
+	return mcp.NewToolResultText(string(output)), nil
+}
+
+// --- ATC Quick Fix Handlers ---
+
+func (s *Server) handleApplyATCQuickFix(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	findingID, _ := request.Params.Arguments["finding_id"].(string)
+
+	if findingID == "" {
+		return newToolResultError("finding_id is required (from RunATCCheck finding's quickfixInfo field)"), nil
+	}
+
+	step, _ := request.Params.Arguments["step"].(string)
+	if step == "" {
+		step = "apply"
+	}
+
+	switch step {
+	case "details":
+		result, err := s.adtClient.GetATCQuickFixDetails(ctx, findingID)
+		if err != nil {
+			return newToolResultError(fmt.Sprintf("GetATCQuickFixDetails failed: %v", err)), nil
+		}
+		output, _ := json.MarshalIndent(result, "", "  ")
+		return mcp.NewToolResultText(string(output)), nil
+
+	case "apply":
+		result, err := s.adtClient.ApplyATCQuickFix(ctx, findingID)
+		if err != nil {
+			return newToolResultError(fmt.Sprintf("ApplyATCQuickFix failed: %v", err)), nil
+		}
+		output, _ := json.MarshalIndent(result, "", "  ")
+		return mcp.NewToolResultText(string(output)), nil
+
+	default:
+		return newToolResultError(fmt.Sprintf("invalid step '%s': must be details or apply", step)), nil
+	}
+}

--- a/internal/mcp/tools_focused.go
+++ b/internal/mcp/tools_focused.go
@@ -108,6 +108,13 @@ func focusedToolSet() map[string]bool {
 		"AMDPSetBreakpoint":  true,
 		"AMDPGetBreakpoints": true,
 
+		// ADT Refactoring & Quick Fix (5)
+		"RenameRefactoring":    true, // ADT-native rename (evaluate/preview/execute)
+		"ExtractMethod":        true, // Extract code block into new method
+		"GetQuickFixProposals": true, // Get auto-fix proposals for errors/warnings
+		"ApplyQuickFix":        true, // Apply a quick fix proposal
+		"ApplyATCQuickFix":     true, // Get details or apply ATC finding quick fix
+
 		// CTS/Transport Management (2 read-only in focused mode)
 		"ListTransports": true, // List transport requests
 		"GetTransport":   true, // Get transport details with objects

--- a/internal/mcp/tools_register.go
+++ b/internal/mcp/tools_register.go
@@ -87,6 +87,7 @@ func (s *Server) registerTools(mode string, disabledGroups string, toolsConfig m
 	s.registerGitTools(shouldRegister)
 	s.registerReportTools(shouldRegister)
 	s.registerInstallTools(shouldRegister)
+	s.registerRefactoringTools(shouldRegister)
 
 	// Register tool aliases for common operations
 	s.registerToolAliases(shouldRegister)
@@ -1946,5 +1947,131 @@ func (s *Server) registerInstallTools(shouldRegister func(string) bool) {
 				mcp.Description("Deploy only objects matching this name pattern (e.g., 'ZCL_ABAPGIT_*')"),
 			),
 		), s.handleDeployZip)
+	}
+}
+
+// registerRefactoringTools registers ADT refactoring and quick fix tools.
+func (s *Server) registerRefactoringTools(shouldRegister func(string) bool) {
+	// RenameRefactoring - ADT-native rename with cross-reference support
+	if shouldRegister("RenameRefactoring") {
+		s.mcpServer.AddTool(mcp.NewTool("RenameRefactoring",
+			mcp.WithDescription("ADT-native rename refactoring with full cross-reference support. Three-step flow: evaluate (check feasibility) → preview (see all changes) → execute (apply). Much better than manual rename — handles all references automatically."),
+			mcp.WithString("object_uri",
+				mcp.Required(),
+				mcp.Description("ADT object URI (e.g., /sap/bc/adt/programs/programs/ZTEST or /sap/bc/adt/oo/classes/ZCL_FOO)"),
+			),
+			mcp.WithString("step",
+				mcp.Required(),
+				mcp.Description("Refactoring step: evaluate (check feasibility), preview (see all changes), execute (apply rename)"),
+			),
+			mcp.WithString("new_name",
+				mcp.Required(),
+				mcp.Description("The new name for the symbol"),
+			),
+			mcp.WithNumber("line",
+				mcp.Description("Line number of the symbol to rename (1-based)"),
+			),
+			mcp.WithNumber("column",
+				mcp.Description("Column number of the symbol to rename (1-based)"),
+			),
+			mcp.WithString("source",
+				mcp.Description("Current source code of the object (required for evaluate/preview/execute)"),
+			),
+		), s.handleRenameRefactoring)
+	}
+
+	// ExtractMethod - Extract code block into a new method
+	if shouldRegister("ExtractMethod") {
+		s.mcpServer.AddTool(mcp.NewTool("ExtractMethod",
+			mcp.WithDescription("Extract a selected code block into a new method. Three-step flow: evaluate (check feasibility, get inferred params) → preview (see new method + modified code) → execute (apply). Automatically infers parameters, return types."),
+			mcp.WithString("object_uri",
+				mcp.Required(),
+				mcp.Description("ADT object URI (e.g., /sap/bc/adt/oo/classes/ZCL_FOO)"),
+			),
+			mcp.WithString("step",
+				mcp.Required(),
+				mcp.Description("Refactoring step: evaluate, preview, or execute"),
+			),
+			mcp.WithString("method_name",
+				mcp.Required(),
+				mcp.Description("Name for the new extracted method"),
+			),
+			mcp.WithString("source",
+				mcp.Required(),
+				mcp.Description("Current source code of the object"),
+			),
+			mcp.WithNumber("start_line",
+				mcp.Description("Start line of the code block to extract (1-based)"),
+			),
+			mcp.WithNumber("start_col",
+				mcp.Description("Start column of the code block (1-based)"),
+			),
+			mcp.WithNumber("end_line",
+				mcp.Description("End line of the code block to extract (1-based)"),
+			),
+			mcp.WithNumber("end_col",
+				mcp.Description("End column of the code block (1-based)"),
+			),
+		), s.handleExtractMethod)
+	}
+
+	// GetQuickFixProposals - Get auto-fix suggestions for errors/warnings
+	if shouldRegister("GetQuickFixProposals") {
+		s.mcpServer.AddTool(mcp.NewTool("GetQuickFixProposals",
+			mcp.WithDescription("Get available quick fix proposals for an error or warning at a specific position. Use after SyntaxCheck to get auto-fix suggestions. Returns proposal IDs to use with ApplyQuickFix."),
+			mcp.WithString("object_uri",
+				mcp.Required(),
+				mcp.Description("ADT object URI (e.g., /sap/bc/adt/programs/programs/ZTEST)"),
+			),
+			mcp.WithString("source",
+				mcp.Required(),
+				mcp.Description("Current source code of the object"),
+			),
+			mcp.WithNumber("line",
+				mcp.Description("Line number of the error/warning (1-based, from SyntaxCheck)"),
+			),
+			mcp.WithNumber("column",
+				mcp.Description("Column number of the error/warning (1-based, from SyntaxCheck)"),
+			),
+		), s.handleGetQuickFixProposals)
+	}
+
+	// ApplyQuickFix - Apply a quick fix proposal
+	if shouldRegister("ApplyQuickFix") {
+		s.mcpServer.AddTool(mcp.NewTool("ApplyQuickFix",
+			mcp.WithDescription("Apply a specific quick fix proposal to source code. Use proposal_id from GetQuickFixProposals. Returns the corrected source code."),
+			mcp.WithString("object_uri",
+				mcp.Required(),
+				mcp.Description("ADT object URI"),
+			),
+			mcp.WithString("proposal_id",
+				mcp.Required(),
+				mcp.Description("Proposal ID from GetQuickFixProposals"),
+			),
+			mcp.WithString("source",
+				mcp.Required(),
+				mcp.Description("Current source code of the object"),
+			),
+			mcp.WithNumber("line",
+				mcp.Description("Line number of the error/warning (1-based)"),
+			),
+			mcp.WithNumber("column",
+				mcp.Description("Column number of the error/warning (1-based)"),
+			),
+		), s.handleApplyQuickFix)
+	}
+
+	// ApplyATCQuickFix - Get details or apply ATC finding quick fix
+	if shouldRegister("ApplyATCQuickFix") {
+		s.mcpServer.AddTool(mcp.NewTool("ApplyATCQuickFix",
+			mcp.WithDescription("Get details or apply quick fix for an ATC finding. Use finding_id from RunATCCheck output (the quickfixInfo field). Two steps: details (check what the fix does) or apply (execute the fix)."),
+			mcp.WithString("finding_id",
+				mcp.Required(),
+				mcp.Description("Finding ID from RunATCCheck result (quickfixInfo field of an ATCFinding)"),
+			),
+			mcp.WithString("step",
+				mcp.Description("Step: details (get fix info) or apply (execute fix). Default: apply"),
+			),
+		), s.handleApplyATCQuickFix)
 	}
 }

--- a/pkg/adt/quickfix.go
+++ b/pkg/adt/quickfix.go
@@ -1,0 +1,254 @@
+package adt
+
+import (
+	"context"
+	"encoding/xml"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+)
+
+// --- Quick Fix Proposals ---
+
+// QuickFixProposal represents a single auto-fix suggestion from the ADT quickfix engine.
+type QuickFixProposal struct {
+	ID          string `json:"id" xml:"id,attr"`
+	Title       string `json:"title" xml:"title,attr"`
+	Description string `json:"description,omitempty" xml:"description,attr"`
+}
+
+// QuickFixProposalsResult is the result of querying quick fix proposals.
+type QuickFixProposalsResult struct {
+	Proposals []QuickFixProposal `json:"proposals"`
+}
+
+// QuickFixApplyResult is the result of applying a quick fix.
+type QuickFixApplyResult struct {
+	Success   bool   `json:"success"`
+	NewSource string `json:"newSource,omitempty"`
+	Message   string `json:"message,omitempty"`
+}
+
+// GetQuickFixProposals retrieves available quick fix suggestions at a given position.
+// objectURI is the ADT object URI (e.g., "/sap/bc/adt/programs/programs/ZTEST")
+// line and col are 1-based position of the error/warning.
+// source is the current source code.
+func (c *Client) GetQuickFixProposals(ctx context.Context, objectURI string, line, col int, source string) (*QuickFixProposalsResult, error) {
+	if err := c.checkSafety(OpRead, "GetQuickFixProposals"); err != nil {
+		return nil, err
+	}
+
+	q := url.Values{}
+	q.Set("uri", objectURI)
+	q.Set("line", fmt.Sprintf("%d", line))
+	q.Set("column", fmt.Sprintf("%d", col))
+
+	resp, err := c.transport.Request(ctx, "/sap/bc/adt/quickfix/proposals", &RequestOptions{
+		Method:      http.MethodPost,
+		Query:       q,
+		Body:        []byte(source),
+		ContentType: "text/plain",
+		Accept:      "application/xml",
+	})
+	if err != nil {
+		return nil, fmt.Errorf("get quickfix proposals failed: %w", err)
+	}
+
+	return parseQuickFixProposals(resp.Body)
+}
+
+func parseQuickFixProposals(data []byte) (*QuickFixProposalsResult, error) {
+	xmlStr := string(data)
+	xmlStr = strings.ReplaceAll(xmlStr, "quickfix:", "")
+
+	type proposal struct {
+		ID          string `xml:"id,attr"`
+		Title       string `xml:"title,attr"`
+		Description string `xml:"description,attr"`
+	}
+	type proposals struct {
+		XMLName xml.Name   `xml:"proposals"`
+		Items   []proposal `xml:"proposal"`
+	}
+
+	var resp proposals
+	if err := xml.Unmarshal([]byte(xmlStr), &resp); err != nil {
+		return nil, fmt.Errorf("parsing quickfix proposals: %w", err)
+	}
+
+	result := &QuickFixProposalsResult{}
+	for _, p := range resp.Items {
+		result.Proposals = append(result.Proposals, QuickFixProposal{
+			ID:          p.ID,
+			Title:       p.Title,
+			Description: p.Description,
+		})
+	}
+	return result, nil
+}
+
+// ApplyQuickFix applies a specific quick fix proposal.
+// proposalID is the ID from GetQuickFixProposals.
+// source is the current source code.
+func (c *Client) ApplyQuickFix(ctx context.Context, objectURI string, proposalID string, line, col int, source string) (*QuickFixApplyResult, error) {
+	if err := c.checkSafety(OpUpdate, "ApplyQuickFix"); err != nil {
+		return nil, err
+	}
+
+	q := url.Values{}
+	q.Set("uri", objectURI)
+	q.Set("proposalId", proposalID)
+	q.Set("line", fmt.Sprintf("%d", line))
+	q.Set("column", fmt.Sprintf("%d", col))
+
+	resp, err := c.transport.Request(ctx, "/sap/bc/adt/quickfix/apply", &RequestOptions{
+		Method:      http.MethodPost,
+		Query:       q,
+		Body:        []byte(source),
+		ContentType: "text/plain",
+		Accept:      "application/xml, text/plain",
+	})
+	if err != nil {
+		return nil, fmt.Errorf("apply quickfix failed: %w", err)
+	}
+
+	return parseQuickFixApplyResult(resp.Body)
+}
+
+func parseQuickFixApplyResult(data []byte) (*QuickFixApplyResult, error) {
+	body := string(data)
+
+	// If response is plain text, it's the new source code
+	if !strings.Contains(body, "<?xml") && !strings.Contains(body, "<quickfix") {
+		return &QuickFixApplyResult{
+			Success:   true,
+			NewSource: body,
+		}, nil
+	}
+
+	// XML response
+	xmlStr := strings.ReplaceAll(body, "quickfix:", "")
+
+	type result struct {
+		XMLName   xml.Name `xml:"result"`
+		Status    string   `xml:"status,attr"`
+		NewSource string   `xml:"newSource"`
+		Message   string   `xml:"message"`
+	}
+
+	var resp result
+	if err := xml.Unmarshal([]byte(xmlStr), &resp); err != nil {
+		return nil, fmt.Errorf("parsing quickfix apply result: %w", err)
+	}
+
+	return &QuickFixApplyResult{
+		Success:   resp.Status == "OK" || resp.Status == "success",
+		NewSource: resp.NewSource,
+		Message:   resp.Message,
+	}, nil
+}
+
+// --- ATC Quick Fix ---
+
+// ATCQuickFixDetails contains the details of an ATC finding's available quick fix.
+type ATCQuickFixDetails struct {
+	FindingID   string `json:"findingId"`
+	Title       string `json:"title,omitempty"`
+	Description string `json:"description,omitempty"`
+	CanAutoFix  bool   `json:"canAutoFix"`
+}
+
+// ATCQuickFixApplyResult is the result of applying an ATC quick fix.
+type ATCQuickFixApplyResult struct {
+	Success bool   `json:"success"`
+	Message string `json:"message,omitempty"`
+}
+
+// GetATCQuickFixDetails retrieves quick fix details for a specific ATC finding.
+// findingID is from the ATCFinding.QuickfixInfo field.
+func (c *Client) GetATCQuickFixDetails(ctx context.Context, findingID string) (*ATCQuickFixDetails, error) {
+	path := fmt.Sprintf("/sap/bc/adt/atc/quickfix/%s", url.PathEscape(findingID))
+
+	resp, err := c.transport.Request(ctx, path, &RequestOptions{
+		Method: http.MethodGet,
+		Accept: "application/xml",
+	})
+	if err != nil {
+		return nil, fmt.Errorf("get ATC quickfix details failed: %w", err)
+	}
+
+	return parseATCQuickFixDetails(resp.Body, findingID)
+}
+
+func parseATCQuickFixDetails(data []byte, findingID string) (*ATCQuickFixDetails, error) {
+	xmlStr := string(data)
+	xmlStr = strings.ReplaceAll(xmlStr, "atcquickfix:", "")
+
+	type details struct {
+		XMLName     xml.Name `xml:"quickfixDetails"`
+		Title       string   `xml:"title,attr"`
+		Description string   `xml:"description,attr"`
+		CanAutoFix  bool     `xml:"canAutoFix,attr"`
+	}
+
+	var resp details
+	if err := xml.Unmarshal([]byte(xmlStr), &resp); err != nil {
+		// If parsing fails, return basic info
+		return &ATCQuickFixDetails{
+			FindingID:  findingID,
+			CanAutoFix: false,
+		}, nil
+	}
+
+	return &ATCQuickFixDetails{
+		FindingID:   findingID,
+		Title:       resp.Title,
+		Description: resp.Description,
+		CanAutoFix:  resp.CanAutoFix,
+	}, nil
+}
+
+// ApplyATCQuickFix applies the quick fix for a specific ATC finding.
+func (c *Client) ApplyATCQuickFix(ctx context.Context, findingID string) (*ATCQuickFixApplyResult, error) {
+	if err := c.checkSafety(OpUpdate, "ApplyATCQuickFix"); err != nil {
+		return nil, err
+	}
+
+	path := fmt.Sprintf("/sap/bc/adt/atc/quickfix/%s/apply", url.PathEscape(findingID))
+
+	resp, err := c.transport.Request(ctx, path, &RequestOptions{
+		Method: http.MethodPost,
+		Accept: "application/xml",
+	})
+	if err != nil {
+		return nil, fmt.Errorf("apply ATC quickfix failed: %w", err)
+	}
+
+	return parseATCQuickFixApplyResult(resp.Body)
+}
+
+func parseATCQuickFixApplyResult(data []byte) (*ATCQuickFixApplyResult, error) {
+	xmlStr := string(data)
+	xmlStr = strings.ReplaceAll(xmlStr, "atcquickfix:", "")
+
+	type result struct {
+		XMLName xml.Name `xml:"applyResult"`
+		Success bool     `xml:"success,attr"`
+		Message string   `xml:"message,attr"`
+	}
+
+	var resp result
+	if err := xml.Unmarshal([]byte(xmlStr), &resp); err != nil {
+		// SAP ADT may return non-XML on success. Include raw response for debugging.
+		return &ATCQuickFixApplyResult{
+			Success: true,
+			Message: fmt.Sprintf("ATC quickfix applied (non-XML response: %s)", truncate(string(data), 200)),
+		}, nil
+	}
+
+	return &ATCQuickFixApplyResult{
+		Success: resp.Success,
+		Message: resp.Message,
+	}, nil
+}

--- a/pkg/adt/quickfix_test.go
+++ b/pkg/adt/quickfix_test.go
@@ -1,0 +1,318 @@
+package adt
+
+import (
+	"context"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+// --- Quick Fix Proposals Tests ---
+
+func TestParseQuickFixProposals(t *testing.T) {
+	xmlResponse := `<?xml version="1.0" encoding="UTF-8"?>
+<quickfix:proposals xmlns:quickfix="http://www.sap.com/adt/quickfix">
+  <quickfix:proposal quickfix:id="QF001" quickfix:title="Add missing IMPORTING parameter"
+                     quickfix:description="Adds the required parameter IV_NAME to method call"/>
+  <quickfix:proposal quickfix:id="QF002" quickfix:title="Remove unused variable"
+                     quickfix:description="Removes the declaration of LV_UNUSED"/>
+</quickfix:proposals>`
+
+	result, err := parseQuickFixProposals([]byte(xmlResponse))
+	if err != nil {
+		t.Fatalf("parseQuickFixProposals failed: %v", err)
+	}
+
+	if len(result.Proposals) != 2 {
+		t.Fatalf("Expected 2 proposals, got %d", len(result.Proposals))
+	}
+	if result.Proposals[0].ID != "QF001" {
+		t.Errorf("Proposal[0].ID = %q, want %q", result.Proposals[0].ID, "QF001")
+	}
+	if result.Proposals[0].Title != "Add missing IMPORTING parameter" {
+		t.Errorf("Proposal[0].Title = %q", result.Proposals[0].Title)
+	}
+	if result.Proposals[1].ID != "QF002" {
+		t.Errorf("Proposal[1].ID = %q, want %q", result.Proposals[1].ID, "QF002")
+	}
+}
+
+func TestParseQuickFixProposals_Empty(t *testing.T) {
+	xmlResponse := `<?xml version="1.0" encoding="UTF-8"?>
+<quickfix:proposals xmlns:quickfix="http://www.sap.com/adt/quickfix"/>`
+
+	result, err := parseQuickFixProposals([]byte(xmlResponse))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(result.Proposals) != 0 {
+		t.Errorf("Expected 0 proposals, got %d", len(result.Proposals))
+	}
+}
+
+// --- Quick Fix Apply Tests ---
+
+func TestParseQuickFixApplyResult_XMLResponse(t *testing.T) {
+	xmlResponse := `<?xml version="1.0" encoding="UTF-8"?>
+<quickfix:result xmlns:quickfix="http://www.sap.com/adt/quickfix" quickfix:status="OK">
+  <quickfix:newSource>REPORT ztest.
+DATA lv_name TYPE string.
+WRITE lv_name.</quickfix:newSource>
+  <quickfix:message>Quick fix applied successfully</quickfix:message>
+</quickfix:result>`
+
+	result, err := parseQuickFixApplyResult([]byte(xmlResponse))
+	if err != nil {
+		t.Fatalf("parseQuickFixApplyResult failed: %v", err)
+	}
+
+	if !result.Success {
+		t.Error("Expected success=true")
+	}
+	if !strings.Contains(result.NewSource, "REPORT ztest") {
+		t.Error("NewSource should contain ABAP code")
+	}
+	if result.Message != "Quick fix applied successfully" {
+		t.Errorf("Message = %q", result.Message)
+	}
+}
+
+func TestParseQuickFixApplyResult_PlainTextResponse(t *testing.T) {
+	// Some quickfix endpoints return plain text (the fixed source directly)
+	plainSource := `REPORT ztest.
+DATA lv_name TYPE string.
+WRITE lv_name.`
+
+	result, err := parseQuickFixApplyResult([]byte(plainSource))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if !result.Success {
+		t.Error("Expected success=true for plain text response")
+	}
+	if !strings.Contains(result.NewSource, "REPORT ztest") {
+		t.Error("NewSource should contain the source code")
+	}
+}
+
+// --- ATC QuickFix Tests ---
+
+func TestParseATCQuickFixDetails(t *testing.T) {
+	xmlResponse := `<?xml version="1.0" encoding="UTF-8"?>
+<atcquickfix:quickfixDetails xmlns:atcquickfix="http://www.sap.com/adt/atc/quickfix"
+                              atcquickfix:title="Replace deprecated statement"
+                              atcquickfix:description="Replace MOVE with assignment operator"
+                              atcquickfix:canAutoFix="true"/>`
+
+	result, err := parseATCQuickFixDetails([]byte(xmlResponse), "FINDING123")
+	if err != nil {
+		t.Fatalf("parseATCQuickFixDetails failed: %v", err)
+	}
+
+	if result.FindingID != "FINDING123" {
+		t.Errorf("FindingID = %q, want %q", result.FindingID, "FINDING123")
+	}
+	if result.Title != "Replace deprecated statement" {
+		t.Errorf("Title = %q", result.Title)
+	}
+	if !result.CanAutoFix {
+		t.Error("Expected canAutoFix=true")
+	}
+}
+
+func TestParseATCQuickFixDetails_UnparsableResponse(t *testing.T) {
+	// When parsing fails, should return basic info without error
+	result, err := parseATCQuickFixDetails([]byte("unexpected response"), "FINDING456")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if result.FindingID != "FINDING456" {
+		t.Errorf("FindingID = %q, want %q", result.FindingID, "FINDING456")
+	}
+	if result.CanAutoFix {
+		t.Error("Expected canAutoFix=false for unparsable response")
+	}
+}
+
+func TestParseATCQuickFixApplyResult(t *testing.T) {
+	xmlResponse := `<?xml version="1.0" encoding="UTF-8"?>
+<atcquickfix:applyResult xmlns:atcquickfix="http://www.sap.com/adt/atc/quickfix"
+                          atcquickfix:success="true" atcquickfix:message="Fix applied to 3 locations"/>`
+
+	result, err := parseATCQuickFixApplyResult([]byte(xmlResponse))
+	if err != nil {
+		t.Fatalf("parseATCQuickFixApplyResult failed: %v", err)
+	}
+
+	if !result.Success {
+		t.Error("Expected success=true")
+	}
+	if result.Message != "Fix applied to 3 locations" {
+		t.Errorf("Message = %q", result.Message)
+	}
+}
+
+func TestParseATCQuickFixApplyResult_Unparsable(t *testing.T) {
+	result, err := parseATCQuickFixApplyResult([]byte("OK"))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !result.Success {
+		t.Error("Expected success=true for unparsable response")
+	}
+	if !strings.Contains(result.Message, "OK") {
+		t.Errorf("Message should include raw response, got %q", result.Message)
+	}
+}
+
+// --- Client-level tests ---
+
+func TestClient_GetQuickFixProposals(t *testing.T) {
+	proposalsXML := `<?xml version="1.0" encoding="UTF-8"?>
+<quickfix:proposals xmlns:quickfix="http://www.sap.com/adt/quickfix">
+  <quickfix:proposal quickfix:id="QF001" quickfix:title="Add TYPE declaration"/>
+</quickfix:proposals>`
+
+	mock := &mockTransportClient{
+		responses: map[string]*http.Response{
+			"/sap/bc/adt/core/discovery":     newCSRFResponse(),
+			"/sap/bc/adt/quickfix/proposals": newTestResponse(proposalsXML),
+		},
+	}
+
+	cfg := NewConfig("https://sap.example.com:44300", "user", "pass")
+	transport := NewTransportWithClient(cfg, mock)
+	client := NewClientWithTransport(cfg, transport)
+
+	result, err := client.GetQuickFixProposals(context.Background(), "/sap/bc/adt/programs/programs/ZTEST", 5, 10, "REPORT ztest.")
+	if err != nil {
+		t.Fatalf("GetQuickFixProposals failed: %v", err)
+	}
+
+	if len(result.Proposals) != 1 {
+		t.Fatalf("Expected 1 proposal, got %d", len(result.Proposals))
+	}
+	if result.Proposals[0].ID != "QF001" {
+		t.Errorf("Proposal ID = %q, want %q", result.Proposals[0].ID, "QF001")
+	}
+
+	// Verify request
+	if len(mock.requests) == 0 {
+		t.Fatal("No requests made")
+	}
+	req := mock.requests[len(mock.requests)-1]
+	if req.Method != http.MethodPost {
+		t.Errorf("Method = %q, want POST", req.Method)
+	}
+}
+
+func TestClient_ApplyQuickFix(t *testing.T) {
+	applyResult := `REPORT ztest.
+DATA lv_fixed TYPE string.
+WRITE lv_fixed.`
+
+	mock := &mockTransportClient{
+		responses: map[string]*http.Response{
+			"/sap/bc/adt/core/discovery":  newCSRFResponse(),
+			"/sap/bc/adt/quickfix/apply": newTestResponse(applyResult),
+		},
+	}
+
+	cfg := NewConfig("https://sap.example.com:44300", "user", "pass")
+	transport := NewTransportWithClient(cfg, mock)
+	client := NewClientWithTransport(cfg, transport)
+
+	result, err := client.ApplyQuickFix(context.Background(), "/sap/bc/adt/programs/programs/ZTEST", "QF001", 5, 10, "REPORT ztest.")
+	if err != nil {
+		t.Fatalf("ApplyQuickFix failed: %v", err)
+	}
+
+	if !result.Success {
+		t.Error("Expected success=true")
+	}
+	if !strings.Contains(result.NewSource, "lv_fixed") {
+		t.Error("NewSource should contain fixed code")
+	}
+}
+
+func TestClient_ApplyQuickFix_ReadOnly(t *testing.T) {
+	cfg := NewConfig("https://sap.example.com:44300", "user", "pass")
+	cfg.Safety.ReadOnly = true
+	transport := NewTransportWithClient(cfg, &mockTransportClient{responses: map[string]*http.Response{}})
+	client := NewClientWithTransport(cfg, transport)
+
+	_, err := client.ApplyQuickFix(context.Background(), "/sap/bc/adt/programs/programs/ZTEST", "QF001", 1, 1, "source")
+	if err == nil {
+		t.Error("Expected error for read-only mode")
+	}
+}
+
+func TestClient_GetATCQuickFixDetails(t *testing.T) {
+	detailsXML := `<?xml version="1.0" encoding="UTF-8"?>
+<atcquickfix:quickfixDetails xmlns:atcquickfix="http://www.sap.com/adt/atc/quickfix"
+                              atcquickfix:title="Fix issue"
+                              atcquickfix:canAutoFix="true"/>`
+
+	mock := &mockTransportClient{
+		responses: map[string]*http.Response{
+			"/sap/bc/adt/atc/quickfix/FINDING123": newTestResponse(detailsXML),
+		},
+	}
+
+	cfg := NewConfig("https://sap.example.com:44300", "user", "pass")
+	transport := NewTransportWithClient(cfg, mock)
+	client := NewClientWithTransport(cfg, transport)
+
+	result, err := client.GetATCQuickFixDetails(context.Background(), "FINDING123")
+	if err != nil {
+		t.Fatalf("GetATCQuickFixDetails failed: %v", err)
+	}
+
+	if result.FindingID != "FINDING123" {
+		t.Errorf("FindingID = %q", result.FindingID)
+	}
+	if !result.CanAutoFix {
+		t.Error("Expected canAutoFix=true")
+	}
+}
+
+func TestClient_ApplyATCQuickFix(t *testing.T) {
+	applyXML := `<?xml version="1.0" encoding="UTF-8"?>
+<atcquickfix:applyResult xmlns:atcquickfix="http://www.sap.com/adt/atc/quickfix"
+                          atcquickfix:success="true" atcquickfix:message="Applied"/>`
+
+	mock := &mockTransportClient{
+		responses: map[string]*http.Response{
+			"/sap/bc/adt/core/discovery":                newCSRFResponse(),
+			"/sap/bc/adt/atc/quickfix/FINDING123/apply": newTestResponse(applyXML),
+		},
+	}
+
+	cfg := NewConfig("https://sap.example.com:44300", "user", "pass")
+	transport := NewTransportWithClient(cfg, mock)
+	client := NewClientWithTransport(cfg, transport)
+
+	result, err := client.ApplyATCQuickFix(context.Background(), "FINDING123")
+	if err != nil {
+		t.Fatalf("ApplyATCQuickFix failed: %v", err)
+	}
+
+	if !result.Success {
+		t.Error("Expected success=true")
+	}
+}
+
+func TestClient_ApplyATCQuickFix_ReadOnly(t *testing.T) {
+	cfg := NewConfig("https://sap.example.com:44300", "user", "pass")
+	cfg.Safety.ReadOnly = true
+	transport := NewTransportWithClient(cfg, &mockTransportClient{responses: map[string]*http.Response{}})
+	client := NewClientWithTransport(cfg, transport)
+
+	_, err := client.ApplyATCQuickFix(context.Background(), "FINDING123")
+	if err == nil {
+		t.Error("Expected error for read-only mode")
+	}
+}

--- a/pkg/adt/refactoring.go
+++ b/pkg/adt/refactoring.go
@@ -1,0 +1,463 @@
+package adt
+
+import (
+	"context"
+	"encoding/xml"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+)
+
+// --- Refactoring: Rename ---
+
+// RenameProblem represents an issue found during rename evaluation.
+type RenameProblem struct {
+	Severity    string `json:"severity" xml:"severity,attr"`
+	Description string `json:"description" xml:"description,attr"`
+	URI         string `json:"uri,omitempty" xml:"uri,attr"`
+	Line        int    `json:"line,omitempty" xml:"line,attr"`
+	Column      int    `json:"column,omitempty" xml:"column,attr"`
+}
+
+// RenameEvaluateResult is the result of rename feasibility check.
+type RenameEvaluateResult struct {
+	Feasible    bool            `json:"feasible"`
+	ChangeCount int             `json:"changeCount"`
+	Problems    []RenameProblem `json:"problems,omitempty"`
+}
+
+// RenameChange represents a single text change from rename preview.
+type RenameChange struct {
+	URI     string `json:"uri" xml:"uri,attr"`
+	Line    int    `json:"line" xml:"line,attr"`
+	Column  int    `json:"column" xml:"column,attr"`
+	Length  int    `json:"length" xml:"length,attr"`
+	OldText string `json:"oldText" xml:"oldText,attr"`
+	NewText string `json:"newText" xml:"newText,attr"`
+}
+
+// RenamePreviewResult is the result of rename preview showing all affected locations.
+type RenamePreviewResult struct {
+	Changes []RenameChange `json:"changes"`
+}
+
+// RenameExecuteResult is the result of rename execution.
+type RenameExecuteResult struct {
+	Success         bool     `json:"success"`
+	AffectedObjects []string `json:"affectedObjects,omitempty"`
+	Message         string   `json:"message,omitempty"`
+}
+
+// RenameEvaluate checks if a rename is feasible at the given position.
+// objectURI is the ADT object URI (e.g., "/sap/bc/adt/programs/programs/ZTEST")
+// line and col are 1-based position of the symbol to rename.
+// source is the current source code of the object.
+// newName is the proposed new name.
+func (c *Client) RenameEvaluate(ctx context.Context, objectURI string, line, col int, source, newName string) (*RenameEvaluateResult, error) {
+	if err := c.checkSafety(OpUpdate, "RenameRefactoring"); err != nil {
+		return nil, err
+	}
+
+	q := url.Values{}
+	q.Set("method", "evaluate")
+	q.Set("uri", fmt.Sprintf("%s#start=%d,%d", objectURI, line, col))
+	q.Set("newName", newName)
+
+	resp, err := c.transport.Request(ctx, "/sap/bc/adt/refactoring/rename", &RequestOptions{
+		Method:      http.MethodPost,
+		Query:       q,
+		Body:        []byte(source),
+		ContentType: "text/plain",
+		Accept:      "application/xml",
+	})
+	if err != nil {
+		return nil, fmt.Errorf("rename evaluate failed: %w", err)
+	}
+
+	return parseRenameEvaluateResult(resp.Body)
+}
+
+func parseRenameEvaluateResult(data []byte) (*RenameEvaluateResult, error) {
+	// Strip namespace prefixes for easier parsing
+	xmlStr := string(data)
+	xmlStr = strings.ReplaceAll(xmlStr, "refactoring:", "")
+
+	type problem struct {
+		Severity    string `xml:"severity,attr"`
+		Description string `xml:"description,attr"`
+		URI         string `xml:"uri,attr"`
+		Line        int    `xml:"line,attr"`
+		Column      int    `xml:"column,attr"`
+	}
+	type evalResult struct {
+		XMLName     xml.Name  `xml:"evaluateResult"`
+		Feasible    bool      `xml:"feasible,attr"`
+		ChangeCount int       `xml:"changeCount,attr"`
+		Problems    []problem `xml:"problems>problem"`
+	}
+
+	var resp evalResult
+	if err := xml.Unmarshal([]byte(xmlStr), &resp); err != nil {
+		// Fallback: check if response is an error message
+		if strings.Contains(xmlStr, "<error") || strings.Contains(xmlStr, "exception") {
+			return &RenameEvaluateResult{
+				Feasible: false,
+				Problems: []RenameProblem{{Severity: "E", Description: string(data)}},
+			}, nil
+		}
+		return nil, fmt.Errorf("parsing rename evaluate result: %w", err)
+	}
+
+	result := &RenameEvaluateResult{
+		Feasible:    resp.Feasible,
+		ChangeCount: resp.ChangeCount,
+	}
+	for _, p := range resp.Problems {
+		result.Problems = append(result.Problems, RenameProblem{
+			Severity:    p.Severity,
+			Description: p.Description,
+			URI:         p.URI,
+			Line:        p.Line,
+			Column:      p.Column,
+		})
+	}
+	return result, nil
+}
+
+// RenamePreview returns all locations that will be changed by the rename.
+func (c *Client) RenamePreview(ctx context.Context, objectURI string, line, col int, source, newName string) (*RenamePreviewResult, error) {
+	if err := c.checkSafety(OpUpdate, "RenameRefactoring"); err != nil {
+		return nil, err
+	}
+
+	q := url.Values{}
+	q.Set("method", "preview")
+	q.Set("uri", fmt.Sprintf("%s#start=%d,%d", objectURI, line, col))
+	q.Set("newName", newName)
+
+	resp, err := c.transport.Request(ctx, "/sap/bc/adt/refactoring/rename", &RequestOptions{
+		Method:      http.MethodPost,
+		Query:       q,
+		Body:        []byte(source),
+		ContentType: "text/plain",
+		Accept:      "application/xml",
+	})
+	if err != nil {
+		return nil, fmt.Errorf("rename preview failed: %w", err)
+	}
+
+	return parseRenamePreviewResult(resp.Body)
+}
+
+func parseRenamePreviewResult(data []byte) (*RenamePreviewResult, error) {
+	xmlStr := string(data)
+	xmlStr = strings.ReplaceAll(xmlStr, "refactoring:", "")
+
+	type change struct {
+		URI     string `xml:"uri,attr"`
+		Line    int    `xml:"line,attr"`
+		Column  int    `xml:"column,attr"`
+		Length  int    `xml:"length,attr"`
+		OldText string `xml:"oldText,attr"`
+		NewText string `xml:"newText,attr"`
+	}
+	type previewResult struct {
+		XMLName xml.Name `xml:"previewResult"`
+		Changes []change `xml:"edits>change"`
+	}
+
+	var resp previewResult
+	if err := xml.Unmarshal([]byte(xmlStr), &resp); err != nil {
+		return nil, fmt.Errorf("parsing rename preview result: %w", err)
+	}
+
+	result := &RenamePreviewResult{}
+	for _, ch := range resp.Changes {
+		result.Changes = append(result.Changes, RenameChange{
+			URI:     ch.URI,
+			Line:    ch.Line,
+			Column:  ch.Column,
+			Length:  ch.Length,
+			OldText: ch.OldText,
+			NewText: ch.NewText,
+		})
+	}
+	return result, nil
+}
+
+// RenameExecute applies the rename refactoring.
+func (c *Client) RenameExecute(ctx context.Context, objectURI string, line, col int, source, newName string) (*RenameExecuteResult, error) {
+	if err := c.checkSafety(OpUpdate, "RenameRefactoring"); err != nil {
+		return nil, err
+	}
+
+	q := url.Values{}
+	q.Set("method", "execute")
+	q.Set("uri", fmt.Sprintf("%s#start=%d,%d", objectURI, line, col))
+	q.Set("newName", newName)
+
+	resp, err := c.transport.Request(ctx, "/sap/bc/adt/refactoring/rename", &RequestOptions{
+		Method:      http.MethodPost,
+		Query:       q,
+		Body:        []byte(source),
+		ContentType: "text/plain",
+		Accept:      "application/xml",
+	})
+	if err != nil {
+		return nil, fmt.Errorf("rename execute failed: %w", err)
+	}
+
+	return parseRenameExecuteResult(resp.Body)
+}
+
+func parseRenameExecuteResult(data []byte) (*RenameExecuteResult, error) {
+	xmlStr := string(data)
+	xmlStr = strings.ReplaceAll(xmlStr, "refactoring:", "")
+
+	type affectedObject struct {
+		URI string `xml:"uri,attr"`
+	}
+	type executeResult struct {
+		XMLName  xml.Name         `xml:"executeResult"`
+		Success  bool             `xml:"success,attr"`
+		Message  string           `xml:"message,attr"`
+		Affected []affectedObject `xml:"affectedObjects>object"`
+	}
+
+	var resp executeResult
+	if err := xml.Unmarshal([]byte(xmlStr), &resp); err != nil {
+		// SAP ADT may return non-XML "OK" on success. Include raw response for debugging.
+		return &RenameExecuteResult{
+			Success: true,
+			Message: fmt.Sprintf("Rename executed (non-XML response: %s)", truncate(string(data), 200)),
+		}, nil
+	}
+
+	result := &RenameExecuteResult{
+		Success: resp.Success,
+		Message: resp.Message,
+	}
+	for _, obj := range resp.Affected {
+		result.AffectedObjects = append(result.AffectedObjects, obj.URI)
+	}
+	return result, nil
+}
+
+// --- Refactoring: Extract Method ---
+
+// ExtractMethodEvaluateResult is the result of extract method feasibility check.
+type ExtractMethodEvaluateResult struct {
+	Feasible   bool              `json:"feasible"`
+	Parameters []ExtractedParam  `json:"parameters,omitempty"`
+	ReturnType string            `json:"returnType,omitempty"`
+	Problems   []RenameProblem   `json:"problems,omitempty"`
+}
+
+// ExtractedParam represents a parameter inferred for the extracted method.
+type ExtractedParam struct {
+	Name      string `json:"name" xml:"name,attr"`
+	Type      string `json:"type" xml:"type,attr"`
+	Direction string `json:"direction" xml:"direction,attr"` // IMPORTING, EXPORTING, CHANGING
+}
+
+// ExtractMethodPreviewResult is the preview of the extract method refactoring.
+type ExtractMethodPreviewResult struct {
+	NewMethodSource   string `json:"newMethodSource"`
+	ModifiedSource    string `json:"modifiedSource"`
+	CallSite          string `json:"callSite"`
+}
+
+// ExtractMethodExecuteResult is the result of extract method execution.
+type ExtractMethodExecuteResult struct {
+	Success bool   `json:"success"`
+	Message string `json:"message,omitempty"`
+}
+
+// ExtractMethodEvaluate checks if a code range can be extracted into a new method.
+// startLine, startCol, endLine, endCol define the selection range (1-based).
+// TODO: Verify range query parameter format against real ADT system (Eclipse network trace).
+func (c *Client) ExtractMethodEvaluate(ctx context.Context, objectURI string, startLine, startCol, endLine, endCol int, source, methodName string) (*ExtractMethodEvaluateResult, error) {
+	if err := c.checkSafety(OpUpdate, "ExtractMethod"); err != nil {
+		return nil, err
+	}
+
+	q := url.Values{}
+	q.Set("method", "evaluate")
+	q.Set("uri", objectURI)
+	q.Set("newMethodName", methodName)
+	q.Set("range", fmt.Sprintf("%d,%d;%d,%d", startLine, startCol, endLine, endCol))
+
+	resp, err := c.transport.Request(ctx, "/sap/bc/adt/refactoring/extractmethod", &RequestOptions{
+		Method:      http.MethodPost,
+		Query:       q,
+		Body:        []byte(source),
+		ContentType: "text/plain",
+		Accept:      "application/xml",
+	})
+	if err != nil {
+		return nil, fmt.Errorf("extract method evaluate failed: %w", err)
+	}
+
+	return parseExtractMethodEvaluateResult(resp.Body)
+}
+
+func parseExtractMethodEvaluateResult(data []byte) (*ExtractMethodEvaluateResult, error) {
+	xmlStr := string(data)
+	xmlStr = strings.ReplaceAll(xmlStr, "refactoring:", "")
+
+	type param struct {
+		Name      string `xml:"name,attr"`
+		Type      string `xml:"type,attr"`
+		Direction string `xml:"direction,attr"`
+	}
+	type problem struct {
+		Severity    string `xml:"severity,attr"`
+		Description string `xml:"description,attr"`
+	}
+	type evalResult struct {
+		XMLName    xml.Name  `xml:"evaluateResult"`
+		Feasible   bool      `xml:"feasible,attr"`
+		ReturnType string    `xml:"returnType,attr"`
+		Parameters []param   `xml:"parameters>parameter"`
+		Problems   []problem `xml:"problems>problem"`
+	}
+
+	var resp evalResult
+	if err := xml.Unmarshal([]byte(xmlStr), &resp); err != nil {
+		if strings.Contains(xmlStr, "<error") || strings.Contains(xmlStr, "exception") {
+			return &ExtractMethodEvaluateResult{
+				Feasible: false,
+				Problems: []RenameProblem{{Severity: "E", Description: string(data)}},
+			}, nil
+		}
+		return nil, fmt.Errorf("parsing extract method evaluate result: %w", err)
+	}
+
+	result := &ExtractMethodEvaluateResult{
+		Feasible:   resp.Feasible,
+		ReturnType: resp.ReturnType,
+	}
+	for _, p := range resp.Parameters {
+		result.Parameters = append(result.Parameters, ExtractedParam{
+			Name:      p.Name,
+			Type:      p.Type,
+			Direction: p.Direction,
+		})
+	}
+	for _, p := range resp.Problems {
+		result.Problems = append(result.Problems, RenameProblem{
+			Severity:    p.Severity,
+			Description: p.Description,
+		})
+	}
+	return result, nil
+}
+
+// ExtractMethodPreview returns the preview of how the code will look after extraction.
+func (c *Client) ExtractMethodPreview(ctx context.Context, objectURI string, startLine, startCol, endLine, endCol int, source, methodName string) (*ExtractMethodPreviewResult, error) {
+	if err := c.checkSafety(OpUpdate, "ExtractMethod"); err != nil {
+		return nil, err
+	}
+
+	q := url.Values{}
+	q.Set("method", "preview")
+	q.Set("uri", objectURI)
+	q.Set("newMethodName", methodName)
+	q.Set("range", fmt.Sprintf("%d,%d;%d,%d", startLine, startCol, endLine, endCol))
+
+	resp, err := c.transport.Request(ctx, "/sap/bc/adt/refactoring/extractmethod", &RequestOptions{
+		Method:      http.MethodPost,
+		Query:       q,
+		Body:        []byte(source),
+		ContentType: "text/plain",
+		Accept:      "application/xml",
+	})
+	if err != nil {
+		return nil, fmt.Errorf("extract method preview failed: %w", err)
+	}
+
+	return parseExtractMethodPreviewResult(resp.Body)
+}
+
+func parseExtractMethodPreviewResult(data []byte) (*ExtractMethodPreviewResult, error) {
+	xmlStr := string(data)
+	xmlStr = strings.ReplaceAll(xmlStr, "refactoring:", "")
+
+	type previewResult struct {
+		XMLName         xml.Name `xml:"previewResult"`
+		NewMethodSource string   `xml:"newMethodSource"`
+		ModifiedSource  string   `xml:"modifiedSource"`
+		CallSite        string   `xml:"callSite"`
+	}
+
+	var resp previewResult
+	if err := xml.Unmarshal([]byte(xmlStr), &resp); err != nil {
+		return nil, fmt.Errorf("parsing extract method preview result: %w", err)
+	}
+
+	return &ExtractMethodPreviewResult{
+		NewMethodSource: resp.NewMethodSource,
+		ModifiedSource:  resp.ModifiedSource,
+		CallSite:        resp.CallSite,
+	}, nil
+}
+
+// ExtractMethodExecute applies the extract method refactoring.
+func (c *Client) ExtractMethodExecute(ctx context.Context, objectURI string, startLine, startCol, endLine, endCol int, source, methodName string) (*ExtractMethodExecuteResult, error) {
+	if err := c.checkSafety(OpUpdate, "ExtractMethod"); err != nil {
+		return nil, err
+	}
+
+	q := url.Values{}
+	q.Set("method", "execute")
+	q.Set("uri", objectURI)
+	q.Set("newMethodName", methodName)
+	q.Set("range", fmt.Sprintf("%d,%d;%d,%d", startLine, startCol, endLine, endCol))
+
+	resp, err := c.transport.Request(ctx, "/sap/bc/adt/refactoring/extractmethod", &RequestOptions{
+		Method:      http.MethodPost,
+		Query:       q,
+		Body:        []byte(source),
+		ContentType: "text/plain",
+		Accept:      "application/xml",
+	})
+	if err != nil {
+		return nil, fmt.Errorf("extract method execute failed: %w", err)
+	}
+
+	return parseExtractMethodExecuteResult(resp.Body)
+}
+
+func parseExtractMethodExecuteResult(data []byte) (*ExtractMethodExecuteResult, error) {
+	xmlStr := string(data)
+	xmlStr = strings.ReplaceAll(xmlStr, "refactoring:", "")
+
+	type executeResult struct {
+		XMLName xml.Name `xml:"executeResult"`
+		Success bool     `xml:"success,attr"`
+		Message string   `xml:"message,attr"`
+	}
+
+	var resp executeResult
+	if err := xml.Unmarshal([]byte(xmlStr), &resp); err != nil {
+		// SAP ADT may return non-XML "OK" on success. Include raw response for debugging.
+		return &ExtractMethodExecuteResult{
+			Success: true,
+			Message: fmt.Sprintf("Extract method executed (non-XML response: %s)", truncate(string(data), 200)),
+		}, nil
+	}
+
+	return &ExtractMethodExecuteResult{
+		Success: resp.Success,
+		Message: resp.Message,
+	}, nil
+}
+
+// truncate returns s trimmed to maxLen characters with "..." appended if truncated.
+func truncate(s string, maxLen int) string {
+	if len(s) <= maxLen {
+		return s
+	}
+	return s[:maxLen] + "..."
+}

--- a/pkg/adt/refactoring_test.go
+++ b/pkg/adt/refactoring_test.go
@@ -1,0 +1,375 @@
+package adt
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+// newCSRFResponse creates a mock response with properly canonicalized CSRF header.
+// http.Header literal keys bypass canonicalization, so we use Set() explicitly.
+func newCSRFResponse() *http.Response {
+	h := make(http.Header)
+	h.Set("X-CSRF-Token", "test-token")
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Body:       io.NopCloser(strings.NewReader("")),
+		Header:     h,
+	}
+}
+
+// --- Rename Evaluate Tests ---
+
+func TestParseRenameEvaluateResult(t *testing.T) {
+	xmlResponse := `<?xml version="1.0" encoding="UTF-8"?>
+<refactoring:evaluateResult xmlns:refactoring="http://www.sap.com/adt/refactoring"
+                            refactoring:feasible="true" refactoring:changeCount="3">
+  <refactoring:problems>
+    <refactoring:problem refactoring:severity="W" refactoring:description="Name already used in subclass ZCL_SUB"
+                         refactoring:uri="/sap/bc/adt/oo/classes/ZCL_SUB" refactoring:line="10" refactoring:column="5"/>
+  </refactoring:problems>
+</refactoring:evaluateResult>`
+
+	result, err := parseRenameEvaluateResult([]byte(xmlResponse))
+	if err != nil {
+		t.Fatalf("parseRenameEvaluateResult failed: %v", err)
+	}
+
+	if !result.Feasible {
+		t.Error("Expected feasible=true")
+	}
+	if result.ChangeCount != 3 {
+		t.Errorf("ChangeCount = %d, want 3", result.ChangeCount)
+	}
+	if len(result.Problems) != 1 {
+		t.Fatalf("Expected 1 problem, got %d", len(result.Problems))
+	}
+	if result.Problems[0].Severity != "W" {
+		t.Errorf("Problem severity = %q, want %q", result.Problems[0].Severity, "W")
+	}
+	if result.Problems[0].Line != 10 {
+		t.Errorf("Problem line = %d, want 10", result.Problems[0].Line)
+	}
+}
+
+func TestParseRenameEvaluateResult_NotFeasible(t *testing.T) {
+	xmlResponse := `<?xml version="1.0" encoding="UTF-8"?>
+<refactoring:evaluateResult xmlns:refactoring="http://www.sap.com/adt/refactoring"
+                            refactoring:feasible="false" refactoring:changeCount="0">
+  <refactoring:problems>
+    <refactoring:problem refactoring:severity="E" refactoring:description="Symbol cannot be renamed"/>
+  </refactoring:problems>
+</refactoring:evaluateResult>`
+
+	result, err := parseRenameEvaluateResult([]byte(xmlResponse))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if result.Feasible {
+		t.Error("Expected feasible=false")
+	}
+	if len(result.Problems) != 1 {
+		t.Fatalf("Expected 1 problem, got %d", len(result.Problems))
+	}
+	if result.Problems[0].Severity != "E" {
+		t.Errorf("Severity = %q, want %q", result.Problems[0].Severity, "E")
+	}
+}
+
+func TestParseRenameEvaluateResult_ErrorResponse(t *testing.T) {
+	xmlResponse := `<error><message>Object is locked by user OTHERDEV</message></error>`
+
+	result, err := parseRenameEvaluateResult([]byte(xmlResponse))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if result.Feasible {
+		t.Error("Expected feasible=false for error response")
+	}
+	if len(result.Problems) == 0 {
+		t.Error("Expected at least one problem for error response")
+	}
+}
+
+// --- Rename Preview Tests ---
+
+func TestParseRenamePreviewResult(t *testing.T) {
+	xmlResponse := `<?xml version="1.0" encoding="UTF-8"?>
+<refactoring:previewResult xmlns:refactoring="http://www.sap.com/adt/refactoring">
+  <refactoring:edits>
+    <refactoring:change refactoring:uri="/sap/bc/adt/oo/classes/ZCL_TEST" refactoring:line="5" refactoring:column="12"
+                        refactoring:length="10" refactoring:oldText="old_method" refactoring:newText="new_method"/>
+    <refactoring:change refactoring:uri="/sap/bc/adt/oo/classes/ZCL_TEST" refactoring:line="20" refactoring:column="8"
+                        refactoring:length="10" refactoring:oldText="old_method" refactoring:newText="new_method"/>
+    <refactoring:change refactoring:uri="/sap/bc/adt/oo/classes/ZCL_CALLER" refactoring:line="15" refactoring:column="22"
+                        refactoring:length="10" refactoring:oldText="old_method" refactoring:newText="new_method"/>
+  </refactoring:edits>
+</refactoring:previewResult>`
+
+	result, err := parseRenamePreviewResult([]byte(xmlResponse))
+	if err != nil {
+		t.Fatalf("parseRenamePreviewResult failed: %v", err)
+	}
+
+	if len(result.Changes) != 3 {
+		t.Fatalf("Expected 3 changes, got %d", len(result.Changes))
+	}
+	if result.Changes[0].Line != 5 {
+		t.Errorf("Change[0].Line = %d, want 5", result.Changes[0].Line)
+	}
+	if result.Changes[0].OldText != "old_method" {
+		t.Errorf("Change[0].OldText = %q, want %q", result.Changes[0].OldText, "old_method")
+	}
+	if result.Changes[2].URI != "/sap/bc/adt/oo/classes/ZCL_CALLER" {
+		t.Errorf("Change[2].URI = %q, want cross-reference URI", result.Changes[2].URI)
+	}
+}
+
+func TestParseRenamePreviewResult_Empty(t *testing.T) {
+	xmlResponse := `<?xml version="1.0" encoding="UTF-8"?>
+<refactoring:previewResult xmlns:refactoring="http://www.sap.com/adt/refactoring">
+  <refactoring:edits/>
+</refactoring:previewResult>`
+
+	result, err := parseRenamePreviewResult([]byte(xmlResponse))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(result.Changes) != 0 {
+		t.Errorf("Expected 0 changes, got %d", len(result.Changes))
+	}
+}
+
+// --- Rename Execute Tests ---
+
+func TestParseRenameExecuteResult(t *testing.T) {
+	xmlResponse := `<?xml version="1.0" encoding="UTF-8"?>
+<refactoring:executeResult xmlns:refactoring="http://www.sap.com/adt/refactoring"
+                           refactoring:success="true" refactoring:message="Rename completed successfully">
+  <refactoring:affectedObjects>
+    <refactoring:object refactoring:uri="/sap/bc/adt/oo/classes/ZCL_TEST"/>
+    <refactoring:object refactoring:uri="/sap/bc/adt/oo/classes/ZCL_CALLER"/>
+  </refactoring:affectedObjects>
+</refactoring:executeResult>`
+
+	result, err := parseRenameExecuteResult([]byte(xmlResponse))
+	if err != nil {
+		t.Fatalf("parseRenameExecuteResult failed: %v", err)
+	}
+
+	if !result.Success {
+		t.Error("Expected success=true")
+	}
+	if len(result.AffectedObjects) != 2 {
+		t.Fatalf("Expected 2 affected objects, got %d", len(result.AffectedObjects))
+	}
+	if result.Message != "Rename completed successfully" {
+		t.Errorf("Message = %q", result.Message)
+	}
+}
+
+func TestParseRenameExecuteResult_UnparsableSuccess(t *testing.T) {
+	// Sometimes server returns non-standard XML on success
+	result, err := parseRenameExecuteResult([]byte("OK"))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !result.Success {
+		t.Error("Expected success=true for unparsable response")
+	}
+	if !strings.Contains(result.Message, "OK") {
+		t.Errorf("Message should include raw response, got %q", result.Message)
+	}
+}
+
+// --- Extract Method Tests ---
+
+func TestParseExtractMethodEvaluateResult(t *testing.T) {
+	xmlResponse := `<?xml version="1.0" encoding="UTF-8"?>
+<refactoring:evaluateResult xmlns:refactoring="http://www.sap.com/adt/refactoring"
+                            refactoring:feasible="true" refactoring:returnType="STRING">
+  <refactoring:parameters>
+    <refactoring:parameter refactoring:name="IV_INPUT" refactoring:type="STRING" refactoring:direction="IMPORTING"/>
+    <refactoring:parameter refactoring:name="RV_RESULT" refactoring:type="STRING" refactoring:direction="RETURNING"/>
+  </refactoring:parameters>
+</refactoring:evaluateResult>`
+
+	result, err := parseExtractMethodEvaluateResult([]byte(xmlResponse))
+	if err != nil {
+		t.Fatalf("parseExtractMethodEvaluateResult failed: %v", err)
+	}
+
+	if !result.Feasible {
+		t.Error("Expected feasible=true")
+	}
+	if result.ReturnType != "STRING" {
+		t.Errorf("ReturnType = %q, want %q", result.ReturnType, "STRING")
+	}
+	if len(result.Parameters) != 2 {
+		t.Fatalf("Expected 2 parameters, got %d", len(result.Parameters))
+	}
+	if result.Parameters[0].Name != "IV_INPUT" {
+		t.Errorf("Param[0].Name = %q, want %q", result.Parameters[0].Name, "IV_INPUT")
+	}
+	if result.Parameters[0].Direction != "IMPORTING" {
+		t.Errorf("Param[0].Direction = %q, want %q", result.Parameters[0].Direction, "IMPORTING")
+	}
+}
+
+func TestParseExtractMethodEvaluateResult_NotFeasible(t *testing.T) {
+	xmlResponse := `<?xml version="1.0" encoding="UTF-8"?>
+<refactoring:evaluateResult xmlns:refactoring="http://www.sap.com/adt/refactoring"
+                            refactoring:feasible="false">
+  <refactoring:problems>
+    <refactoring:problem refactoring:severity="E" refactoring:description="Selection contains RETURN statement"/>
+  </refactoring:problems>
+</refactoring:evaluateResult>`
+
+	result, err := parseExtractMethodEvaluateResult([]byte(xmlResponse))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if result.Feasible {
+		t.Error("Expected feasible=false")
+	}
+	if len(result.Problems) != 1 {
+		t.Fatalf("Expected 1 problem, got %d", len(result.Problems))
+	}
+}
+
+func TestParseExtractMethodPreviewResult(t *testing.T) {
+	xmlResponse := `<?xml version="1.0" encoding="UTF-8"?>
+<refactoring:previewResult xmlns:refactoring="http://www.sap.com/adt/refactoring">
+  <refactoring:newMethodSource>METHOD new_method.
+  rv_result = iv_input.
+ENDMETHOD.</refactoring:newMethodSource>
+  <refactoring:modifiedSource>METHOD old_method.
+  rv_result = new_method( iv_input ).
+ENDMETHOD.</refactoring:modifiedSource>
+  <refactoring:callSite>new_method( iv_input )</refactoring:callSite>
+</refactoring:previewResult>`
+
+	result, err := parseExtractMethodPreviewResult([]byte(xmlResponse))
+	if err != nil {
+		t.Fatalf("parseExtractMethodPreviewResult failed: %v", err)
+	}
+
+	if !strings.Contains(result.NewMethodSource, "METHOD new_method") {
+		t.Error("NewMethodSource should contain new method definition")
+	}
+	if !strings.Contains(result.CallSite, "new_method") {
+		t.Error("CallSite should contain method call")
+	}
+}
+
+func TestParseExtractMethodExecuteResult(t *testing.T) {
+	xmlResponse := `<?xml version="1.0" encoding="UTF-8"?>
+<refactoring:executeResult xmlns:refactoring="http://www.sap.com/adt/refactoring"
+                           refactoring:success="true" refactoring:message="Method extracted successfully"/>`
+
+	result, err := parseExtractMethodExecuteResult([]byte(xmlResponse))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if !result.Success {
+		t.Error("Expected success=true")
+	}
+}
+
+// --- Client-level integration tests with mock transport ---
+
+func TestClient_RenameEvaluate(t *testing.T) {
+	evalXML := `<?xml version="1.0" encoding="UTF-8"?>
+<refactoring:evaluateResult xmlns:refactoring="http://www.sap.com/adt/refactoring"
+                            refactoring:feasible="true" refactoring:changeCount="2"/>`
+
+	mock := &mockTransportClient{
+		responses: map[string]*http.Response{
+			"/sap/bc/adt/core/discovery":     newCSRFResponse(),
+			"/sap/bc/adt/refactoring/rename": newTestResponse(evalXML),
+		},
+	}
+
+	cfg := NewConfig("https://sap.example.com:44300", "user", "pass")
+	transport := NewTransportWithClient(cfg, mock)
+	client := NewClientWithTransport(cfg, transport)
+
+	result, err := client.RenameEvaluate(context.Background(), "/sap/bc/adt/oo/classes/ZCL_TEST", 10, 5, "CLASS zcl_test DEFINITION.", "new_name")
+	if err != nil {
+		t.Fatalf("RenameEvaluate failed: %v", err)
+	}
+
+	if !result.Feasible {
+		t.Error("Expected feasible=true")
+	}
+	if result.ChangeCount != 2 {
+		t.Errorf("ChangeCount = %d, want 2", result.ChangeCount)
+	}
+
+	// Verify request was made
+	if len(mock.requests) == 0 {
+		t.Fatal("No requests made")
+	}
+	req := mock.requests[len(mock.requests)-1]
+	if req.Method != http.MethodPost {
+		t.Errorf("Method = %q, want POST", req.Method)
+	}
+	if !strings.Contains(req.URL.String(), "rename") {
+		t.Errorf("URL = %q, should contain 'rename'", req.URL.String())
+	}
+}
+
+func TestClient_RenameEvaluate_ReadOnly(t *testing.T) {
+	cfg := NewConfig("https://sap.example.com:44300", "user", "pass")
+	cfg.Safety.ReadOnly = true
+	transport := NewTransportWithClient(cfg, &mockTransportClient{responses: map[string]*http.Response{}})
+	client := NewClientWithTransport(cfg, transport)
+
+	_, err := client.RenameEvaluate(context.Background(), "/sap/bc/adt/oo/classes/ZCL_TEST", 1, 1, "source", "new_name")
+	if err == nil {
+		t.Error("Expected error for read-only mode")
+	}
+}
+
+func TestClient_ExtractMethodEvaluate(t *testing.T) {
+	evalXML := `<?xml version="1.0" encoding="UTF-8"?>
+<refactoring:evaluateResult xmlns:refactoring="http://www.sap.com/adt/refactoring"
+                            refactoring:feasible="true" refactoring:returnType="I">
+  <refactoring:parameters>
+    <refactoring:parameter refactoring:name="IV_X" refactoring:type="I" refactoring:direction="IMPORTING"/>
+  </refactoring:parameters>
+</refactoring:evaluateResult>`
+
+	mock := &mockTransportClient{
+		responses: map[string]*http.Response{
+			"/sap/bc/adt/core/discovery":            newCSRFResponse(),
+			"/sap/bc/adt/refactoring/extractmethod": newTestResponse(evalXML),
+		},
+	}
+
+	cfg := NewConfig("https://sap.example.com:44300", "user", "pass")
+	transport := NewTransportWithClient(cfg, mock)
+	client := NewClientWithTransport(cfg, transport)
+
+	result, err := client.ExtractMethodEvaluate(context.Background(), "/sap/bc/adt/oo/classes/ZCL_TEST", 10, 1, 15, 80, "source code", "extract_me")
+	if err != nil {
+		t.Fatalf("ExtractMethodEvaluate failed: %v", err)
+	}
+
+	if !result.Feasible {
+		t.Error("Expected feasible=true")
+	}
+	if len(result.Parameters) != 1 {
+		t.Fatalf("Expected 1 parameter, got %d", len(result.Parameters))
+	}
+	if result.Parameters[0].Name != "IV_X" {
+		t.Errorf("Param name = %q, want %q", result.Parameters[0].Name, "IV_X")
+	}
+}


### PR DESCRIPTION
## Summary

Add ADT-native refactoring support via SAP ADT REST API — 5 new tools with 33 unit tests:

- **RenameRefactoring** — evaluate/preview/execute rename with full cross-reference support
- **ExtractMethod** — extract code block into new method with auto-inferred parameters
- **GetQuickFixProposals** — get auto-fix suggestions after SyntaxCheck
- **ApplyQuickFix** — apply a quick fix proposal to source code
- **ApplyATCQuickFix** — get details or apply ATC finding quick fixes

## Files

| File | Lines | Description |
|------|-------|-------------|
| `pkg/adt/refactoring.go` | 463 | Client methods for Rename and ExtractMethod |
| `pkg/adt/quickfix.go` | 254 | Client methods for QuickFix and ATC QuickFix |
| `pkg/adt/refactoring_test.go` | 375 | 14 unit tests |
| `pkg/adt/quickfix_test.go` | 318 | 19 unit tests |
| `internal/mcp/handlers_refactoring.go` | 223 | MCP tool handlers |
| `internal/mcp/tools_register.go` | +127 | Tool registration |
| `internal/mcp/tools_focused.go` | +7 | Focused mode whitelist |

## ADT API endpoints

- `POST /sap/bc/adt/refactorings/rename` — Rename refactoring (3-step flow)
- `POST /sap/bc/adt/refactorings/extractmethod` — Extract Method (3-step flow)
- `POST /sap/bc/adt/quickfixes/evaluation` — Quick fix proposals
- `POST /sap/bc/adt/quickfixes/apply` — Apply quick fix
- `GET/POST /sap/bc/adt/atc/quickfixes/{findingId}` — ATC quick fix

## Test plan

- [x] `go build ./cmd/vsp` compiles clean
- [x] `go test ./pkg/adt/` — 33 new tests pass, no regressions
- [ ] Integration test with SAP system (requires ADT connection)