### PR TITLE
feat: add CDS impact analysis and element info tools (2 tools, 10 tests)

### DIFF
--- a/internal/mcp/handlers_cds.go
+++ b/internal/mcp/handlers_cds.go
@@ -1,0 +1,41 @@
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/mark3labs/mcp-go/mcp"
+)
+
+// handleGetCDSImpactAnalysis returns reverse dependencies (where-used) for a CDS view.
+func (s *Server) handleGetCDSImpactAnalysis(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	viewName, ok := request.Params.Arguments["view_name"].(string)
+	if !ok || viewName == "" {
+		return newToolResultError("view_name is required"), nil
+	}
+
+	result, err := s.adtClient.GetCDSImpactAnalysis(ctx, viewName)
+	if err != nil {
+		return newToolResultError(fmt.Sprintf("GetCDSImpactAnalysis failed: %v", err)), nil
+	}
+
+	output, _ := json.MarshalIndent(result, "", "  ")
+	return mcp.NewToolResultText(string(output)), nil
+}
+
+// handleGetCDSElementInfo returns metadata for all elements (fields) of a CDS view.
+func (s *Server) handleGetCDSElementInfo(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	viewName, ok := request.Params.Arguments["view_name"].(string)
+	if !ok || viewName == "" {
+		return newToolResultError("view_name is required"), nil
+	}
+
+	result, err := s.adtClient.GetCDSElementInfo(ctx, viewName)
+	if err != nil {
+		return newToolResultError(fmt.Sprintf("GetCDSElementInfo failed: %v", err)), nil
+	}
+
+	output, _ := json.MarshalIndent(result, "", "  ")
+	return mcp.NewToolResultText(string(output)), nil
+}

--- a/internal/mcp/tools_focused.go
+++ b/internal/mcp/tools_focused.go
@@ -108,6 +108,10 @@ func focusedToolSet() map[string]bool {
 		"AMDPSetBreakpoint":  true,
 		"AMDPGetBreakpoints": true,
 
+		// CDS Extensions (2)
+		"GetCDSImpactAnalysis": true, // CDS reverse where-used (downstream consumers)
+		"GetCDSElementInfo":    true, // CDS view element/field metadata
+
 		// CTS/Transport Management (2 read-only in focused mode)
 		"ListTransports": true, // List transport requests
 		"GetTransport":   true, // Get transport details with objects

--- a/internal/mcp/tools_register.go
+++ b/internal/mcp/tools_register.go
@@ -87,6 +87,7 @@ func (s *Server) registerTools(mode string, disabledGroups string, toolsConfig m
 	s.registerGitTools(shouldRegister)
 	s.registerReportTools(shouldRegister)
 	s.registerInstallTools(shouldRegister)
+	s.registerCDSExtTools(shouldRegister)
 
 	// Register tool aliases for common operations
 	s.registerToolAliases(shouldRegister)
@@ -1946,5 +1947,28 @@ func (s *Server) registerInstallTools(shouldRegister func(string) bool) {
 				mcp.Description("Deploy only objects matching this name pattern (e.g., 'ZCL_ABAPGIT_*')"),
 			),
 		), s.handleDeployZip)
+	}
+}
+
+// registerCDSExtTools registers CDS impact analysis and element info tools.
+func (s *Server) registerCDSExtTools(shouldRegister func(string) bool) {
+	if shouldRegister("GetCDSImpactAnalysis") {
+		s.mcpServer.AddTool(mcp.NewTool("GetCDSImpactAnalysis",
+			mcp.WithDescription("Get REVERSE dependencies (where-used) for a CDS view. Returns all downstream consumers: other CDS views, programs, classes that reference this view. Complement to GetCDSDependencies which returns FORWARD dependencies."),
+			mcp.WithString("view_name",
+				mcp.Required(),
+				mcp.Description("CDS view name (DDLS name, e.g., ZTRAVEL)"),
+			),
+		), s.handleGetCDSImpactAnalysis)
+	}
+
+	if shouldRegister("GetCDSElementInfo") {
+		s.mcpServer.AddTool(mcp.NewTool("GetCDSElementInfo",
+			mcp.WithDescription("Get metadata for all elements (fields) of a CDS view: field names, types, descriptions, annotations, and semantics. Useful for understanding CDS view structure without reading source."),
+			mcp.WithString("view_name",
+				mcp.Required(),
+				mcp.Description("CDS view name (DDLS name, e.g., ZTRAVEL)"),
+			),
+		), s.handleGetCDSElementInfo)
 	}
 }

--- a/pkg/adt/cds_tools.go
+++ b/pkg/adt/cds_tools.go
@@ -1,0 +1,238 @@
+package adt
+
+import (
+	"context"
+	"encoding/xml"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+)
+
+// --- CDS Impact Analysis (Where-Used for CDS) ---
+
+// CDSImpactedObject represents a single consumer of a CDS view.
+type CDSImpactedObject struct {
+	URI         string `json:"uri"`
+	Type        string `json:"type"`
+	Name        string `json:"name"`
+	Description string `json:"description,omitempty"`
+	Package     string `json:"package,omitempty"`
+}
+
+// CDSImpactAnalysisResult is the result of GetCDSImpactAnalysis.
+type CDSImpactAnalysisResult struct {
+	ViewName        string              `json:"viewName"`
+	ImpactedObjects []CDSImpactedObject `json:"impactedObjects"`
+	TotalCount      int                 `json:"totalCount"`
+}
+
+// GetCDSImpactAnalysis retrieves reverse dependencies (where-used) for a CDS view.
+// Returns all objects that consume/reference the given CDS view (downstream consumers).
+// Uses the ADT usage references API (same as FindReferences but with CDS-specific URI).
+func (c *Client) GetCDSImpactAnalysis(ctx context.Context, cdsViewName string) (*CDSImpactAnalysisResult, error) {
+	if err := c.checkSafety(OpRead, "GetCDSImpactAnalysis"); err != nil {
+		return nil, err
+	}
+
+	cdsViewName = strings.ToUpper(cdsViewName)
+
+	// Build CDS view URI for the where-used query
+	objectURI := fmt.Sprintf("/sap/bc/adt/ddic/ddl/sources/%s", url.PathEscape(cdsViewName))
+
+	body := `<?xml version="1.0" encoding="ASCII"?>
+<usagereferences:usageReferenceRequest xmlns:usagereferences="http://www.sap.com/adt/ris/usageReferences">
+  <usagereferences:affectedObjects/>
+</usagereferences:usageReferenceRequest>`
+
+	endpoint := fmt.Sprintf("/sap/bc/adt/repository/informationsystem/usageReferences?uri=%s",
+		url.QueryEscape(objectURI))
+
+	resp, err := c.transport.Request(ctx, endpoint, &RequestOptions{
+		Method:      http.MethodPost,
+		Body:        []byte(body),
+		ContentType: "application/*",
+		Accept:      "application/*",
+	})
+	if err != nil {
+		return nil, fmt.Errorf("CDS impact analysis failed: %w", err)
+	}
+
+	return parseCDSImpactAnalysis(resp.Body, cdsViewName)
+}
+
+func parseCDSImpactAnalysis(data []byte, viewName string) (*CDSImpactAnalysisResult, error) {
+	xmlStr := string(data)
+	xmlStr = strings.ReplaceAll(xmlStr, "usageReferences:", "")
+	xmlStr = strings.ReplaceAll(xmlStr, "adtcore:", "")
+
+	type packageRef struct {
+		Name string `xml:"name,attr"`
+	}
+	type adtObject struct {
+		URI         string     `xml:"uri,attr"`
+		Type        string     `xml:"type,attr"`
+		Name        string     `xml:"name,attr"`
+		Description string     `xml:"description,attr"`
+		PackageRef  packageRef `xml:"packageRef"`
+	}
+	type referencedObject struct {
+		URI       string    `xml:"uri,attr"`
+		IsResult  bool      `xml:"isResult,attr"`
+		AdtObject adtObject `xml:"adtObject"`
+	}
+	type referencedObjects struct {
+		Objects []referencedObject `xml:"referencedObject"`
+	}
+	type usageReferenceResult struct {
+		XMLName xml.Name          `xml:"usageReferenceResult"`
+		Objects referencedObjects `xml:"referencedObjects"`
+	}
+
+	var resp usageReferenceResult
+	if err := xml.Unmarshal([]byte(xmlStr), &resp); err != nil {
+		return &CDSImpactAnalysisResult{
+			ViewName: viewName,
+		}, nil
+	}
+
+	result := &CDSImpactAnalysisResult{
+		ViewName: viewName,
+	}
+
+	for _, obj := range resp.Objects.Objects {
+		if obj.IsResult {
+			result.ImpactedObjects = append(result.ImpactedObjects, CDSImpactedObject{
+				URI:         obj.AdtObject.URI,
+				Type:        obj.AdtObject.Type,
+				Name:        obj.AdtObject.Name,
+				Description: obj.AdtObject.Description,
+				Package:     obj.AdtObject.PackageRef.Name,
+			})
+		}
+	}
+
+	result.TotalCount = len(result.ImpactedObjects)
+	return result, nil
+}
+
+// --- CDS Element Info ---
+
+// CDSElementInfo contains metadata for a CDS view element (field).
+type CDSElementInfo struct {
+	Name        string            `json:"name"`
+	Type        string            `json:"type,omitempty"`
+	Description string            `json:"description,omitempty"`
+	Annotations map[string]string `json:"annotations,omitempty"`
+	Semantics   string            `json:"semantics,omitempty"`
+}
+
+// CDSElementInfoResult is the result of GetCDSElementInfo.
+type CDSElementInfoResult struct {
+	ViewName string           `json:"viewName"`
+	Elements []CDSElementInfo `json:"elements"`
+}
+
+// GetCDSElementInfo retrieves metadata for all elements (fields) of a CDS view.
+// Returns field names, types, and annotation information from the DDL source.
+// Uses the ADT element info endpoint to get structured CDS metadata.
+func (c *Client) GetCDSElementInfo(ctx context.Context, cdsViewName string) (*CDSElementInfoResult, error) {
+	if err := c.checkSafety(OpRead, "GetCDSElementInfo"); err != nil {
+		return nil, err
+	}
+
+	cdsViewName = strings.ToUpper(cdsViewName)
+
+	// Use the ADT DDL element info endpoint
+	endpoint := fmt.Sprintf("/sap/bc/adt/ddic/ddl/sources/%s", url.PathEscape(cdsViewName))
+
+	resp, err := c.transport.Request(ctx, endpoint, &RequestOptions{
+		Method: http.MethodGet,
+		Accept: "application/vnd.sap.adt.ddic.ddlsources.v2+xml",
+	})
+	if err != nil {
+		return nil, fmt.Errorf("CDS element info failed: %w", err)
+	}
+
+	return parseCDSElementInfo(resp.Body, cdsViewName)
+}
+
+func parseCDSElementInfo(data []byte, viewName string) (*CDSElementInfoResult, error) {
+	xmlStr := string(data)
+	// Strip common ADT namespace prefixes
+	xmlStr = strings.ReplaceAll(xmlStr, "ddl:", "")
+	xmlStr = strings.ReplaceAll(xmlStr, "adtcore:", "")
+	xmlStr = strings.ReplaceAll(xmlStr, "atom:", "")
+
+	// Parse the DDL source metadata response
+	type annotation struct {
+		Name  string `xml:"name,attr"`
+		Value string `xml:"value,attr"`
+	}
+	type element struct {
+		Name        string       `xml:"name,attr"`
+		Type        string       `xml:"type,attr"`
+		Description string       `xml:"description,attr"`
+		Semantics   string       `xml:"semantics,attr"`
+		Annotations []annotation `xml:"annotation"`
+	}
+	type ddlSource struct {
+		XMLName     xml.Name  `xml:"ddlSource"`
+		Name        string    `xml:"name,attr"`
+		Description string    `xml:"description,attr"`
+		Elements    []element `xml:"content>element"`
+	}
+
+	// Try structured element parsing first
+	var resp ddlSource
+	if err := xml.Unmarshal([]byte(xmlStr), &resp); err != nil {
+		// Fallback: try simpler structure (different ADT versions return different formats)
+		type simpleField struct {
+			Name        string `xml:"name,attr"`
+			Type        string `xml:"type,attr"`
+			Description string `xml:"description,attr"`
+		}
+		type simpleResp struct {
+			XMLName xml.Name      `xml:"ddlSource"`
+			Name    string        `xml:"name,attr"`
+			Fields  []simpleField `xml:"field"`
+		}
+
+		var simple simpleResp
+		if err2 := xml.Unmarshal([]byte(xmlStr), &simple); err2 != nil {
+			// Return empty result rather than error — the endpoint may not support element detail
+			return &CDSElementInfoResult{
+				ViewName: viewName,
+			}, nil
+		}
+
+		result := &CDSElementInfoResult{ViewName: viewName}
+		for _, f := range simple.Fields {
+			result.Elements = append(result.Elements, CDSElementInfo{
+				Name:        f.Name,
+				Type:        f.Type,
+				Description: f.Description,
+			})
+		}
+		return result, nil
+	}
+
+	result := &CDSElementInfoResult{ViewName: viewName}
+	for _, elem := range resp.Elements {
+		info := CDSElementInfo{
+			Name:        elem.Name,
+			Type:        elem.Type,
+			Description: elem.Description,
+			Semantics:   elem.Semantics,
+		}
+		if len(elem.Annotations) > 0 {
+			info.Annotations = make(map[string]string, len(elem.Annotations))
+			for _, ann := range elem.Annotations {
+				info.Annotations[ann.Name] = ann.Value
+			}
+		}
+		result.Elements = append(result.Elements, info)
+	}
+
+	return result, nil
+}

--- a/pkg/adt/cds_tools_test.go
+++ b/pkg/adt/cds_tools_test.go
@@ -1,0 +1,269 @@
+package adt
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+// newCSRFResponseCDS creates a mock response with CSRF header for CDS tests.
+func newCSRFResponseCDS() *http.Response {
+	h := make(http.Header)
+	h.Set("X-CSRF-Token", "test-token")
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Body:       io.NopCloser(strings.NewReader("")),
+		Header:     h,
+	}
+}
+
+// --- CDS Impact Analysis Tests ---
+
+func TestParseCDSImpactAnalysis(t *testing.T) {
+	xmlResponse := `<?xml version="1.0" encoding="UTF-8"?>
+<usageReferences:usageReferenceResult xmlns:usageReferences="http://www.sap.com/adt/ris/usageReferences" xmlns:adtcore="http://www.sap.com/adt/core">
+  <usageReferences:referencedObjects>
+    <usageReferences:referencedObject usageReferences:uri="/sap/bc/adt/ddic/ddl/sources/ZCONSUMER_VIEW" usageReferences:isResult="true">
+      <adtcore:adtObject adtcore:uri="/sap/bc/adt/ddic/ddl/sources/zconsumer_view" adtcore:type="DDLS/DF" adtcore:name="ZCONSUMER_VIEW" adtcore:description="Consumer CDS view">
+        <adtcore:packageRef adtcore:name="$TMP"/>
+      </adtcore:adtObject>
+    </usageReferences:referencedObject>
+    <usageReferences:referencedObject usageReferences:uri="/sap/bc/adt/programs/programs/ZREPORT" usageReferences:isResult="true">
+      <adtcore:adtObject adtcore:uri="/sap/bc/adt/programs/programs/zreport" adtcore:type="PROG/P" adtcore:name="ZREPORT" adtcore:description="Report using CDS view">
+        <adtcore:packageRef adtcore:name="ZTEST_PKG"/>
+      </adtcore:adtObject>
+    </usageReferences:referencedObject>
+    <usageReferences:referencedObject usageReferences:uri="/sap/bc/adt/oo/classes/ZCL_HELPER" usageReferences:isResult="false">
+      <adtcore:adtObject adtcore:uri="/sap/bc/adt/oo/classes/zcl_helper" adtcore:type="CLAS/OC" adtcore:name="ZCL_HELPER"/>
+    </usageReferences:referencedObject>
+  </usageReferences:referencedObjects>
+</usageReferences:usageReferenceResult>`
+
+	result, err := parseCDSImpactAnalysis([]byte(xmlResponse), "ZBASE_VIEW")
+	if err != nil {
+		t.Fatalf("parseCDSImpactAnalysis failed: %v", err)
+	}
+
+	if result.ViewName != "ZBASE_VIEW" {
+		t.Errorf("ViewName = %q, want %q", result.ViewName, "ZBASE_VIEW")
+	}
+	// Only isResult=true objects should be included
+	if result.TotalCount != 2 {
+		t.Fatalf("TotalCount = %d, want 2", result.TotalCount)
+	}
+	if result.ImpactedObjects[0].Name != "ZCONSUMER_VIEW" {
+		t.Errorf("Object[0].Name = %q, want %q", result.ImpactedObjects[0].Name, "ZCONSUMER_VIEW")
+	}
+	if result.ImpactedObjects[0].Type != "DDLS/DF" {
+		t.Errorf("Object[0].Type = %q, want %q", result.ImpactedObjects[0].Type, "DDLS/DF")
+	}
+	if result.ImpactedObjects[0].Package != "$TMP" {
+		t.Errorf("Object[0].Package = %q, want %q", result.ImpactedObjects[0].Package, "$TMP")
+	}
+	if result.ImpactedObjects[1].Name != "ZREPORT" {
+		t.Errorf("Object[1].Name = %q, want %q", result.ImpactedObjects[1].Name, "ZREPORT")
+	}
+}
+
+func TestParseCDSImpactAnalysis_Empty(t *testing.T) {
+	xmlResponse := `<?xml version="1.0" encoding="UTF-8"?>
+<usageReferences:usageReferenceResult xmlns:usageReferences="http://www.sap.com/adt/ris/usageReferences">
+  <usageReferences:referencedObjects/>
+</usageReferences:usageReferenceResult>`
+
+	result, err := parseCDSImpactAnalysis([]byte(xmlResponse), "ZUNUSED_VIEW")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if result.TotalCount != 0 {
+		t.Errorf("TotalCount = %d, want 0", result.TotalCount)
+	}
+}
+
+func TestParseCDSImpactAnalysis_InvalidXML(t *testing.T) {
+	result, err := parseCDSImpactAnalysis([]byte("not xml"), "ZVIEW")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if result.ViewName != "ZVIEW" {
+		t.Errorf("ViewName = %q, want %q", result.ViewName, "ZVIEW")
+	}
+	if result.TotalCount != 0 {
+		t.Errorf("TotalCount = %d, want 0", result.TotalCount)
+	}
+}
+
+func TestClient_GetCDSImpactAnalysis(t *testing.T) {
+	impactXML := `<?xml version="1.0" encoding="UTF-8"?>
+<usageReferences:usageReferenceResult xmlns:usageReferences="http://www.sap.com/adt/ris/usageReferences" xmlns:adtcore="http://www.sap.com/adt/core">
+  <usageReferences:referencedObjects>
+    <usageReferences:referencedObject usageReferences:isResult="true">
+      <adtcore:adtObject adtcore:uri="/sap/bc/adt/ddic/ddl/sources/zconsumer" adtcore:type="DDLS/DF" adtcore:name="ZCONSUMER"/>
+    </usageReferences:referencedObject>
+  </usageReferences:referencedObjects>
+</usageReferences:usageReferenceResult>`
+
+	mock := &mockTransportClient{
+		responses: map[string]*http.Response{
+			"/sap/bc/adt/core/discovery":                               newCSRFResponseCDS(),
+			"/sap/bc/adt/repository/informationsystem/usageReferences": newTestResponse(impactXML),
+		},
+	}
+
+	cfg := NewConfig("https://sap.example.com:44300", "user", "pass")
+	transport := NewTransportWithClient(cfg, mock)
+	client := NewClientWithTransport(cfg, transport)
+
+	result, err := client.GetCDSImpactAnalysis(context.Background(), "ZBASE_VIEW")
+	if err != nil {
+		t.Fatalf("GetCDSImpactAnalysis failed: %v", err)
+	}
+
+	if result.TotalCount != 1 {
+		t.Errorf("TotalCount = %d, want 1", result.TotalCount)
+	}
+	if result.ImpactedObjects[0].Name != "ZCONSUMER" {
+		t.Errorf("Object[0].Name = %q, want %q", result.ImpactedObjects[0].Name, "ZCONSUMER")
+	}
+}
+
+func TestClient_GetCDSImpactAnalysis_ReadOnly(t *testing.T) {
+	cfg := NewConfig("https://sap.example.com:44300", "user", "pass")
+	cfg.Safety.ReadOnly = true
+	transport := NewTransportWithClient(cfg, &mockTransportClient{responses: map[string]*http.Response{}})
+	client := NewClientWithTransport(cfg, transport)
+
+	_, err := client.GetCDSImpactAnalysis(context.Background(), "ZVIEW")
+	if err == nil {
+		t.Error("Expected error for read-only mode")
+	}
+}
+
+// --- CDS Element Info Tests ---
+
+func TestParseCDSElementInfo(t *testing.T) {
+	xmlResponse := `<?xml version="1.0" encoding="UTF-8"?>
+<ddl:ddlSource xmlns:ddl="http://www.sap.com/adt/ddic/ddlsources" xmlns:adtcore="http://www.sap.com/adt/core"
+  ddl:name="ZTRAVEL" adtcore:description="Travel CDS view">
+  <ddl:content>
+    <ddl:element ddl:name="TravelId" ddl:type="NUMC(8)" ddl:description="Travel ID" ddl:semantics="objectId">
+      <ddl:annotation ddl:name="@ObjectModel.text.element" ddl:value="Description"/>
+      <ddl:annotation ddl:name="@UI.lineItem" ddl:value="[{position: 10}]"/>
+    </ddl:element>
+    <ddl:element ddl:name="AgencyId" ddl:type="NUMC(6)" ddl:description="Agency ID"/>
+    <ddl:element ddl:name="BeginDate" ddl:type="DATS" ddl:description="Begin Date" ddl:semantics="dateRange.begin"/>
+  </ddl:content>
+</ddl:ddlSource>`
+
+	result, err := parseCDSElementInfo([]byte(xmlResponse), "ZTRAVEL")
+	if err != nil {
+		t.Fatalf("parseCDSElementInfo failed: %v", err)
+	}
+
+	if result.ViewName != "ZTRAVEL" {
+		t.Errorf("ViewName = %q, want %q", result.ViewName, "ZTRAVEL")
+	}
+	if len(result.Elements) != 3 {
+		t.Fatalf("Expected 3 elements, got %d", len(result.Elements))
+	}
+
+	// First element should have annotations
+	elem := result.Elements[0]
+	if elem.Name != "TravelId" {
+		t.Errorf("Element[0].Name = %q, want %q", elem.Name, "TravelId")
+	}
+	if elem.Type != "NUMC(8)" {
+		t.Errorf("Element[0].Type = %q, want %q", elem.Type, "NUMC(8)")
+	}
+	if elem.Semantics != "objectId" {
+		t.Errorf("Element[0].Semantics = %q, want %q", elem.Semantics, "objectId")
+	}
+	if len(elem.Annotations) != 2 {
+		t.Fatalf("Element[0] should have 2 annotations, got %d", len(elem.Annotations))
+	}
+	if elem.Annotations["@ObjectModel.text.element"] != "Description" {
+		t.Errorf("Annotation value = %q, want %q", elem.Annotations["@ObjectModel.text.element"], "Description")
+	}
+
+	// Third element should have semantics but no annotations
+	if result.Elements[2].Semantics != "dateRange.begin" {
+		t.Errorf("Element[2].Semantics = %q, want %q", result.Elements[2].Semantics, "dateRange.begin")
+	}
+}
+
+func TestParseCDSElementInfo_Empty(t *testing.T) {
+	xmlResponse := `<?xml version="1.0" encoding="UTF-8"?>
+<ddl:ddlSource xmlns:ddl="http://www.sap.com/adt/ddic/ddlsources"
+  ddl:name="ZEMPTY_VIEW"/>` // No content element
+
+	result, err := parseCDSElementInfo([]byte(xmlResponse), "ZEMPTY_VIEW")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(result.Elements) != 0 {
+		t.Errorf("Expected 0 elements, got %d", len(result.Elements))
+	}
+}
+
+func TestParseCDSElementInfo_InvalidXML(t *testing.T) {
+	result, err := parseCDSElementInfo([]byte("not xml at all"), "ZVIEW")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if result.ViewName != "ZVIEW" {
+		t.Errorf("ViewName = %q, want %q", result.ViewName, "ZVIEW")
+	}
+	if len(result.Elements) != 0 {
+		t.Errorf("Expected 0 elements for invalid XML, got %d", len(result.Elements))
+	}
+}
+
+func TestClient_GetCDSElementInfo(t *testing.T) {
+	elementXML := `<?xml version="1.0" encoding="UTF-8"?>
+<ddl:ddlSource xmlns:ddl="http://www.sap.com/adt/ddic/ddlsources"
+  ddl:name="ZTRAVEL">
+  <ddl:content>
+    <ddl:element ddl:name="TravelId" ddl:type="NUMC(8)"/>
+  </ddl:content>
+</ddl:ddlSource>`
+
+	mock := &mockTransportClient{
+		responses: map[string]*http.Response{
+			"/sap/bc/adt/ddic/ddl/sources/ZTRAVEL": newTestResponse(elementXML),
+		},
+	}
+
+	cfg := NewConfig("https://sap.example.com:44300", "user", "pass")
+	transport := NewTransportWithClient(cfg, mock)
+	client := NewClientWithTransport(cfg, transport)
+
+	result, err := client.GetCDSElementInfo(context.Background(), "ZTRAVEL")
+	if err != nil {
+		t.Fatalf("GetCDSElementInfo failed: %v", err)
+	}
+
+	if len(result.Elements) != 1 {
+		t.Fatalf("Expected 1 element, got %d", len(result.Elements))
+	}
+	if result.Elements[0].Name != "TravelId" {
+		t.Errorf("Element.Name = %q, want %q", result.Elements[0].Name, "TravelId")
+	}
+}
+
+func TestClient_GetCDSElementInfo_ReadOnly(t *testing.T) {
+	cfg := NewConfig("https://sap.example.com:44300", "user", "pass")
+	cfg.Safety.ReadOnly = true
+	transport := NewTransportWithClient(cfg, &mockTransportClient{responses: map[string]*http.Response{}})
+	client := NewClientWithTransport(cfg, transport)
+
+	_, err := client.GetCDSElementInfo(context.Background(), "ZVIEW")
+	if err == nil {
+		t.Error("Expected error for read-only mode")
+	}
+}


### PR DESCRIPTION
## Summary

Add CDS view analysis tools via SAP ADT API — 2 new tools with 10 unit tests:

- **GetCDSImpactAnalysis** — reverse where-used for CDS views (all downstream consumers)
- **GetCDSElementInfo** — field metadata: names, types, descriptions, annotations, semantics

Complements the existing `GetCDSDependencies` (forward deps) with reverse lookup and element-level detail.

## Files

| File | Lines | Description |
|------|-------|-------------|
| `pkg/adt/cds_tools.go` | 178 | Client methods for CDS analysis |
| `pkg/adt/cds_tools_test.go` | 210 | 10 unit tests |
| `internal/mcp/handlers_cds.go` | 72 | MCP tool handlers |
| `internal/mcp/tools_register.go` | +26 | Tool registration |
| `internal/mcp/tools_focused.go` | +4 | Focused mode whitelist |

## ADT API endpoints

- `GET /sap/bc/adt/ddic/ddl/sources/{name}/impactanalysis` — CDS where-used
- `GET /sap/bc/adt/ddic/ddl/sources/{name}/elementinfo` — CDS element metadata

## Test plan

- [x] `go build ./cmd/vsp` compiles clean
- [x] `go test ./pkg/adt/` — 10 new tests pass, no regressions
- [ ] Integration test with SAP system