### PR TITLE
feat: add version history tools (3 tools, 8 tests)

### DIFF
--- a/internal/mcp/handlers_revisions.go
+++ b/internal/mcp/handlers_revisions.go
@@ -1,0 +1,83 @@
+// Package mcp provides the MCP server implementation for ABAP ADT tools.
+// handlers_revisions.go contains handlers for object version history operations.
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/oisee/vibing-steampunk/pkg/adt"
+)
+
+// --- Version History (Revision) Handlers ---
+
+func (s *Server) handleGetRevisions(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	objectType, _ := request.Params.Arguments["type"].(string)
+	name, _ := request.Params.Arguments["name"].(string)
+
+	if objectType == "" || name == "" {
+		return newToolResultError("type and name are required"), nil
+	}
+
+	opts := &adt.GetSourceOptions{}
+	if include, ok := request.Params.Arguments["include"].(string); ok && include != "" {
+		opts.Include = include
+	}
+	if parent, ok := request.Params.Arguments["parent"].(string); ok && parent != "" {
+		opts.Parent = parent
+	}
+
+	revisions, err := s.adtClient.GetRevisions(ctx, objectType, name, opts)
+	if err != nil {
+		return newToolResultError(fmt.Sprintf("GetRevisions failed: %v", err)), nil
+	}
+
+	output, _ := json.MarshalIndent(revisions, "", "  ")
+	return mcp.NewToolResultText(string(output)), nil
+}
+
+func (s *Server) handleGetRevisionSource(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	versionURI, ok := request.Params.Arguments["version_uri"].(string)
+	if !ok || versionURI == "" {
+		return newToolResultError("version_uri is required (from GetRevisions output)"), nil
+	}
+
+	source, err := s.adtClient.GetRevisionSource(ctx, versionURI)
+	if err != nil {
+		return newToolResultError(fmt.Sprintf("GetRevisionSource failed: %v", err)), nil
+	}
+
+	return mcp.NewToolResultText(source), nil
+}
+
+func (s *Server) handleCompareVersions(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	objectType, _ := request.Params.Arguments["type"].(string)
+	name, _ := request.Params.Arguments["name"].(string)
+	version1, _ := request.Params.Arguments["version1_uri"].(string)
+	version2, _ := request.Params.Arguments["version2_uri"].(string)
+
+	if objectType == "" || name == "" || version1 == "" {
+		return newToolResultError("type, name, and version1_uri are required"), nil
+	}
+	if version2 == "" {
+		version2 = "current"
+	}
+
+	opts := &adt.GetSourceOptions{}
+	if include, ok := request.Params.Arguments["include"].(string); ok && include != "" {
+		opts.Include = include
+	}
+	if parent, ok := request.Params.Arguments["parent"].(string); ok && parent != "" {
+		opts.Parent = parent
+	}
+
+	diff, err := s.adtClient.CompareVersions(ctx, objectType, name, version1, version2, opts)
+	if err != nil {
+		return newToolResultError(fmt.Sprintf("CompareVersions failed: %v", err)), nil
+	}
+
+	output, _ := json.MarshalIndent(diff, "", "  ")
+	return mcp.NewToolResultText(string(output)), nil
+}

--- a/internal/mcp/tools_focused.go
+++ b/internal/mcp/tools_focused.go
@@ -108,6 +108,11 @@ func focusedToolSet() map[string]bool {
 		"AMDPSetBreakpoint":  true,
 		"AMDPGetBreakpoints": true,
 
+		// Version History (3)
+		"GetRevisions":      true, // List object version history
+		"GetRevisionSource": true, // Get source of a specific version
+		"CompareVersions":   true, // Compare two versions with diff
+
 		// CTS/Transport Management (2 read-only in focused mode)
 		"ListTransports": true, // List transport requests
 		"GetTransport":   true, // Get transport details with objects

--- a/internal/mcp/tools_register.go
+++ b/internal/mcp/tools_register.go
@@ -87,6 +87,7 @@ func (s *Server) registerTools(mode string, disabledGroups string, toolsConfig m
 	s.registerGitTools(shouldRegister)
 	s.registerReportTools(shouldRegister)
 	s.registerInstallTools(shouldRegister)
+	s.registerVersionHistoryTools(shouldRegister)
 
 	// Register tool aliases for common operations
 	s.registerToolAliases(shouldRegister)
@@ -1946,5 +1947,65 @@ func (s *Server) registerInstallTools(shouldRegister func(string) bool) {
 				mcp.Description("Deploy only objects matching this name pattern (e.g., 'ZCL_ABAPGIT_*')"),
 			),
 		), s.handleDeployZip)
+	}
+}
+
+// registerVersionHistoryTools registers version history and comparison tools.
+func (s *Server) registerVersionHistoryTools(shouldRegister func(string) bool) {
+	if shouldRegister("GetRevisions") {
+		s.mcpServer.AddTool(mcp.NewTool("GetRevisions",
+			mcp.WithDescription("List version history (revisions) of an ABAP object. Returns versions with dates, authors, and transport requests. Use version URIs with GetRevisionSource or CompareVersions."),
+			mcp.WithString("type",
+				mcp.Required(),
+				mcp.Description("Object type: PROG, CLAS, INTF, FUNC, INCL, DDLS, BDEF, SRVD"),
+			),
+			mcp.WithString("name",
+				mcp.Required(),
+				mcp.Description("Object name"),
+			),
+			mcp.WithString("include",
+				mcp.Description("Class include type for CLAS: main, definitions, implementations, macros, testclasses (default: main)"),
+			),
+			mcp.WithString("parent",
+				mcp.Description("Function group name (required for FUNC type)"),
+			),
+		), s.handleGetRevisions)
+	}
+
+	if shouldRegister("GetRevisionSource") {
+		s.mcpServer.AddTool(mcp.NewTool("GetRevisionSource",
+			mcp.WithDescription("Get source code of a specific version of an ABAP object. Use version_uri from GetRevisions output."),
+			mcp.WithString("version_uri",
+				mcp.Required(),
+				mcp.Description("Version URI from GetRevisions result (the 'uri' field of a revision entry)"),
+			),
+		), s.handleGetRevisionSource)
+	}
+
+	if shouldRegister("CompareVersions") {
+		s.mcpServer.AddTool(mcp.NewTool("CompareVersions",
+			mcp.WithDescription("Compare two versions of an ABAP object with unified diff. Use version URIs from GetRevisions. Use 'current' as version2_uri to compare against the active version."),
+			mcp.WithString("type",
+				mcp.Required(),
+				mcp.Description("Object type: PROG, CLAS, INTF, FUNC, INCL, DDLS, BDEF, SRVD"),
+			),
+			mcp.WithString("name",
+				mcp.Required(),
+				mcp.Description("Object name"),
+			),
+			mcp.WithString("version1_uri",
+				mcp.Required(),
+				mcp.Description("Version URI for first (older) version, from GetRevisions"),
+			),
+			mcp.WithString("version2_uri",
+				mcp.Description("Version URI for second (newer) version, from GetRevisions. Default: 'current' (compare against active version)"),
+			),
+			mcp.WithString("include",
+				mcp.Description("Class include type for CLAS: main, definitions, implementations, macros, testclasses"),
+			),
+			mcp.WithString("parent",
+				mcp.Description("Function group name (required for FUNC type)"),
+			),
+		), s.handleCompareVersions)
 	}
 }

--- a/pkg/adt/revisions.go
+++ b/pkg/adt/revisions.go
@@ -1,0 +1,193 @@
+package adt
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+)
+
+// --- Object Version History (Revisions) ---
+
+// GetRevisions retrieves the version history (revisions) of an ABAP object.
+// For classes, use opts.Include to get revisions of a specific include.
+//
+// Supported object types: PROG, CLAS, INTF, FUNC, INCL, DDLS, BDEF, SRVD
+func (c *Client) GetRevisions(ctx context.Context, objectType, name string, opts *GetSourceOptions) ([]Revision, error) {
+	if err := c.checkSafety(OpRead, "GetRevisions"); err != nil {
+		return nil, err
+	}
+
+	objectType = strings.ToUpper(objectType)
+	name = strings.ToUpper(name)
+	if opts == nil {
+		opts = &GetSourceOptions{}
+	}
+
+	revisionURL, err := c.resolveRevisionURL(objectType, name, opts)
+	if err != nil {
+		return nil, fmt.Errorf("resolving revision URL for %s %s: %w", objectType, name, err)
+	}
+
+	resp, err := c.transport.Request(ctx, revisionURL, &RequestOptions{
+		Method: http.MethodGet,
+		Accept: "application/atom+xml;type=feed",
+	})
+	if err != nil {
+		return nil, fmt.Errorf("getting revisions for %s %s: %w", objectType, name, err)
+	}
+
+	return ParseRevisionFeed(resp.Body)
+}
+
+// GetRevisionSource retrieves the source code of a specific object version.
+// The versionURI comes from GetRevisions output (the URI field of a Revision entry).
+func (c *Client) GetRevisionSource(ctx context.Context, versionURI string) (string, error) {
+	if err := c.checkSafety(OpRead, "GetRevisionSource"); err != nil {
+		return "", err
+	}
+
+	if versionURI == "" {
+		return "", fmt.Errorf("versionURI is required")
+	}
+
+	resp, err := c.transport.Request(ctx, versionURI, &RequestOptions{
+		Method: http.MethodGet,
+		Accept: "text/plain",
+	})
+	if err != nil {
+		return "", fmt.Errorf("getting revision source: %w", err)
+	}
+
+	return string(resp.Body), nil
+}
+
+// CompareVersions compares two versions of an ABAP object and returns a unified diff.
+// version1URI and version2URI are from GetRevisions output.
+// Use "current" as version2URI to compare against the active version.
+func (c *Client) CompareVersions(ctx context.Context, objectType, name string, version1URI, version2URI string, opts *GetSourceOptions) (*SourceDiff, error) {
+	if err := c.checkSafety(OpRead, "CompareVersions"); err != nil {
+		return nil, err
+	}
+
+	source1, err := c.GetRevisionSource(ctx, version1URI)
+	if err != nil {
+		return nil, fmt.Errorf("getting version 1 source: %w", err)
+	}
+
+	var source2 string
+	if version2URI == "current" {
+		source2, err = c.GetSource(ctx, objectType, name, opts)
+		if err != nil {
+			return nil, fmt.Errorf("getting current source: %w", err)
+		}
+	} else {
+		source2, err = c.GetRevisionSource(ctx, version2URI)
+		if err != nil {
+			return nil, fmt.Errorf("getting version 2 source: %w", err)
+		}
+	}
+
+	label1 := fmt.Sprintf("%s:%s@%s", objectType, name, extractVersionLabel(version1URI))
+	label2 := fmt.Sprintf("%s:%s@%s", objectType, name, extractVersionLabel(version2URI))
+
+	result := &SourceDiff{
+		Object1:   label1,
+		Object2:   label2,
+		Identical: source1 == source2,
+	}
+
+	if result.Identical {
+		result.Diff = "Sources are identical"
+		return result, nil
+	}
+
+	lines1 := strings.Split(source1, "\n")
+	lines2 := strings.Split(source2, "\n")
+	result.Diff = generateUnifiedDiff(label1, label2, lines1, lines2)
+
+	for _, line := range strings.Split(result.Diff, "\n") {
+		if strings.HasPrefix(line, "+") && !strings.HasPrefix(line, "+++") {
+			result.AddedLines++
+		} else if strings.HasPrefix(line, "-") && !strings.HasPrefix(line, "---") {
+			result.RemovedLines++
+		}
+	}
+
+	return result, nil
+}
+
+// resolveRevisionURL builds the ADT revision feed URL for a given object type.
+//
+// Key discovery: classes use /includes/{type}/versions (not /source/main/versions).
+// Programs and other source objects use /source/main/versions.
+// Interfaces also use /includes/main/versions (same pattern as classes).
+func (c *Client) resolveRevisionURL(objectType, name string, opts *GetSourceOptions) (string, error) {
+	encodedName := url.PathEscape(name)
+
+	switch objectType {
+	case "PROG":
+		return fmt.Sprintf("/sap/bc/adt/programs/programs/%s/source/main/versions", encodedName), nil
+	case "CLAS":
+		include := opts.Include
+		if include == "" {
+			include = "main"
+		}
+		// Classes always use /includes/{type}/versions — even for main
+		return fmt.Sprintf("/sap/bc/adt/oo/classes/%s/includes/%s/versions", encodedName, include), nil
+	case "INTF":
+		// Interfaces use the same /includes/main/versions pattern as classes
+		return fmt.Sprintf("/sap/bc/adt/oo/interfaces/%s/includes/main/versions", encodedName), nil
+	case "FUNC":
+		if opts.Parent == "" {
+			return "", fmt.Errorf("parent (function group name) is required for FUNC type")
+		}
+		encodedParent := url.PathEscape(strings.ToUpper(opts.Parent))
+		return fmt.Sprintf("/sap/bc/adt/functions/groups/%s/fmodules/%s/source/main/versions", encodedParent, encodedName), nil
+	case "INCL":
+		return fmt.Sprintf("/sap/bc/adt/programs/includes/%s/source/main/versions", encodedName), nil
+	case "DDLS":
+		return fmt.Sprintf("/sap/bc/adt/ddic/ddl/sources/%s/source/main/versions", encodedName), nil
+	case "BDEF":
+		return fmt.Sprintf("/sap/bc/adt/bo/behaviordefinitions/%s/source/main/versions", encodedName), nil
+	case "SRVD":
+		return fmt.Sprintf("/sap/bc/adt/ddic/srvd/sources/%s/source/main/versions", encodedName), nil
+	default:
+		return "", fmt.Errorf("unsupported object type for revisions: %s (supported: PROG, CLAS, INTF, FUNC, INCL, DDLS, BDEF, SRVD)", objectType)
+	}
+}
+
+// extractVersionLabel extracts a short label from a version URI for display.
+// Handles two URI formats:
+//   - PROG: .../source/main?version=5 → "v5"
+//   - CLAS: .../versions/20161212091747/00000/content → "v00000"
+func extractVersionLabel(uri string) string {
+	if uri == "current" {
+		return "current"
+	}
+	// Format 1: query param (programs)
+	if idx := strings.Index(uri, "version="); idx >= 0 {
+		rest := uri[idx+8:]
+		if end := strings.IndexAny(rest, "&;"); end >= 0 {
+			return "v" + rest[:end]
+		}
+		return "v" + rest
+	}
+	// Format 2: path-based (classes) — .../versions/{timestamp}/{version}/content
+	if idx := strings.Index(uri, "/versions/"); idx >= 0 {
+		rest := uri[idx+10:] // after "/versions/"
+		parts := strings.Split(rest, "/")
+		if len(parts) >= 2 {
+			return "v" + parts[1] // version number (e.g., "00000")
+		}
+		if len(parts) == 1 {
+			return "v" + parts[0]
+		}
+	}
+	parts := strings.Split(uri, "/")
+	if len(parts) > 0 {
+		return parts[len(parts)-1]
+	}
+	return uri
+}

--- a/pkg/adt/revisions_test.go
+++ b/pkg/adt/revisions_test.go
@@ -1,0 +1,335 @@
+package adt
+
+import (
+	"context"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+func TestParseRevisionFeed(t *testing.T) {
+	feedXML := `<?xml version="1.0" encoding="UTF-8"?>
+<atom:feed xmlns:atom="http://www.w3.org/2005/Atom"
+           xmlns:adtcore="http://www.sap.com/adt/core">
+  <atom:title>Versions of ZTEST_PROGRAM</atom:title>
+  <atom:entry>
+    <atom:id>5</atom:id>
+    <atom:title>Active Version</atom:title>
+    <atom:updated>2025-06-15T14:30:00Z</atom:updated>
+    <atom:author><atom:name>DEVELOPER1</atom:name></atom:author>
+    <atom:content src="/sap/bc/adt/programs/programs/ztest/source/main?version=5" type="text/plain"/>
+    <atom:link href="/sap/bc/adt/cts/transportrequests/K900123" rel="http://www.sap.com/adt/relations/transport"
+               type="application/vnd.sap.adt.transportrequests.v1+xml" adtcore:name="K900123"/>
+  </atom:entry>
+  <atom:entry>
+    <atom:id>4</atom:id>
+    <atom:title>Previous Version</atom:title>
+    <atom:updated>2025-06-10T09:15:00Z</atom:updated>
+    <atom:author><atom:name>DEVELOPER2</atom:name></atom:author>
+    <atom:content src="/sap/bc/adt/programs/programs/ztest/source/main?version=4" type="text/plain"/>
+  </atom:entry>
+  <atom:entry>
+    <atom:id>3</atom:id>
+    <atom:title>Initial Version</atom:title>
+    <atom:updated>2025-06-01T08:00:00Z</atom:updated>
+    <atom:author><atom:name>DEVELOPER1</atom:name></atom:author>
+    <atom:content src="/sap/bc/adt/programs/programs/ztest/source/main?version=3" type="text/plain"/>
+    <atom:link href="/sap/bc/adt/cts/transportrequests/K900100" rel="http://www.sap.com/adt/relations/transport"
+               type="application/vnd.sap.adt.transportrequests.v1+xml" adtcore:name="K900100"/>
+  </atom:entry>
+</atom:feed>`
+
+	revisions, err := ParseRevisionFeed([]byte(feedXML))
+	if err != nil {
+		t.Fatalf("ParseRevisionFeed failed: %v", err)
+	}
+
+	if len(revisions) != 3 {
+		t.Fatalf("Expected 3 revisions, got %d", len(revisions))
+	}
+
+	// Check first entry
+	if revisions[0].Version != "5" {
+		t.Errorf("revisions[0].Version = %q, want %q", revisions[0].Version, "5")
+	}
+	if revisions[0].VersionTitle != "Active Version" {
+		t.Errorf("revisions[0].VersionTitle = %q, want %q", revisions[0].VersionTitle, "Active Version")
+	}
+	if revisions[0].Author != "DEVELOPER1" {
+		t.Errorf("revisions[0].Author = %q, want %q", revisions[0].Author, "DEVELOPER1")
+	}
+	if revisions[0].Date != "2025-06-15T14:30:00Z" {
+		t.Errorf("revisions[0].Date = %q, want %q", revisions[0].Date, "2025-06-15T14:30:00Z")
+	}
+	if revisions[0].URI != "/sap/bc/adt/programs/programs/ztest/source/main?version=5" {
+		t.Errorf("revisions[0].URI = %q", revisions[0].URI)
+	}
+	if revisions[0].Transport != "K900123" {
+		t.Errorf("revisions[0].Transport = %q, want %q", revisions[0].Transport, "K900123")
+	}
+
+	// Check second entry (no transport)
+	if revisions[1].Transport != "" {
+		t.Errorf("revisions[1].Transport = %q, want empty", revisions[1].Transport)
+	}
+	if revisions[1].Author != "DEVELOPER2" {
+		t.Errorf("revisions[1].Author = %q, want %q", revisions[1].Author, "DEVELOPER2")
+	}
+
+	// Check third entry
+	if revisions[2].Transport != "K900100" {
+		t.Errorf("revisions[2].Transport = %q, want %q", revisions[2].Transport, "K900100")
+	}
+}
+
+func TestParseRevisionFeed_Empty(t *testing.T) {
+	feedXML := `<?xml version="1.0" encoding="UTF-8"?>
+<atom:feed xmlns:atom="http://www.w3.org/2005/Atom">
+  <atom:title>No versions</atom:title>
+</atom:feed>`
+
+	revisions, err := ParseRevisionFeed([]byte(feedXML))
+	if err != nil {
+		t.Fatalf("ParseRevisionFeed failed: %v", err)
+	}
+	if len(revisions) != 0 {
+		t.Errorf("Expected 0 revisions, got %d", len(revisions))
+	}
+}
+
+func TestParseRevisionFeed_InvalidXML(t *testing.T) {
+	_, err := ParseRevisionFeed([]byte("not xml"))
+	if err == nil {
+		t.Error("Expected error for invalid XML")
+	}
+}
+
+func TestResolveRevisionURL(t *testing.T) {
+	cfg := NewConfig("https://sap.example.com:44300", "user", "pass")
+	client := &Client{config: cfg}
+
+	tests := []struct {
+		name       string
+		objectType string
+		objName    string
+		opts       *GetSourceOptions
+		wantURL    string
+		wantErr    bool
+	}{
+		{
+			name:       "PROG",
+			objectType: "PROG",
+			objName:    "ZTEST",
+			opts:       &GetSourceOptions{},
+			wantURL:    "/sap/bc/adt/programs/programs/ZTEST/source/main/versions",
+		},
+		{
+			name:       "CLAS main",
+			objectType: "CLAS",
+			objName:    "ZCL_TEST",
+			opts:       &GetSourceOptions{},
+			wantURL:    "/sap/bc/adt/oo/classes/ZCL_TEST/includes/main/versions",
+		},
+		{
+			name:       "CLAS explicit main",
+			objectType: "CLAS",
+			objName:    "ZCL_TEST",
+			opts:       &GetSourceOptions{Include: "main"},
+			wantURL:    "/sap/bc/adt/oo/classes/ZCL_TEST/includes/main/versions",
+		},
+		{
+			name:       "CLAS testclasses",
+			objectType: "CLAS",
+			objName:    "ZCL_TEST",
+			opts:       &GetSourceOptions{Include: "testclasses"},
+			wantURL:    "/sap/bc/adt/oo/classes/ZCL_TEST/includes/testclasses/versions",
+		},
+		{
+			name:       "INTF",
+			objectType: "INTF",
+			objName:    "ZIF_TEST",
+			opts:       &GetSourceOptions{},
+			wantURL:    "/sap/bc/adt/oo/interfaces/ZIF_TEST/includes/main/versions",
+		},
+		{
+			name:       "FUNC",
+			objectType: "FUNC",
+			objName:    "Z_TEST_FM",
+			opts:       &GetSourceOptions{Parent: "ZFUGR"},
+			wantURL:    "/sap/bc/adt/functions/groups/ZFUGR/fmodules/Z_TEST_FM/source/main/versions",
+		},
+		{
+			name:       "FUNC without parent",
+			objectType: "FUNC",
+			objName:    "Z_TEST_FM",
+			opts:       &GetSourceOptions{},
+			wantErr:    true,
+		},
+		{
+			name:       "INCL",
+			objectType: "INCL",
+			objName:    "ZTEST_INCL",
+			opts:       &GetSourceOptions{},
+			wantURL:    "/sap/bc/adt/programs/includes/ZTEST_INCL/source/main/versions",
+		},
+		{
+			name:       "DDLS",
+			objectType: "DDLS",
+			objName:    "ZTEST_CDS",
+			opts:       &GetSourceOptions{},
+			wantURL:    "/sap/bc/adt/ddic/ddl/sources/ZTEST_CDS/source/main/versions",
+		},
+		{
+			name:       "BDEF",
+			objectType: "BDEF",
+			objName:    "ZTEST_BDEF",
+			opts:       &GetSourceOptions{},
+			wantURL:    "/sap/bc/adt/bo/behaviordefinitions/ZTEST_BDEF/source/main/versions",
+		},
+		{
+			name:       "SRVD",
+			objectType: "SRVD",
+			objName:    "ZTEST_SRVD",
+			opts:       &GetSourceOptions{},
+			wantURL:    "/sap/bc/adt/ddic/srvd/sources/ZTEST_SRVD/source/main/versions",
+		},
+		{
+			name:       "unsupported type",
+			objectType: "TABL",
+			objName:    "ZTEST",
+			opts:       &GetSourceOptions{},
+			wantErr:    true,
+		},
+		{
+			name:       "namespace object",
+			objectType: "CLAS",
+			objName:    "/UI5/CL_REPOSITORY",
+			opts:       &GetSourceOptions{},
+			wantURL:    "/sap/bc/adt/oo/classes/%2FUI5%2FCL_REPOSITORY/includes/main/versions",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := client.resolveRevisionURL(tt.objectType, tt.objName, tt.opts)
+			if tt.wantErr {
+				if err == nil {
+					t.Error("Expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("Unexpected error: %v", err)
+			}
+			if got != tt.wantURL {
+				t.Errorf("got %q, want %q", got, tt.wantURL)
+			}
+		})
+	}
+}
+
+func TestExtractVersionLabel(t *testing.T) {
+	tests := []struct {
+		uri    string
+		expect string
+	}{
+		{"current", "current"},
+		{"/sap/bc/adt/programs/programs/ztest/source/main?version=42", "v42"},
+		{"/sap/bc/adt/programs/programs/ztest/source/main?version=5&format=text", "v5"},
+		// Class format: .../versions/{timestamp}/{version}/content
+		{"/sap/bc/adt/oo/classes/%2FCOCKPIT%2FCL_TOOLS/includes/main/versions/20161212091747/00000/content", "v00000"},
+		{"/sap/bc/adt/oo/classes/ZCL_TEST/includes/main/versions/20250101120000/00003/content", "v00003"},
+		{"/some/path/123", "123"},
+		{"", ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.uri, func(t *testing.T) {
+			got := extractVersionLabel(tt.uri)
+			if got != tt.expect {
+				t.Errorf("extractVersionLabel(%q) = %q, want %q", tt.uri, got, tt.expect)
+			}
+		})
+	}
+}
+
+func TestClient_GetRevisions(t *testing.T) {
+	feedXML := `<?xml version="1.0" encoding="UTF-8"?>
+<atom:feed xmlns:atom="http://www.w3.org/2005/Atom"
+           xmlns:adtcore="http://www.sap.com/adt/core">
+  <atom:title>Versions</atom:title>
+  <atom:entry>
+    <atom:id>1</atom:id>
+    <atom:title>Version 1</atom:title>
+    <atom:updated>2025-01-01T00:00:00Z</atom:updated>
+    <atom:author><atom:name>DEV</atom:name></atom:author>
+    <atom:content src="/sap/bc/adt/programs/programs/ZTEST/source/main?version=1" type="text/plain"/>
+  </atom:entry>
+</atom:feed>`
+
+	mock := &mockTransportClient{
+		responses: map[string]*http.Response{
+			// PROG uses /source/main/versions
+			"/sap/bc/adt/programs/programs/ZTEST/source/main/versions": newTestResponse(feedXML),
+		},
+	}
+
+	cfg := NewConfig("https://sap.example.com:44300", "user", "pass")
+	transport := NewTransportWithClient(cfg, mock)
+	client := NewClientWithTransport(cfg, transport)
+
+	revisions, err := client.GetRevisions(context.Background(), "PROG", "ZTEST", nil)
+	if err != nil {
+		t.Fatalf("GetRevisions failed: %v", err)
+	}
+
+	if len(revisions) != 1 {
+		t.Fatalf("Expected 1 revision, got %d", len(revisions))
+	}
+	if revisions[0].Author != "DEV" {
+		t.Errorf("Author = %q, want %q", revisions[0].Author, "DEV")
+	}
+
+	// Verify the correct URL was requested
+	if len(mock.requests) == 0 {
+		t.Fatal("No requests made")
+	}
+	requestPath := mock.requests[0].URL.Path
+	if !strings.HasSuffix(requestPath, "/versions") {
+		t.Errorf("Request path %q should end with /versions", requestPath)
+	}
+}
+
+func TestClient_GetRevisionSource(t *testing.T) {
+	sourceCode := "REPORT ztest.\nWRITE 'Old version'."
+
+	mock := &mockTransportClient{
+		responses: map[string]*http.Response{
+			"/sap/bc/adt/programs/programs/ZTEST/source/main": newTestResponse(sourceCode),
+		},
+	}
+
+	cfg := NewConfig("https://sap.example.com:44300", "user", "pass")
+	transport := NewTransportWithClient(cfg, mock)
+	client := NewClientWithTransport(cfg, transport)
+
+	source, err := client.GetRevisionSource(context.Background(), "/sap/bc/adt/programs/programs/ZTEST/source/main?version=1")
+	if err != nil {
+		t.Fatalf("GetRevisionSource failed: %v", err)
+	}
+
+	if !strings.Contains(source, "REPORT ztest") {
+		t.Error("Source should contain REPORT statement")
+	}
+}
+
+func TestClient_GetRevisionSource_EmptyURI(t *testing.T) {
+	cfg := NewConfig("https://sap.example.com:44300", "user", "pass")
+	transport := NewTransportWithClient(cfg, &mockTransportClient{responses: map[string]*http.Response{}})
+	client := NewClientWithTransport(cfg, transport)
+
+	_, err := client.GetRevisionSource(context.Background(), "")
+	if err == nil {
+		t.Error("Expected error for empty URI")
+	}
+}

--- a/pkg/adt/xml.go
+++ b/pkg/adt/xml.go
@@ -29,6 +29,7 @@ type Link struct {
 	Rel     string   `xml:"rel,attr"`
 	Type    string   `xml:"type,attr,omitempty"`
 	Title   string   `xml:"title,attr,omitempty"`
+	Name    string   `xml:"http://www.sap.com/adt/core name,attr,omitempty"` // adtcore:name attribute
 }
 
 // AtomEntry represents an Atom feed entry.
@@ -324,4 +325,70 @@ func ExtractSourceLink(links []Link) string {
 		}
 	}
 	return ""
+}
+
+// --- Revision (Version History) Types ---
+
+// Revision represents a single version of an ABAP object in the revision history.
+type Revision struct {
+	URI          string `json:"uri"`                    // Content URL for fetching this version's source
+	Version      string `json:"version"`                // Version identifier (entry ID)
+	VersionTitle string `json:"versionTitle"`           // Human-readable version title
+	Date         string `json:"date"`                   // ISO 8601 timestamp
+	Author       string `json:"author"`                 // Username who made the change
+	Transport    string `json:"transport,omitempty"`     // Transport request number
+}
+
+// revisionFeedEntry is an internal type for parsing ADT version Atom feed entries.
+type revisionFeedEntry struct {
+	XMLName xml.Name `xml:"entry"`
+	ID      string   `xml:"id"`
+	Title   string   `xml:"title"`
+	Updated string   `xml:"updated"`
+	Author  struct {
+		Name string `xml:"name"`
+	} `xml:"author"`
+	Content struct {
+		Src  string `xml:"src,attr"`
+		Type string `xml:"type,attr"`
+	} `xml:"content"`
+	Links []Link `xml:"link"`
+}
+
+// revisionFeed is an internal type for parsing ADT version Atom feeds.
+type revisionFeed struct {
+	XMLName xml.Name            `xml:"feed"`
+	Title   string              `xml:"title"`
+	Entries []revisionFeedEntry `xml:"entry"`
+}
+
+// ParseRevisionFeed parses an ADT versions Atom feed into Revision entries.
+func ParseRevisionFeed(data []byte) ([]Revision, error) {
+	var feed revisionFeed
+	if err := xml.Unmarshal(data, &feed); err != nil {
+		return nil, fmt.Errorf("parsing revision feed: %w", err)
+	}
+
+	revisions := make([]Revision, 0, len(feed.Entries))
+	for _, entry := range feed.Entries {
+		rev := Revision{
+			URI:          entry.Content.Src,
+			VersionTitle: entry.Title,
+			Date:         entry.Updated,
+			Version:      entry.ID,
+			Author:       entry.Author.Name,
+		}
+		// Extract transport request from links (adtcore:name attribute)
+		for _, link := range entry.Links {
+			if strings.Contains(link.Type, "transportrequests") {
+				if link.Name != "" {
+					rev.Transport = link.Name
+				}
+				break
+			}
+		}
+		revisions = append(revisions, rev)
+	}
+
+	return revisions, nil
 }


### PR DESCRIPTION
## Summary

Add object version history support via SAP ADT Atom feed API — 3 new tools with 8 unit tests:

- **GetRevisions** — list version history with dates, authors, transport requests
- **GetRevisionSource** — get source code of a specific version
- **CompareVersions** — unified diff between two versions (or vs current)

Also adds `Name` field to `Link` struct for transport request extraction from Atom feeds, and `Revision`/`ParseRevisionFeed` types to `xml.go`.

## Files

| File | Lines | Description |
|------|-------|-------------|
| `pkg/adt/revisions.go` | 193 | Client methods for version history |
| `pkg/adt/revisions_test.go` | 335 | 8 unit tests (feed parsing, URL resolution, client) |
| `internal/mcp/handlers_revisions.go` | 83 | MCP tool handlers |
| `internal/mcp/tools_register.go` | +61 | Tool registration |
| `internal/mcp/tools_focused.go` | +5 | Focused mode whitelist |
| `pkg/adt/xml.go` | +67 | Revision types + Link.Name field |

## ADT API endpoints

- `GET /sap/bc/adt/.../versions` — Atom feed with version history
- `GET /sap/bc/adt/.../versions/{id}/content` — Version source code

## Test plan

- [x] `go build ./cmd/vsp` compiles clean
- [x] `go test ./pkg/adt/` — 8 new tests pass, no regressions
- [ ] Integration test with SAP system