### PR TITLE
feat: add Intelligence Layer — 4 AI code analysis tools (46 tests)

### DIFF
--- a/internal/mcp/handlers_codeanalysis.go
+++ b/internal/mcp/handlers_codeanalysis.go
@@ -1,0 +1,56 @@
+// Package mcp provides the MCP server implementation for ABAP ADT tools.
+// handlers_codeanalysis.go contains handlers for code analysis tools
+// (AnalyzeABAPCode, CheckRegression).
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/mark3labs/mcp-go/mcp"
+)
+
+// --- AnalyzeABAPCode Handler ---
+
+func (s *Server) handleAnalyzeABAPCode(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	objectURI, _ := request.Params.Arguments["object_uri"].(string)
+	source, _ := request.Params.Arguments["source"].(string)
+
+	if objectURI == "" && source == "" {
+		return newToolResultError("either object_uri or source is required"), nil
+	}
+
+	result, err := s.adtClient.AnalyzeABAPCode(ctx, objectURI, source)
+	if err != nil {
+		return newToolResultError(fmt.Sprintf("AnalyzeABAPCode failed: %v", err)), nil
+	}
+
+	output, err2 := json.MarshalIndent(result, "", "  ")
+	if err2 != nil {
+		return newToolResultError(fmt.Sprintf("failed to serialize result: %v", err2)), nil
+	}
+	return mcp.NewToolResultText(string(output)), nil
+}
+
+// --- CheckRegression Handler ---
+
+func (s *Server) handleCheckRegression(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	objectURI, ok := request.Params.Arguments["object_uri"].(string)
+	if !ok || objectURI == "" {
+		return newToolResultError("object_uri is required"), nil
+	}
+
+	baseVersion, _ := request.Params.Arguments["base_version"].(string)
+
+	result, err := s.adtClient.CheckRegression(ctx, objectURI, baseVersion)
+	if err != nil {
+		return newToolResultError(fmt.Sprintf("CheckRegression failed: %v", err)), nil
+	}
+
+	output, err2 := json.MarshalIndent(result, "", "  ")
+	if err2 != nil {
+		return newToolResultError(fmt.Sprintf("failed to serialize result: %v", err2)), nil
+	}
+	return mcp.NewToolResultText(string(output)), nil
+}

--- a/internal/mcp/handlers_intelligence.go
+++ b/internal/mcp/handlers_intelligence.go
@@ -1,0 +1,85 @@
+// Package mcp provides the MCP server implementation for ABAP ADT tools.
+// handlers_intelligence.go contains handlers for Intelligence Layer tools
+// (AnalyzeSQLPerformance, GetImpactAnalysis).
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/oisee/vibing-steampunk/pkg/adt"
+)
+
+// --- AnalyzeSQLPerformance Handler ---
+
+func (s *Server) handleAnalyzeSQLPerformance(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	sqlQuery, ok := request.Params.Arguments["sql_query"].(string)
+	if !ok || sqlQuery == "" {
+		return newToolResultError("sql_query is required"), nil
+	}
+
+	// Bridge Server-level feature detection to Client method parameter
+	hanaAvailable := s.featureProber.IsAvailable(ctx, adt.FeatureHANA)
+
+	result, err := s.adtClient.AnalyzeSQLPerformance(ctx, sqlQuery, hanaAvailable)
+	if err != nil {
+		return newToolResultError(fmt.Sprintf("AnalyzeSQLPerformance failed: %v", err)), nil
+	}
+
+	output, err2 := json.MarshalIndent(result, "", "  ")
+	if err2 != nil {
+		return newToolResultError(fmt.Sprintf("failed to serialize result: %v", err2)), nil
+	}
+	return mcp.NewToolResultText(string(output)), nil
+}
+
+// --- GetImpactAnalysis Handler ---
+
+func (s *Server) handleGetImpactAnalysis(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	objectURI, ok := request.Params.Arguments["object_uri"].(string)
+	if !ok || objectURI == "" {
+		return newToolResultError("object_uri is required"), nil
+	}
+
+	objectName, _ := request.Params.Arguments["object_name"].(string)
+
+	opts := adt.ImpactAnalysisOptions{
+		StaticRefs: true, // always on by default
+	}
+
+	if v, ok := request.Params.Arguments["transitive"].(bool); ok {
+		opts.Transitive = v
+	}
+	if v, ok := request.Params.Arguments["max_depth"].(float64); ok {
+		opts.MaxDepth = int(v)
+	}
+	if v, ok := request.Params.Arguments["dynamic_patterns"].(bool); ok {
+		opts.DynamicPatterns = v
+	}
+	if v, ok := request.Params.Arguments["extension_points"].(bool); ok {
+		opts.ExtensionPoints = v
+	}
+	if v, ok := request.Params.Arguments["max_results"].(float64); ok {
+		opts.MaxResults = int(v)
+	}
+	if v, ok := request.Params.Arguments["scope_packages"].([]interface{}); ok {
+		for _, pkg := range v {
+			if s, ok := pkg.(string); ok {
+				opts.ScopePackages = append(opts.ScopePackages, s)
+			}
+		}
+	}
+
+	result, err := s.adtClient.GetImpactAnalysis(ctx, objectURI, objectName, opts)
+	if err != nil {
+		return newToolResultError(fmt.Sprintf("GetImpactAnalysis failed: %v", err)), nil
+	}
+
+	output, err2 := json.MarshalIndent(result, "", "  ")
+	if err2 != nil {
+		return newToolResultError(fmt.Sprintf("failed to serialize result: %v", err2)), nil
+	}
+	return mcp.NewToolResultText(string(output)), nil
+}

--- a/internal/mcp/tools_focused.go
+++ b/internal/mcp/tools_focused.go
@@ -108,6 +108,12 @@ func focusedToolSet() map[string]bool {
 		"AMDPSetBreakpoint":  true,
 		"AMDPGetBreakpoints": true,
 
+		// Intelligence Layer (4)
+		"AnalyzeSQLPerformance": true, // SQL performance analysis (text + HANA plan)
+		"GetImpactAnalysis":     true, // Multi-layer blast radius analysis
+		"AnalyzeABAPCode":       true, // 21-rule ABAP source analysis
+		"CheckRegression":       true, // Diff-based breaking change detection
+
 		// CTS/Transport Management (2 read-only in focused mode)
 		"ListTransports": true, // List transport requests
 		"GetTransport":   true, // Get transport details with objects

--- a/internal/mcp/tools_register.go
+++ b/internal/mcp/tools_register.go
@@ -87,6 +87,7 @@ func (s *Server) registerTools(mode string, disabledGroups string, toolsConfig m
 	s.registerGitTools(shouldRegister)
 	s.registerReportTools(shouldRegister)
 	s.registerInstallTools(shouldRegister)
+	s.registerIntelligenceTools(shouldRegister)
 
 	// Register tool aliases for common operations
 	s.registerToolAliases(shouldRegister)
@@ -1946,5 +1947,75 @@ func (s *Server) registerInstallTools(shouldRegister func(string) bool) {
 				mcp.Description("Deploy only objects matching this name pattern (e.g., 'ZCL_ABAPGIT_*')"),
 			),
 		), s.handleDeployZip)
+	}
+}
+
+// registerIntelligenceTools registers AI code analysis and intelligence tools.
+func (s *Server) registerIntelligenceTools(shouldRegister func(string) bool) {
+	if shouldRegister("AnalyzeSQLPerformance") {
+		s.mcpServer.AddTool(mcp.NewTool("AnalyzeSQLPerformance",
+			mcp.WithDescription("Analyze SQL query performance. Runs text-based analysis (detects SELECT *, missing WHERE, CLIENT SPECIFIED, etc.) on both ABAP SQL and native SQL. On HANA systems, also runs execution plan analysis (full table scans, missing indexes, nested loops). Returns findings with severity and fix suggestions."),
+			mcp.WithString("sql_query",
+				mcp.Required(),
+				mcp.Description("SQL query to analyze (ABAP SQL or native SQL)"),
+			),
+		), s.handleAnalyzeSQLPerformance)
+	}
+
+	if shouldRegister("GetImpactAnalysis") {
+		s.mcpServer.AddTool(mcp.NewTool("GetImpactAnalysis",
+			mcp.WithDescription("Analyze blast radius of changing an ABAP object. Layer 1 (always): static cross-references via FindReferences. Layer 2 (opt-in): transitive callers via call graph. Layer 3 (opt-in): dynamic call risk — searches for object name as string literal in scope packages. Layer 4 (opt-in): config-driven calls — detects BAdI, enhancement points, user exits in source + queries customizing tables. Returns affected objects, risk level, and warnings."),
+			mcp.WithString("object_uri",
+				mcp.Required(),
+				mcp.Description("ADT URI of the object (e.g., /sap/bc/adt/oo/classes/zcl_test)"),
+			),
+			mcp.WithString("object_name",
+				mcp.Description("Object name (e.g., ZCL_TEST) — needed for Layer 3-4 pattern searches"),
+			),
+			mcp.WithBoolean("transitive",
+				mcp.Description("Enable Layer 2: transitive callers via call graph (default: false)"),
+			),
+			mcp.WithNumber("max_depth",
+				mcp.Description("Max depth for transitive callers (default: 3)"),
+			),
+			mcp.WithBoolean("dynamic_patterns",
+				mcp.Description("Enable Layer 3: search for dynamic call patterns in scope packages (default: false)"),
+			),
+			mcp.WithBoolean("extension_points",
+				mcp.Description("Enable Layer 4: detect BAdI, enhancement points, user exits (default: false)"),
+			),
+			mcp.WithNumber("max_results",
+				mcp.Description("Max consumers to return (default: 200)"),
+			),
+			mcp.WithArray("scope_packages",
+				mcp.Description("Package scope for Layer 3-4 searches (e.g., [\"ZFI\", \"$TMP\"])"),
+				mcp.Items(map[string]interface{}{"type": "string"}),
+			),
+		), s.handleGetImpactAnalysis)
+	}
+
+	if shouldRegister("AnalyzeABAPCode") {
+		s.mcpServer.AddTool(mcp.NewTool("AnalyzeABAPCode",
+			mcp.WithDescription("Analyze ABAP source code for anti-patterns, performance issues, and security risks. 21 rules across 4 categories (performance, security, robustness, quality). Uses two-pass statement assembler (handles multi-line statements). Provide either object_uri (fetches source) or source text directly."),
+			mcp.WithString("object_uri",
+				mcp.Description("ADT URI of the object — source will be fetched automatically"),
+			),
+			mcp.WithString("source",
+				mcp.Description("ABAP source text to analyze (alternative to object_uri)"),
+			),
+		), s.handleAnalyzeABAPCode)
+	}
+
+	if shouldRegister("CheckRegression") {
+		s.mcpServer.AddTool(mcp.NewTool("CheckRegression",
+			mcp.WithDescription("Detect breaking changes by comparing current source against a previous version. Finds: changed method signatures, removed public methods, interface changes, RAISING clause changes. Auto-detects base version from revision history if not specified."),
+			mcp.WithString("object_uri",
+				mcp.Required(),
+				mcp.Description("ADT URI of the object to check (e.g., /sap/bc/adt/oo/classes/zcl_test)"),
+			),
+			mcp.WithString("base_version",
+				mcp.Description("Revision URI to compare against (from GetRevisions); default = auto-detect previous version"),
+			),
+		), s.handleCheckRegression)
 	}
 }

--- a/pkg/adt/codeanalysis.go
+++ b/pkg/adt/codeanalysis.go
@@ -1,0 +1,835 @@
+package adt
+
+import (
+	"context"
+	"fmt"
+	"regexp"
+	"strings"
+	"time"
+)
+
+// Pre-compiled regex patterns for ABAP code analysis (compiled once at package init).
+var (
+	reSelectStarABAP    = regexp.MustCompile(`(?i)^SELECT\s+(SINGLE\s+)?\*\s+FROM\b`)
+	reModifyDbtabAll    = regexp.MustCompile(`(?i)^(MODIFY|UPDATE)\s+\w+\s+FROM\b`)
+	reHardcodedCreds    = regexp.MustCompile("(?i)(password|passwd|secret|api_key|apikey|token)\\s*=\\s*(?:'[^']{3,}'|`[^`]{3,}`|\\|[^|]{3,}\\|)")
+	reClientSpecABAP    = regexp.MustCompile(`(?i)\bCLIENT\s+SPECIFIED\b`)
+	reCatchCxRoot       = regexp.MustCompile(`(?i)\bCATCH\s+CX_ROOT\b`)
+	reCallMethodDyn     = regexp.MustCompile(`(?i)CALL\s+METHOD\s+\(`)
+	reCallFuncDyn       = regexp.MustCompile(`(?i)CALL\s+FUNCTION\s+[^'"]`)
+	reObsoleteMove      = regexp.MustCompile(`(?i)^MOVE\s+\S+\s+TO\s+`)
+	reObsoleteAdd       = regexp.MustCompile(`(?i)^ADD\s+\S+\s+TO\s+`)
+	reObsoleteSubtract  = regexp.MustCompile(`(?i)^SUBTRACT\s+\S+\s+FROM\s+`)
+	reObsoleteMultiply  = regexp.MustCompile(`(?i)^MULTIPLY\s+\S+\s+BY\s+`)
+	reObsoleteDivide    = regexp.MustCompile(`(?i)^DIVIDE\s+\S+\s+BY\s+`)
+	reObsoleteCompute   = regexp.MustCompile(`(?i)^COMPUTE\s+`)
+)
+
+const maxSourceBytes = 500 * 1024 // 500KB input size limit
+
+// CodeAnalysisResult is the result of ABAP source code analysis.
+type CodeAnalysisResult struct {
+	ObjectURI    string              `json:"objectUri,omitempty"`
+	ObjectName   string              `json:"objectName,omitempty"`
+	Findings     []CodeFinding       `json:"findings"`
+	Summary      CodeAnalysisSummary `json:"summary"`
+	RulesApplied int                 `json:"rulesApplied"`
+}
+
+// CodeFinding represents a single code quality finding.
+type CodeFinding struct {
+	Rule        string `json:"rule"`
+	Category    string `json:"category"`    // "performance", "security", "quality", "robustness"
+	Severity    string `json:"severity"`    // "critical", "high", "medium", "low", "info"
+	Line        int    `json:"line"`        // start line
+	EndLine     int    `json:"endLine"`     // end line
+	Match       string `json:"match"`       // offending statement (trimmed, max 200 chars)
+	Description string `json:"description"`
+	Suggestion  string `json:"suggestion"`
+}
+
+// CodeAnalysisSummary contains aggregate analysis metrics.
+type CodeAnalysisSummary struct {
+	TotalFindings int            `json:"totalFindings"`
+	BySeverity    map[string]int `json:"bySeverity"`
+	ByCategory    map[string]int `json:"byCategory"`
+	Score         string         `json:"score"` // "good", "warning", "critical"
+}
+
+// abapStatement is a complete ABAP statement (may span multiple source lines).
+type abapStatement struct {
+	Text      string
+	StartLine int
+	EndLine   int
+	IsComment bool
+}
+
+// scanContext tracks state during the rule engine pass.
+type scanContext struct {
+	InLoop    bool
+	LoopDepth int
+	TryDepth  int
+	PrevStmt  *abapStatement
+}
+
+// AssembleStatements splits ABAP source into complete statements (period-terminated).
+// Pass 1 of the two-pass architecture. Exported for testing.
+func AssembleStatements(source string) []abapStatement {
+	lines := strings.Split(source, "\n")
+	var stmts []abapStatement
+	var buf strings.Builder
+	startLine := 1
+	strState := ssNone
+
+	for i, rawLine := range lines {
+		lineNum := i + 1
+		line := strings.TrimRight(rawLine, "\r")
+
+		// Full-line comment (* in column 1)
+		trimmed := strings.TrimLeft(line, " \t")
+		if strings.HasPrefix(trimmed, "*") {
+			stmts = append(stmts, abapStatement{
+				Text:      trimmed,
+				StartLine: lineNum,
+				EndLine:   lineNum,
+				IsComment: true,
+			})
+			continue
+		}
+
+		// Strip inline comment (after unquoted ")
+		cleaned := stripInlineComment(line, &strState)
+		cleaned = strings.TrimSpace(cleaned)
+		if cleaned == "" {
+			continue
+		}
+
+		if buf.Len() == 0 {
+			startLine = lineNum
+		}
+		if buf.Len() > 0 {
+			buf.WriteByte(' ')
+		}
+		buf.WriteString(cleaned)
+
+		// Check if statement ends with period (outside string literal)
+		if strState == ssNone && strings.HasSuffix(cleaned, ".") {
+			stmts = append(stmts, abapStatement{
+				Text:      strings.TrimSpace(buf.String()),
+				StartLine: startLine,
+				EndLine:   lineNum,
+			})
+			buf.Reset()
+		}
+	}
+
+	// Remaining buffer (unterminated statement)
+	if buf.Len() > 0 {
+		stmts = append(stmts, abapStatement{
+			Text:      strings.TrimSpace(buf.String()),
+			StartLine: startLine,
+			EndLine:   startLine,
+		})
+	}
+
+	return stmts
+}
+
+// stringState tracks what kind of string literal we are currently inside.
+type stringState int
+
+const (
+	ssNone     stringState = iota
+	ssSingle               // inside '...'
+	ssBacktick             // inside `...`
+	ssTemplate             // inside |...|
+)
+
+// stripInlineComment removes inline comments (text after unquoted ") from a line.
+// Tracks string literal state across calls via the state pointer.
+// Handles single-quote '...', backtick `...`, and string template |...| literals.
+func stripInlineComment(line string, state *stringState) string {
+	var result strings.Builder
+	for i := 0; i < len(line); i++ {
+		ch := line[i]
+		switch *state {
+		case ssSingle:
+			result.WriteByte(ch)
+			if ch == '\'' {
+				if i+1 < len(line) && line[i+1] == '\'' {
+					result.WriteByte(line[i+1])
+					i++ // skip escaped quote ''
+				} else {
+					*state = ssNone
+				}
+			}
+		case ssBacktick:
+			result.WriteByte(ch)
+			if ch == '`' {
+				if i+1 < len(line) && line[i+1] == '`' {
+					result.WriteByte(line[i+1])
+					i++ // skip escaped backtick ``
+				} else {
+					*state = ssNone
+				}
+			}
+		case ssTemplate:
+			result.WriteByte(ch)
+			if ch == '\\' && i+1 < len(line) && line[i+1] == '|' {
+				result.WriteByte(line[i+1])
+				i++ // skip escaped pipe \|
+			} else if ch == '|' {
+				*state = ssNone
+			}
+		default: // ssNone
+			switch ch {
+			case '\'':
+				*state = ssSingle
+				result.WriteByte(ch)
+			case '`':
+				*state = ssBacktick
+				result.WriteByte(ch)
+			case '|':
+				*state = ssTemplate
+				result.WriteByte(ch)
+			case '"':
+				// Inline comment starts here — rest of line is comment
+				return result.String()
+			default:
+				result.WriteByte(ch)
+			}
+		}
+	}
+	return result.String()
+}
+
+// AnalyzeABAPSource runs the full rule engine on ABAP source text.
+// Two-pass: assembleStatements → context-tracking rule engine.
+// Pure Go, no network calls. Exported for testing.
+func AnalyzeABAPSource(source string) *CodeAnalysisResult {
+	stmts := AssembleStatements(source)
+	var findings []CodeFinding
+
+	ctx := &scanContext{}
+	totalRules := 21 // includes missing_authority_check (placeholder — always returns nil)
+
+	for i, stmt := range stmts {
+		if stmt.IsComment {
+			findings = append(findings, checkTodoFixme(stmt)...)
+			continue
+		}
+
+		upper := strings.ToUpper(stmt.Text)
+
+		// Reset context on method/form boundaries to prevent stale loop/TRY state
+		if strings.HasPrefix(upper, "METHOD ") || strings.HasPrefix(upper, "FORM ") ||
+			strings.HasPrefix(upper, "ENDMETHOD.") || strings.HasPrefix(upper, "ENDFORM.") {
+			ctx.InLoop = false
+			ctx.LoopDepth = 0
+			ctx.TryDepth = 0
+		}
+
+		// Track loop context
+		if isLoopStart(upper) {
+			ctx.InLoop = true
+			ctx.LoopDepth++
+		}
+		if isLoopEnd(upper) {
+			ctx.LoopDepth--
+			if ctx.LoopDepth <= 0 {
+				ctx.InLoop = false
+				ctx.LoopDepth = 0
+			}
+		}
+
+		// Track TRY/ENDTRY context
+		if strings.HasPrefix(upper, "TRY.") || upper == "TRY" {
+			ctx.TryDepth++
+		}
+		if strings.HasPrefix(upper, "ENDTRY.") || upper == "ENDTRY" {
+			ctx.TryDepth--
+			if ctx.TryDepth < 0 {
+				ctx.TryDepth = 0
+			}
+		}
+
+		// Apply rules
+		findings = append(findings, checkSelectInLoop(stmt, upper, ctx)...)
+		findings = append(findings, checkSelectStar(stmt, upper)...)
+		findings = append(findings, checkFAENoEmptyCheck(stmt, upper, ctx)...)
+		findings = append(findings, checkNestedLoop(stmt, upper, ctx)...)
+		findings = append(findings, checkSelectEndselect(stmt, upper)...)
+		findings = append(findings, checkModifyDbtabAll(stmt, upper)...)
+		findings = append(findings, checkCommitInLoop(stmt, upper, ctx)...)
+		findings = append(findings, checkReadTableNoBinary(stmt, upper)...)
+		findings = append(findings, checkMissingAuthorityCheck(stmt, upper)...)
+		findings = append(findings, checkHardcodedCredentials(stmt, upper)...)
+		findings = append(findings, checkDynamicSQLUnvalidated(stmt, upper)...)
+		findings = append(findings, checkClientSpecified(stmt, upper)...)
+		findings = append(findings, checkMissingSysubrcRead(stmt, upper, stmts, i)...)
+		findings = append(findings, checkMissingSysubrcCall(stmt, upper, stmts, i)...)
+		findings = append(findings, checkEmptyCatch(stmt, upper, stmts, i)...)
+		findings = append(findings, checkCatchCxRoot(stmt, upper)...)
+		findings = append(findings, checkObsoleteStatement(stmt, upper)...)
+		findings = append(findings, checkDynamicCallNoTry(stmt, upper, ctx)...)
+		findings = append(findings, checkPerformUsage(stmt, upper)...)
+		findings = append(findings, checkCommitWorkAndWait(stmt, upper)...)
+
+		ctx.PrevStmt = &stmts[i]
+	}
+
+	// Build summary
+	bySeverity := map[string]int{}
+	byCategory := map[string]int{}
+	for _, f := range findings {
+		bySeverity[f.Severity]++
+		byCategory[f.Category]++
+	}
+
+	return &CodeAnalysisResult{
+		Findings:     findings,
+		RulesApplied: totalRules,
+		Summary: CodeAnalysisSummary{
+			TotalFindings: len(findings),
+			BySeverity:    bySeverity,
+			ByCategory:    byCategory,
+			Score:         calculateCodeScore(findings),
+		},
+	}
+}
+
+func calculateCodeScore(findings []CodeFinding) string {
+	for _, f := range findings {
+		if f.Severity == "critical" {
+			return "critical"
+		}
+	}
+	for _, f := range findings {
+		if f.Severity == "high" {
+			return "warning"
+		}
+	}
+	return "good"
+}
+
+// AnalyzeABAPCode is the Client method that optionally fetches source before analysis.
+func (c *Client) AnalyzeABAPCode(ctx context.Context, objectURI, source string) (*CodeAnalysisResult, error) {
+	if err := c.checkSafety(OpRead, "AnalyzeABAPCode"); err != nil {
+		return nil, err
+	}
+
+	if source == "" && objectURI == "" {
+		return nil, fmt.Errorf("either object_uri or source is required")
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+
+	if source == "" {
+		fetched, err := c.getSourceForAnalysis(ctx, objectURI)
+		if err != nil {
+			return nil, fmt.Errorf("fetching source: %w", err)
+		}
+		source = fetched
+	}
+
+	if len(source) > maxSourceBytes {
+		return nil, fmt.Errorf("source too large: %d bytes (max %d)", len(source), maxSourceBytes)
+	}
+
+	result := AnalyzeABAPSource(source)
+	result.ObjectURI = objectURI
+	if objectURI != "" {
+		if _, name := parseObjectURIComponents(objectURI); name != "" {
+			result.ObjectName = name
+		}
+	}
+	return result, nil
+}
+
+// --- Loop tracking helpers ---
+
+func isLoopStart(upper string) bool {
+	return strings.HasPrefix(upper, "LOOP AT ") ||
+		strings.HasPrefix(upper, "DO.") || strings.HasPrefix(upper, "DO ") ||
+		strings.HasPrefix(upper, "WHILE ") ||
+		(strings.HasPrefix(upper, "SELECT ") && !strings.Contains(upper, " INTO TABLE ") &&
+			!strings.Contains(upper, " INTO CORRESPONDING ") &&
+			!strings.Contains(upper, " APPENDING ") &&
+			!strings.Contains(upper, " SINGLE ") &&
+			!strings.Contains(upper, " INTO @") &&
+			!strings.Contains(upper, " INTO (") &&
+			!strings.Contains(upper, "COUNT(") && !strings.Contains(upper, "SUM(") &&
+			!strings.Contains(upper, "MIN(") && !strings.Contains(upper, "MAX(") &&
+			!strings.Contains(upper, "AVG("))
+}
+
+func isLoopEnd(upper string) bool {
+	return strings.HasPrefix(upper, "ENDLOOP.") ||
+		strings.HasPrefix(upper, "ENDDO.") ||
+		strings.HasPrefix(upper, "ENDWHILE.") ||
+		strings.HasPrefix(upper, "ENDSELECT.")
+}
+
+func truncStmt(s string, max int) string {
+	if len(s) <= max {
+		return s
+	}
+	return s[:max] + "..."
+}
+
+// --- Rule implementations ---
+
+// Rule 1: select_in_loop (critical/performance)
+func checkSelectInLoop(stmt abapStatement, upper string, ctx *scanContext) []CodeFinding {
+	if !ctx.InLoop {
+		return nil
+	}
+	if !strings.HasPrefix(upper, "SELECT ") {
+		return nil
+	}
+	return []CodeFinding{{
+		Rule:        "select_in_loop",
+		Category:    "performance",
+		Severity:    "critical",
+		Line:        stmt.StartLine,
+		EndLine:     stmt.EndLine,
+		Match:       truncStmt(stmt.Text, 200),
+		Description: "SELECT inside loop — causes N+1 database roundtrips",
+		Suggestion:  "Move SELECT before the loop using FOR ALL ENTRIES or JOIN",
+	}}
+}
+
+// Rule 2: select_star (info/performance)
+func checkSelectStar(stmt abapStatement, upper string) []CodeFinding {
+	if !reSelectStarABAP.MatchString(upper) {
+		return nil
+	}
+	return []CodeFinding{{
+		Rule:        "select_star",
+		Category:    "performance",
+		Severity:    "info",
+		Line:        stmt.StartLine,
+		EndLine:     stmt.EndLine,
+		Match:       truncStmt(stmt.Text, 200),
+		Description: "SELECT * fetches all columns — prefer explicit field list",
+		Suggestion:  "List only the fields you need to reduce data transfer",
+	}}
+}
+
+// Rule 3: fae_no_empty_check (critical/performance)
+func checkFAENoEmptyCheck(stmt abapStatement, upper string, ctx *scanContext) []CodeFinding {
+	if !strings.Contains(upper, "FOR ALL ENTRIES IN") {
+		return nil
+	}
+	// Check if previous statement contains an emptiness check
+	if ctx.PrevStmt != nil {
+		prevUpper := strings.ToUpper(ctx.PrevStmt.Text)
+		if strings.Contains(prevUpper, "IS NOT INITIAL") ||
+			strings.Contains(prevUpper, "LINES(") ||
+			strings.Contains(prevUpper, "LINE_EXISTS(") ||
+			strings.Contains(prevUpper, "IS INITIAL") {
+			return nil
+		}
+	}
+	return []CodeFinding{{
+		Rule:        "fae_no_empty_check",
+		Category:    "performance",
+		Severity:    "critical",
+		Line:        stmt.StartLine,
+		EndLine:     stmt.EndLine,
+		Match:       truncStmt(stmt.Text, 200),
+		Description: "FOR ALL ENTRIES without preceding empty check — returns ALL rows if table is empty",
+		Suggestion:  "Add IF itab IS NOT INITIAL check before the SELECT with FOR ALL ENTRIES",
+	}}
+}
+
+// Rule 4: nested_loop (high/performance)
+func checkNestedLoop(stmt abapStatement, upper string, ctx *scanContext) []CodeFinding {
+	if !ctx.InLoop || !strings.HasPrefix(upper, "LOOP AT ") {
+		return nil
+	}
+	// We're inside a loop and starting another LOOP AT
+	if ctx.LoopDepth < 2 {
+		return nil // the outer LOOP context should set depth >= 1, inner LOOP starts at 2
+	}
+	return []CodeFinding{{
+		Rule:        "nested_loop",
+		Category:    "performance",
+		Severity:    "high",
+		Line:        stmt.StartLine,
+		EndLine:     stmt.EndLine,
+		Match:       truncStmt(stmt.Text, 200),
+		Description: "Nested LOOP AT — O(n*m) complexity",
+		Suggestion:  "Use SORTED/HASHED table or READ TABLE with BINARY SEARCH instead",
+	}}
+}
+
+// Rule 5: select_endselect (medium/performance)
+func checkSelectEndselect(stmt abapStatement, upper string) []CodeFinding {
+	// Detect SELECT...ENDSELECT by checking for SELECT without INTO TABLE
+	if !strings.HasPrefix(upper, "SELECT ") {
+		return nil
+	}
+	if strings.Contains(upper, " INTO TABLE ") ||
+		strings.Contains(upper, " INTO CORRESPONDING ") ||
+		strings.Contains(upper, " APPENDING ") ||
+		strings.Contains(upper, " SINGLE ") {
+		return nil
+	}
+	// SELECT INTO @var or INTO (a,b,c) is single-row fetch, not a cursor select
+	if strings.Contains(upper, " INTO @") || strings.Contains(upper, " INTO (") {
+		return nil
+	}
+	return []CodeFinding{{
+		Rule:        "select_endselect",
+		Category:    "performance",
+		Severity:    "medium",
+		Line:        stmt.StartLine,
+		EndLine:     stmt.EndLine,
+		Match:       truncStmt(stmt.Text, 200),
+		Description: "SELECT...ENDSELECT processes rows one by one — prefer INTO TABLE",
+		Suggestion:  "Use SELECT ... INTO TABLE itab for bulk fetch",
+	}}
+}
+
+// Rule 6: modify_dbtab_all (high/performance)
+func checkModifyDbtabAll(stmt abapStatement, upper string) []CodeFinding {
+	if !reModifyDbtabAll.MatchString(upper) {
+		return nil
+	}
+	if strings.Contains(upper, " WHERE ") {
+		return nil
+	}
+	return []CodeFinding{{
+		Rule:        "modify_dbtab_all",
+		Category:    "performance",
+		Severity:    "high",
+		Line:        stmt.StartLine,
+		EndLine:     stmt.EndLine,
+		Match:       truncStmt(stmt.Text, 200),
+		Description: "MODIFY/UPDATE without WHERE — may affect all rows in the table",
+		Suggestion:  "Add WHERE clause or use internal table with specific records",
+	}}
+}
+
+// Rule 7: commit_in_loop (critical/performance)
+func checkCommitInLoop(stmt abapStatement, upper string, ctx *scanContext) []CodeFinding {
+	if !ctx.InLoop {
+		return nil
+	}
+	if !strings.HasPrefix(upper, "COMMIT WORK") {
+		return nil
+	}
+	return []CodeFinding{{
+		Rule:        "commit_in_loop",
+		Category:    "performance",
+		Severity:    "critical",
+		Line:        stmt.StartLine,
+		EndLine:     stmt.EndLine,
+		Match:       truncStmt(stmt.Text, 200),
+		Description: "COMMIT WORK inside loop — destroys transactional integrity, causes performance issues",
+		Suggestion:  "Move COMMIT WORK outside the loop, process all records in one LUW",
+	}}
+}
+
+// Rule 8: read_table_no_binary (medium/performance)
+func checkReadTableNoBinary(stmt abapStatement, upper string) []CodeFinding {
+	if !strings.HasPrefix(upper, "READ TABLE ") {
+		return nil
+	}
+	if !strings.Contains(upper, " WITH KEY ") {
+		return nil
+	}
+	if strings.Contains(upper, " BINARY SEARCH") ||
+		strings.Contains(upper, " WITH TABLE KEY") {
+		return nil
+	}
+	return []CodeFinding{{
+		Rule:        "read_table_no_binary",
+		Category:    "performance",
+		Severity:    "medium",
+		Line:        stmt.StartLine,
+		EndLine:     stmt.EndLine,
+		Match:       truncStmt(stmt.Text, 200),
+		Description: "READ TABLE WITH KEY without BINARY SEARCH on standard table — linear scan",
+		Suggestion:  "Sort the table and add BINARY SEARCH, or use SORTED/HASHED table type",
+	}}
+}
+
+// Rule 9: missing_authority_check (info/security)
+func checkMissingAuthorityCheck(_ abapStatement, _ string) []CodeFinding {
+	// Deliberately returns nil — too many false positives.
+	// Would need full method scope tracking to be useful.
+	return nil
+}
+
+// Rule 10: hardcoded_credentials (critical/security)
+func checkHardcodedCredentials(stmt abapStatement, _ string) []CodeFinding {
+	// Only match in assignment context: lv_password = 'literal'
+	if !reHardcodedCreds.MatchString(stmt.Text) {
+		return nil
+	}
+	return []CodeFinding{{
+		Rule:        "hardcoded_credentials",
+		Category:    "security",
+		Severity:    "critical",
+		Line:        stmt.StartLine,
+		EndLine:     stmt.EndLine,
+		Match:       truncStmt(stmt.Text, 200),
+		Description: "Hardcoded credential detected in assignment",
+		Suggestion:  "Use secure storage (SSF, ICM, Destination service) instead of hardcoded credentials",
+	}}
+}
+
+// Rule 11: dynamic_sql_unvalidated (high/security)
+func checkDynamicSQLUnvalidated(stmt abapStatement, upper string) []CodeFinding {
+	// Dynamic WHERE with concatenated variable, no CL_ABAP_DYN_PRG
+	if !strings.Contains(upper, "WHERE (") && !strings.Contains(upper, "WHERE(") {
+		return nil
+	}
+	return []CodeFinding{{
+		Rule:        "dynamic_sql_unvalidated",
+		Category:    "security",
+		Severity:    "high",
+		Line:        stmt.StartLine,
+		EndLine:     stmt.EndLine,
+		Match:       truncStmt(stmt.Text, 200),
+		Description: "Dynamic WHERE clause — potential SQL injection if input is not validated",
+		Suggestion:  "Use CL_ABAP_DYN_PRG=>CHECK_COLUMN_NAME or parameterized queries",
+	}}
+}
+
+// Rule 12: client_specified (medium/security)
+func checkClientSpecified(stmt abapStatement, upper string) []CodeFinding {
+	if !reClientSpecABAP.MatchString(upper) {
+		return nil
+	}
+	return []CodeFinding{{
+		Rule:        "client_specified",
+		Category:    "security",
+		Severity:    "medium",
+		Line:        stmt.StartLine,
+		EndLine:     stmt.EndLine,
+		Match:       truncStmt(stmt.Text, 200),
+		Description: "CLIENT SPECIFIED bypasses automatic client handling — cross-client data access",
+		Suggestion:  "Use CLIENT SPECIFIED only when cross-client access is intentional",
+	}}
+}
+
+// Rule 13: missing_sysubrc_read (medium/robustness)
+func checkMissingSysubrcRead(stmt abapStatement, upper string, stmts []abapStatement, idx int) []CodeFinding {
+	if !strings.HasPrefix(upper, "READ TABLE ") {
+		return nil
+	}
+	// Check next non-comment statement for SY-SUBRC
+	for j := idx + 1; j < len(stmts) && j <= idx+2; j++ {
+		if stmts[j].IsComment {
+			continue
+		}
+		nextUpper := strings.ToUpper(stmts[j].Text)
+		if strings.Contains(nextUpper, "SY-SUBRC") || strings.Contains(nextUpper, "SYST-SUBRC") {
+			return nil
+		}
+		break // only check the very next non-comment statement
+	}
+	return []CodeFinding{{
+		Rule:        "missing_sysubrc_read",
+		Category:    "robustness",
+		Severity:    "medium",
+		Line:        stmt.StartLine,
+		EndLine:     stmt.EndLine,
+		Match:       truncStmt(stmt.Text, 200),
+		Description: "READ TABLE without SY-SUBRC check in next statement",
+		Suggestion:  "Check SY-SUBRC after READ TABLE to handle not-found case",
+	}}
+}
+
+// Rule 14: missing_sysubrc_call (medium/robustness)
+func checkMissingSysubrcCall(stmt abapStatement, upper string, stmts []abapStatement, idx int) []CodeFinding {
+	if !strings.HasPrefix(upper, "CALL FUNCTION ") {
+		return nil
+	}
+	// Skip if EXCEPTIONS clause is present (explicit handling)
+	if strings.Contains(upper, " EXCEPTIONS") {
+		return nil
+	}
+	// Check next non-comment statement for SY-SUBRC
+	for j := idx + 1; j < len(stmts) && j <= idx+2; j++ {
+		if stmts[j].IsComment {
+			continue
+		}
+		nextUpper := strings.ToUpper(stmts[j].Text)
+		if strings.Contains(nextUpper, "SY-SUBRC") || strings.Contains(nextUpper, "SYST-SUBRC") {
+			return nil
+		}
+		break
+	}
+	return []CodeFinding{{
+		Rule:        "missing_sysubrc_call",
+		Category:    "robustness",
+		Severity:    "medium",
+		Line:        stmt.StartLine,
+		EndLine:     stmt.EndLine,
+		Match:       truncStmt(stmt.Text, 200),
+		Description: "CALL FUNCTION without SY-SUBRC check or EXCEPTIONS clause",
+		Suggestion:  "Check SY-SUBRC after CALL FUNCTION or add EXCEPTIONS clause",
+	}}
+}
+
+// Rule 15: empty_catch (medium/robustness)
+func checkEmptyCatch(stmt abapStatement, upper string, stmts []abapStatement, idx int) []CodeFinding {
+	if !strings.HasPrefix(upper, "CATCH ") {
+		return nil
+	}
+	// Check if the next non-comment statement is ENDTRY or another CATCH (empty catch body)
+	for j := idx + 1; j < len(stmts); j++ {
+		if stmts[j].IsComment {
+			continue
+		}
+		nextUpper := strings.ToUpper(stmts[j].Text)
+		if strings.HasPrefix(nextUpper, "ENDTRY.") || strings.HasPrefix(nextUpper, "CATCH ") {
+			return []CodeFinding{{
+				Rule:        "empty_catch",
+				Category:    "robustness",
+				Severity:    "medium",
+				Line:        stmt.StartLine,
+				EndLine:     stmt.EndLine,
+				Match:       truncStmt(stmt.Text, 200),
+				Description: "Empty CATCH block — exceptions are silently swallowed",
+				Suggestion:  "Log the exception or re-raise it; do not silently ignore errors",
+			}}
+		}
+		break
+	}
+	return nil
+}
+
+// Rule 16: catch_cx_root (medium/robustness)
+func checkCatchCxRoot(stmt abapStatement, upper string) []CodeFinding {
+	if !reCatchCxRoot.MatchString(upper) {
+		return nil
+	}
+	return []CodeFinding{{
+		Rule:        "catch_cx_root",
+		Category:    "robustness",
+		Severity:    "medium",
+		Line:        stmt.StartLine,
+		EndLine:     stmt.EndLine,
+		Match:       truncStmt(stmt.Text, 200),
+		Description: "CATCH CX_ROOT catches all exceptions including system errors",
+		Suggestion:  "Catch specific exception classes instead of CX_ROOT",
+	}}
+}
+
+// Rule 17: obsolete_statement (info/quality)
+func checkObsoleteStatement(stmt abapStatement, upper string) []CodeFinding {
+	obsolete := []struct {
+		re   *regexp.Regexp
+		name string
+	}{
+		{reObsoleteMove, "MOVE x TO y"},
+		{reObsoleteAdd, "ADD x TO y"},
+		{reObsoleteSubtract, "SUBTRACT x FROM y"},
+		{reObsoleteMultiply, "MULTIPLY x BY y"},
+		{reObsoleteDivide, "DIVIDE x BY y"},
+		{reObsoleteCompute, "COMPUTE"},
+	}
+	for _, o := range obsolete {
+		if o.re.MatchString(upper) {
+			return []CodeFinding{{
+				Rule:        "obsolete_statement",
+				Category:    "quality",
+				Severity:    "info",
+				Line:        stmt.StartLine,
+				EndLine:     stmt.EndLine,
+				Match:       truncStmt(stmt.Text, 200),
+				Description: fmt.Sprintf("Obsolete statement: %s — use modern syntax", o.name),
+				Suggestion:  "Use inline expressions: x = y + z, instead of COMPUTE/ADD/MOVE",
+			}}
+		}
+	}
+	return nil
+}
+
+// Rule 18: dynamic_call_no_try (high/quality)
+func checkDynamicCallNoTry(stmt abapStatement, upper string, ctx *scanContext) []CodeFinding {
+	// Match: CALL METHOD (var)=>method or CALL FUNCTION (var) or CALL FUNCTION lv_name
+	isDynamic := reCallMethodDyn.MatchString(upper) || reCallFuncDyn.MatchString(upper)
+	if !isDynamic {
+		return nil
+	}
+	// Already inside TRY block — properly protected
+	if ctx.TryDepth > 0 {
+		return nil
+	}
+	return []CodeFinding{{
+		Rule:        "dynamic_call_no_try",
+		Category:    "quality",
+		Severity:    "high",
+		Line:        stmt.StartLine,
+		EndLine:     stmt.EndLine,
+		Match:       truncStmt(stmt.Text, 200),
+		Description: "Dynamic CALL METHOD/FUNCTION without TRY — can crash at runtime if target doesn't exist",
+		Suggestion:  "Wrap dynamic calls in TRY...CATCH CX_SY_DYN_CALL_ERROR",
+	}}
+}
+
+// Rule 19: perform_usage (info/quality)
+func checkPerformUsage(stmt abapStatement, upper string) []CodeFinding {
+	if !strings.HasPrefix(upper, "PERFORM ") && !strings.HasPrefix(upper, "FORM ") {
+		return nil
+	}
+	return []CodeFinding{{
+		Rule:        "perform_usage",
+		Category:    "quality",
+		Severity:    "info",
+		Line:        stmt.StartLine,
+		EndLine:     stmt.EndLine,
+		Match:       truncStmt(stmt.Text, 200),
+		Description: "PERFORM/FORM is obsolete — consider migration to methods",
+		Suggestion:  "Refactor FORM routines into class methods for better encapsulation and testability",
+	}}
+}
+
+// Rule 20: commit_work_and_wait (medium/quality)
+func checkCommitWorkAndWait(stmt abapStatement, upper string) []CodeFinding {
+	if !strings.HasPrefix(upper, "COMMIT WORK") {
+		return nil
+	}
+	if strings.Contains(upper, "AND WAIT") {
+		return nil
+	}
+	return []CodeFinding{{
+		Rule:        "commit_work_and_wait",
+		Category:    "quality",
+		Severity:    "medium",
+		Line:        stmt.StartLine,
+		EndLine:     stmt.EndLine,
+		Match:       truncStmt(stmt.Text, 200),
+		Description: "COMMIT WORK without AND WAIT — async commit hides update task errors",
+		Suggestion:  "Use COMMIT WORK AND WAIT to ensure update task completes synchronously",
+	}}
+}
+
+// Rule 21: todo_fixme (info/quality)
+func checkTodoFixme(stmt abapStatement) []CodeFinding {
+	if !stmt.IsComment {
+		return nil
+	}
+	upper := strings.ToUpper(stmt.Text)
+	if strings.Contains(upper, "TODO") || strings.Contains(upper, "FIXME") ||
+		strings.Contains(upper, "HACK") || strings.Contains(upper, "XXX") {
+		return []CodeFinding{{
+			Rule:        "todo_fixme",
+			Category:    "quality",
+			Severity:    "info",
+			Line:        stmt.StartLine,
+			EndLine:     stmt.EndLine,
+			Match:       truncStmt(stmt.Text, 200),
+			Description: "TODO/FIXME/HACK comment found — indicates unfinished work",
+			Suggestion:  "Address the TODO or create a tracking issue",
+		}}
+	}
+	return nil
+}

--- a/pkg/adt/codeanalysis_test.go
+++ b/pkg/adt/codeanalysis_test.go
@@ -1,0 +1,414 @@
+package adt
+
+import (
+	"context"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+func TestAssembleStatements_MultiLine(t *testing.T) {
+	source := `SELECT matnr maktx
+  FROM mara
+  INTO TABLE @DATA(lt_mara)
+  WHERE matnr LIKE 'Z%'.`
+
+	stmts := AssembleStatements(source)
+
+	nonComment := 0
+	for _, s := range stmts {
+		if !s.IsComment {
+			nonComment++
+		}
+	}
+	if nonComment != 1 {
+		t.Fatalf("expected 1 statement, got %d", nonComment)
+	}
+	if stmts[0].StartLine != 1 || stmts[0].EndLine != 4 {
+		t.Errorf("expected lines 1-4, got %d-%d", stmts[0].StartLine, stmts[0].EndLine)
+	}
+	if !strings.Contains(stmts[0].Text, "SELECT") || !strings.Contains(stmts[0].Text, "WHERE") {
+		t.Error("assembled statement should contain SELECT and WHERE")
+	}
+}
+
+func TestAssembleStatements_Comments(t *testing.T) {
+	source := `* Full-line comment
+DATA: lv_x TYPE string. " inline comment
+* Another comment`
+
+	stmts := AssembleStatements(source)
+
+	comments := 0
+	code := 0
+	for _, s := range stmts {
+		if s.IsComment {
+			comments++
+		} else {
+			code++
+		}
+	}
+	if comments != 2 {
+		t.Errorf("expected 2 comments, got %d", comments)
+	}
+	if code != 1 {
+		t.Errorf("expected 1 code statement, got %d", code)
+	}
+	// Inline comment should be stripped
+	for _, s := range stmts {
+		if !s.IsComment && strings.Contains(s.Text, "inline comment") {
+			t.Error("inline comment should be stripped from code statement")
+		}
+	}
+}
+
+func TestAssembleStatements_StringLiterals(t *testing.T) {
+	source := `lv_str = 'Hello. World'.`
+
+	stmts := AssembleStatements(source)
+
+	nonComment := 0
+	for _, s := range stmts {
+		if !s.IsComment {
+			nonComment++
+		}
+	}
+	if nonComment != 1 {
+		t.Fatalf("expected 1 statement (period inside string), got %d", nonComment)
+	}
+}
+
+func TestAnalyzeABAPSource_SelectInLoop(t *testing.T) {
+	source := `LOOP AT lt_items INTO DATA(ls_item).
+  SELECT SINGLE matnr FROM mara INTO @DATA(lv_matnr) WHERE matnr = @ls_item-matnr.
+ENDLOOP.`
+
+	result := AnalyzeABAPSource(source)
+
+	found := false
+	for _, f := range result.Findings {
+		if f.Rule == "select_in_loop" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("expected select_in_loop finding")
+	}
+}
+
+func TestAnalyzeABAPSource_FAENoCheck(t *testing.T) {
+	source := `DATA: lt_items TYPE TABLE OF mara.
+SELECT * FROM mara INTO TABLE @lt_items FOR ALL ENTRIES IN @lt_keys WHERE matnr = @lt_keys-matnr.`
+
+	result := AnalyzeABAPSource(source)
+
+	found := false
+	for _, f := range result.Findings {
+		if f.Rule == "fae_no_empty_check" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("expected fae_no_empty_check finding when no IF check precedes FAE")
+	}
+}
+
+func TestAnalyzeABAPSource_FAEWithCheck(t *testing.T) {
+	source := `IF lt_keys IS NOT INITIAL.
+  SELECT * FROM mara INTO TABLE @lt_items FOR ALL ENTRIES IN @lt_keys WHERE matnr = @lt_keys-matnr.
+ENDIF.`
+
+	result := AnalyzeABAPSource(source)
+
+	for _, f := range result.Findings {
+		if f.Rule == "fae_no_empty_check" {
+			t.Error("should NOT report fae_no_empty_check when preceded by IS NOT INITIAL")
+		}
+	}
+}
+
+func TestAnalyzeABAPSource_CommitInLoop(t *testing.T) {
+	source := `LOOP AT lt_items INTO DATA(ls_item).
+  MODIFY ztable FROM ls_item.
+  COMMIT WORK.
+ENDLOOP.`
+
+	result := AnalyzeABAPSource(source)
+
+	found := false
+	for _, f := range result.Findings {
+		if f.Rule == "commit_in_loop" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("expected commit_in_loop finding")
+	}
+}
+
+func TestAnalyzeABAPSource_MissingSysubrc(t *testing.T) {
+	source := `READ TABLE lt_data INTO DATA(ls_data) WITH KEY matnr = lv_matnr.
+lv_result = ls_data-werks.`
+
+	result := AnalyzeABAPSource(source)
+
+	found := false
+	for _, f := range result.Findings {
+		if f.Rule == "missing_sysubrc_read" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("expected missing_sysubrc_read finding when SY-SUBRC is not checked")
+	}
+}
+
+func TestAnalyzeABAPSource_HardcodedCredentials(t *testing.T) {
+	source := `lv_password = 'SuperSecret123'.
+lv_user = 'admin'.`
+
+	result := AnalyzeABAPSource(source)
+
+	found := false
+	for _, f := range result.Findings {
+		if f.Rule == "hardcoded_credentials" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("expected hardcoded_credentials finding for password assignment")
+	}
+}
+
+func TestAnalyzeABAPSource_DynamicCallNoTry(t *testing.T) {
+	source := `CALL METHOD (lv_class_name)=>(lv_method_name).`
+
+	result := AnalyzeABAPSource(source)
+
+	found := false
+	for _, f := range result.Findings {
+		if f.Rule == "dynamic_call_no_try" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("expected dynamic_call_no_try finding for dynamic CALL METHOD")
+	}
+}
+
+func TestAnalyzeABAPSource_CleanCode(t *testing.T) {
+	source := `METHOD do_something.
+  DATA(lt_data) = get_data( ).
+  IF lt_data IS NOT INITIAL.
+    SELECT matnr maktx FROM mara
+      INTO TABLE @DATA(lt_result)
+      FOR ALL ENTRIES IN @lt_data
+      WHERE matnr = @lt_data-matnr.
+    IF sy-subrc = 0.
+      process( lt_result ).
+    ENDIF.
+  ENDIF.
+ENDMETHOD.`
+
+	result := AnalyzeABAPSource(source)
+
+	criticals := 0
+	for _, f := range result.Findings {
+		if f.Severity == "critical" || f.Severity == "high" {
+			criticals++
+		}
+	}
+	if criticals > 0 {
+		for _, f := range result.Findings {
+			if f.Severity == "critical" || f.Severity == "high" {
+				t.Errorf("unexpected critical/high finding in clean code: %s (line %d)", f.Rule, f.Line)
+			}
+		}
+	}
+}
+
+func TestCodeAnalysisSummary_Score(t *testing.T) {
+	tests := []struct {
+		name     string
+		findings []CodeFinding
+		expected string
+	}{
+		{"good", nil, "good"},
+		{"good-info", []CodeFinding{{Severity: "info"}}, "good"},
+		{"warning", []CodeFinding{{Severity: "high"}}, "warning"},
+		{"critical", []CodeFinding{{Severity: "critical"}, {Severity: "info"}}, "critical"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			score := calculateCodeScore(tt.findings)
+			if score != tt.expected {
+				t.Errorf("calculateCodeScore() = %q, want %q", score, tt.expected)
+			}
+		})
+	}
+}
+
+func TestClient_AnalyzeABAPCode_URI(t *testing.T) {
+	abapSource := `REPORT ztest.
+SELECT * FROM mara INTO TABLE @DATA(lt_mara).
+LOOP AT lt_mara INTO DATA(ls_mara).
+  SELECT SINGLE maktx FROM makt INTO @DATA(lv_text) WHERE matnr = @ls_mara-matnr.
+ENDLOOP.`
+
+	mock := &mockTransportClient{
+		responses: map[string]*http.Response{
+			"source/main": newTestResponse(abapSource),
+			"discovery":   newTestResponse("OK"),
+		},
+	}
+	cfg := NewConfig("https://sap.example.com:44300", "user", "pass")
+	transport := NewTransportWithClient(cfg, mock)
+	client := NewClientWithTransport(cfg, transport)
+
+	result, err := client.AnalyzeABAPCode(context.Background(), "/sap/bc/adt/programs/programs/ztest", "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.ObjectURI != "/sap/bc/adt/programs/programs/ztest" {
+		t.Errorf("ObjectURI = %q, want /sap/bc/adt/programs/programs/ztest", result.ObjectURI)
+	}
+	if len(result.Findings) == 0 {
+		t.Error("expected findings from analysis")
+	}
+
+	// Should find select_in_loop at minimum
+	found := false
+	for _, f := range result.Findings {
+		if f.Rule == "select_in_loop" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("expected select_in_loop finding from URI-based analysis")
+	}
+}
+
+func TestAssembleStatements_StringTemplate(t *testing.T) {
+	// ABAP string templates use |...| and can contain periods
+	source := `lv_msg = |Hello. World { lv_name }. Done|.
+lv_other = 'test'.`
+
+	stmts := AssembleStatements(source)
+
+	nonComment := 0
+	for _, s := range stmts {
+		if !s.IsComment {
+			nonComment++
+		}
+	}
+	if nonComment != 2 {
+		t.Fatalf("expected 2 statements (period inside |...| should not split), got %d", nonComment)
+	}
+	if !strings.Contains(stmts[0].Text, "Hello. World") {
+		t.Error("string template content should be preserved")
+	}
+}
+
+func TestAssembleStatements_BacktickLiteral(t *testing.T) {
+	// Backtick strings can also contain periods
+	source := "lv_str = `Contains. Period`.\nlv_x = 1."
+
+	stmts := AssembleStatements(source)
+
+	nonComment := 0
+	for _, s := range stmts {
+		if !s.IsComment {
+			nonComment++
+		}
+	}
+	if nonComment != 2 {
+		t.Fatalf("expected 2 statements (period inside backtick should not split), got %d", nonComment)
+	}
+}
+
+func TestAnalyzeABAPSource_DynamicCallFunction(t *testing.T) {
+	// CALL FUNCTION (var) form — was a bug (H3: missed this form)
+	source := `DATA: lv_fname TYPE funcname.
+lv_fname = 'BAPI_USER_GET_DETAIL'.
+CALL FUNCTION lv_fname EXPORTING username = 'ADMIN'.`
+
+	result := AnalyzeABAPSource(source)
+
+	found := false
+	for _, f := range result.Findings {
+		if f.Rule == "dynamic_call_no_try" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("expected dynamic_call_no_try for CALL FUNCTION with variable name")
+	}
+}
+
+func TestAnalyzeABAPSource_StaticCallFunctionNoFalsePositive(t *testing.T) {
+	// Static CALL FUNCTION with literal name should NOT trigger dynamic_call_no_try
+	source := `CALL FUNCTION 'BAPI_USER_GET_DETAIL'
+  EXPORTING username = 'ADMIN'
+  IMPORTING return = ls_return.
+IF sy-subrc <> 0.
+  MESSAGE ls_return-message TYPE 'E'.
+ENDIF.`
+
+	result := AnalyzeABAPSource(source)
+
+	for _, f := range result.Findings {
+		if f.Rule == "dynamic_call_no_try" {
+			t.Errorf("static CALL FUNCTION 'LITERAL' should not trigger dynamic_call_no_try, got: %s", f.Match)
+		}
+	}
+}
+
+func TestAnalyzeABAPSource_TodoFixme(t *testing.T) {
+	// Fix M1: todo_fixme rule should fire on comment lines
+	source := `* TODO: implement error handling
+DATA: lv_x TYPE string.`
+
+	result := AnalyzeABAPSource(source)
+
+	found := false
+	for _, f := range result.Findings {
+		if f.Rule == "todo_fixme" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("expected todo_fixme finding on comment line with TODO")
+	}
+}
+
+func TestClient_AnalyzeABAPCode_Source(t *testing.T) {
+	source := `REPORT ztest.
+DATA: lv_x TYPE string.`
+
+	cfg := NewConfig("https://sap.example.com:44300", "user", "pass")
+	mock := &mockTransportClient{
+		responses: map[string]*http.Response{
+			"discovery": newTestResponse("OK"),
+		},
+	}
+	transport := NewTransportWithClient(cfg, mock)
+	client := NewClientWithTransport(cfg, transport)
+
+	result, err := client.AnalyzeABAPCode(context.Background(), "", source)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.RulesApplied != 21 {
+		t.Errorf("RulesApplied = %d, want 21", result.RulesApplied)
+	}
+}

--- a/pkg/adt/impact.go
+++ b/pkg/adt/impact.go
@@ -1,0 +1,374 @@
+package adt
+
+import (
+	"context"
+	"fmt"
+	"regexp"
+	"sort"
+	"strings"
+	"time"
+)
+
+// Pre-compiled regexes (compiled once at package init).
+var (
+	reSQLSanitize    = regexp.MustCompile(`[^a-zA-Z0-9/_]`)
+	reUserExitCall   = regexp.MustCompile(`(?i)CALL\s+FUNCTION\s+['"]EXIT_`)
+	reCrossProgramFM = regexp.MustCompile(`(?i)PERFORM\s+\w+.*IN\s+PROGRAM`)
+	reBAdIInterface  = regexp.MustCompile(`(?i)IF_EX_\w+|IF_BADI_\w+`)
+)
+
+// ImpactAnalysisOptions configures which layers to execute.
+type ImpactAnalysisOptions struct {
+	StaticRefs      bool     // Layer 1 (default: true)
+	Transitive      bool     // Layer 2 (default: false)
+	MaxDepth        int      // Layer 2 depth (default: 3)
+	DynamicPatterns bool     // Layer 3 (default: false)
+	ExtensionPoints bool     // Layer 4 (default: false)
+	MaxResults      int      // Cap (default: 200)
+	ScopePackages   []string // Scope for Layer 3-4 searches
+}
+
+// ImpactAnalysisResult is the full impact analysis output.
+type ImpactAnalysisResult struct {
+	ObjectURI         string            `json:"objectUri"`
+	ObjectName        string            `json:"objectName,omitempty"`
+	DirectConsumers   []ImpactedObject  `json:"directConsumers,omitempty"`
+	TransitiveCallers []ImpactedObject  `json:"transitiveCallers,omitempty"`
+	DynamicCallRisks  []DynamicCallRisk `json:"dynamicCallRisks,omitempty"`
+	ConfigCallRisks   []ConfigCallRisk  `json:"configCallRisks,omitempty"`
+	Summary           ImpactSummary     `json:"summary"`
+	Layers            []string          `json:"layersExecuted"`
+	Warnings          []string          `json:"warnings,omitempty"`
+}
+
+// ImpactedObject represents an object affected by a change.
+type ImpactedObject struct {
+	URI         string `json:"uri"`
+	Name        string `json:"name"`
+	Type        string `json:"type,omitempty"`
+	Package     string `json:"package,omitempty"`
+	Description string `json:"description,omitempty"`
+	Depth       int    `json:"depth,omitempty"` // hops from changed object (Layer 2)
+}
+
+// DynamicCallRisk represents a potential dynamic call reference to the target.
+type DynamicCallRisk struct {
+	ObjectURI  string `json:"objectUri"`
+	ObjectName string `json:"objectName"`
+	ObjectType string `json:"objectType,omitempty"`
+	Package    string `json:"package,omitempty"`
+	Pattern    string `json:"pattern"`
+	MatchLine  string `json:"matchLine,omitempty"`
+	LineNumber int    `json:"lineNumber,omitempty"`
+	RiskLevel  string `json:"riskLevel"` // "high", "medium"
+}
+
+// ConfigCallRisk represents a configuration-driven call pattern.
+type ConfigCallRisk struct {
+	Type        string `json:"type"`        // "badi", "enhancement", "user_exit", "nace", etc.
+	Name        string `json:"name"`        // BAdI name, enhancement spot, etc.
+	ObjectURI   string `json:"objectUri,omitempty"`
+	ObjectName  string `json:"objectName,omitempty"`
+	Description string `json:"description"`
+	Source      string `json:"source"` // "source_analysis" or "table_query"
+}
+
+// ImpactSummary aggregates the analysis results.
+type ImpactSummary struct {
+	DirectConsumerCount  int    `json:"directConsumerCount"`
+	TransitiveCallerCount int   `json:"transitiveCallerCount"`
+	DynamicRiskCount     int    `json:"dynamicRiskCount"`
+	ConfigRiskCount      int    `json:"configRiskCount"`
+	TotalAffected        int    `json:"totalAffected"`
+	RiskLevel            string `json:"riskLevel"` // "low", "medium", "high", "critical"
+	Truncated            bool   `json:"truncated,omitempty"`
+}
+
+// CalculateRiskLevel determines the overall risk level from counts.
+func CalculateRiskLevel(dynamicRisks, configRisks, totalAffected int) string {
+	if dynamicRisks > 0 || configRisks > 0 {
+		return "critical" // unknown blast radius
+	}
+	if totalAffected > 50 {
+		return "high"
+	}
+	if totalAffected > 10 {
+		return "medium"
+	}
+	return "low"
+}
+
+// GetImpactAnalysis performs multi-layer impact analysis for a given object.
+func (c *Client) GetImpactAnalysis(ctx context.Context, objectURI string, objectName string, opts ImpactAnalysisOptions) (*ImpactAnalysisResult, error) {
+	if err := c.checkSafety(OpRead, "GetImpactAnalysis"); err != nil {
+		return nil, err
+	}
+
+	if objectURI == "" {
+		return nil, fmt.Errorf("object_uri is required")
+	}
+
+	// Apply timeout
+	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+
+	if opts.MaxResults <= 0 {
+		opts.MaxResults = 200
+	}
+	if opts.MaxDepth <= 0 {
+		opts.MaxDepth = 3
+	}
+
+	result := &ImpactAnalysisResult{
+		ObjectURI:  objectURI,
+		ObjectName: objectName,
+	}
+
+	// Track visited URIs for deduplication across layers
+	visited := make(map[string]bool)
+
+	// Layer 1: Static References (always on unless explicitly disabled)
+	if opts.StaticRefs {
+		result.Layers = append(result.Layers, "static_references")
+		refs, err := c.FindReferences(ctx, objectURI, 0, 0)
+		if err != nil {
+			result.Warnings = append(result.Warnings, fmt.Sprintf("Layer 1 (static refs) failed: %v", err))
+		} else {
+			for _, ref := range refs {
+				if ref.URI == "" || visited[ref.URI] {
+					continue
+				}
+				visited[ref.URI] = true
+				result.DirectConsumers = append(result.DirectConsumers, ImpactedObject{
+					URI:         ref.URI,
+					Name:        ref.Name,
+					Type:        ref.Type,
+					Package:     ref.PackageName,
+					Description: ref.Description,
+					Depth:       1,
+				})
+				if len(result.DirectConsumers) >= opts.MaxResults {
+					break
+				}
+			}
+		}
+	}
+
+	// Layer 2: Transitive Callers (opt-in)
+	if opts.Transitive {
+		result.Layers = append(result.Layers, "transitive_callers")
+		callGraph, err := c.GetCallersOf(ctx, objectURI, opts.MaxDepth)
+		if err != nil {
+			result.Warnings = append(result.Warnings, fmt.Sprintf("Layer 2 (transitive callers) failed: %v", err))
+		} else if callGraph != nil {
+			edges := FlattenCallGraph(callGraph)
+			for _, edge := range edges {
+				if edge.CallerURI == "" || visited[edge.CallerURI] {
+					continue
+				}
+				visited[edge.CallerURI] = true
+				result.TransitiveCallers = append(result.TransitiveCallers, ImpactedObject{
+					URI:   edge.CallerURI,
+					Name:  edge.CallerName,
+					Depth: 2, // simplified depth — actual depth requires BFS from root
+				})
+				if len(result.DirectConsumers)+len(result.TransitiveCallers) >= opts.MaxResults {
+					break
+				}
+			}
+			// Stable sort by URI for deterministic output
+			sort.Slice(result.TransitiveCallers, func(i, j int) bool {
+				return result.TransitiveCallers[i].URI < result.TransitiveCallers[j].URI
+			})
+		}
+	}
+
+	// Layer 3: Dynamic Call Patterns (opt-in, needs scope)
+	if opts.DynamicPatterns {
+		result.Layers = append(result.Layers, "dynamic_patterns")
+		if len(opts.ScopePackages) == 0 {
+			result.Warnings = append(result.Warnings, "Layer 3 skipped: specify scope_packages for dynamic call detection")
+		} else if objectName != "" {
+			risks, err := c.searchDynamicPatterns(ctx, objectName, opts.ScopePackages)
+			if err != nil {
+				result.Warnings = append(result.Warnings, fmt.Sprintf("Layer 3 partial: %v", err))
+			}
+			result.DynamicCallRisks = risks
+		}
+	}
+
+	// Layer 4: Config-Driven Calls (opt-in)
+	if opts.ExtensionPoints {
+		result.Layers = append(result.Layers, "extension_points")
+
+		// 4a: Source analysis of the target object
+		if objectURI != "" {
+			source, err := c.getSourceForAnalysis(ctx, objectURI)
+			if err != nil {
+				result.Warnings = append(result.Warnings, fmt.Sprintf("Layer 4a (source analysis) failed: %v", err))
+			} else if source != "" {
+				configRisks := DetectConfigPatterns(source, objectName)
+				result.ConfigCallRisks = append(result.ConfigCallRisks, configRisks...)
+			}
+		}
+
+		// 4b: Table queries (optional, graceful degradation)
+		if len(opts.ScopePackages) > 0 && objectName != "" {
+			tableRisks := c.queryConfigTables(ctx, objectName)
+			result.ConfigCallRisks = append(result.ConfigCallRisks, tableRisks...)
+		}
+	}
+
+	// Build summary
+	total := len(result.DirectConsumers) + len(result.TransitiveCallers)
+	truncated := total >= opts.MaxResults
+	result.Summary = ImpactSummary{
+		DirectConsumerCount:   len(result.DirectConsumers),
+		TransitiveCallerCount: len(result.TransitiveCallers),
+		DynamicRiskCount:      len(result.DynamicCallRisks),
+		ConfigRiskCount:       len(result.ConfigCallRisks),
+		TotalAffected:         total,
+		RiskLevel:             CalculateRiskLevel(len(result.DynamicCallRisks), len(result.ConfigCallRisks), total),
+		Truncated:             truncated,
+	}
+
+	return result, nil
+}
+
+// searchDynamicPatterns searches for the target object name as a string literal in scope packages.
+func (c *Client) searchDynamicPatterns(ctx context.Context, objectName string, packages []string) ([]DynamicCallRisk, error) {
+	var risks []DynamicCallRisk
+
+	// Search for object name as string literal in scope packages
+	grepResult, err := c.GrepPackages(ctx, packages, true, objectName, true, nil, 50)
+	if err != nil {
+		return risks, fmt.Errorf("GrepPackages failed: %w", err)
+	}
+
+	for _, obj := range grepResult.Objects {
+		for _, match := range obj.Matches {
+			risks = append(risks, DynamicCallRisk{
+				ObjectURI:  obj.ObjectURL,
+				ObjectName: obj.ObjectName,
+				ObjectType: obj.ObjectType,
+				Pattern:    objectName,
+				MatchLine:  match.MatchedLine,
+				LineNumber: match.LineNumber,
+				RiskLevel:  "medium",
+			})
+		}
+	}
+	return risks, nil
+}
+
+// getSourceForAnalysis fetches object source for config pattern analysis.
+func (c *Client) getSourceForAnalysis(ctx context.Context, objectURI string) (string, error) {
+	resp, err := c.transport.Request(ctx, objectURI+"/source/main", &RequestOptions{
+		Accept: "text/plain",
+	})
+	if err != nil {
+		return "", err
+	}
+	return string(resp.Body), nil
+}
+
+// DetectConfigPatterns analyzes source code for configuration-driven call patterns.
+// Pure Go, exported for testing.
+func DetectConfigPatterns(source, objectName string) []ConfigCallRisk {
+	var risks []ConfigCallRisk
+	upper := strings.ToUpper(source)
+
+	// ENHANCEMENT-SECTION / ENHANCEMENT-POINT
+	if strings.Contains(upper, "ENHANCEMENT-SECTION") || strings.Contains(upper, "ENHANCEMENT-POINT") {
+		risks = append(risks, ConfigCallRisk{
+			Type:        "enhancement",
+			Name:        objectName,
+			Description: "Object contains enhancement points — external code can inject logic",
+			Source:      "source_analysis",
+		})
+	}
+
+	// GET BADI / CALL BADI
+	if strings.Contains(upper, "GET BADI") || strings.Contains(upper, "CALL BADI") {
+		risks = append(risks, ConfigCallRisk{
+			Type:        "badi",
+			Name:        objectName,
+			Description: "Object uses BAdI — implementations may change behavior",
+			Source:      "source_analysis",
+		})
+	}
+
+	// EXIT_ prefix in CALL FUNCTION
+	if reUserExitCall.MatchString(source) {
+		risks = append(risks, ConfigCallRisk{
+			Type:        "user_exit",
+			Name:        objectName,
+			Description: "Object calls user exit function module",
+			Source:      "source_analysis",
+		})
+	}
+
+	// PERFORM...IN PROGRAM
+	if reCrossProgramFM.MatchString(source) {
+		risks = append(risks, ConfigCallRisk{
+			Type:        "cross_program",
+			Name:        objectName,
+			Description: "Object calls FORM in external program (often config-driven)",
+			Source:      "source_analysis",
+		})
+	}
+
+	// IF_EX_ or IF_BADI_ interface implementation
+	if reBAdIInterface.MatchString(source) {
+		risks = append(risks, ConfigCallRisk{
+			Type:        "badi",
+			Name:        objectName,
+			Description: "Object implements BAdI interface (IF_EX_/IF_BADI_)",
+			Source:      "source_analysis",
+		})
+	}
+
+	return risks
+}
+
+// queryConfigTables queries customizing tables for registrations referencing the object.
+// Graceful degradation: if RunQuery is blocked, skip silently.
+func (c *Client) queryConfigTables(ctx context.Context, objectName string) []ConfigCallRisk {
+	var risks []ConfigCallRisk
+
+	// Sanitize object name for SQL (strip quotes, allow only alphanumeric + / for namespaces)
+	sanitized := reSQLSanitize.ReplaceAllString(objectName, "")
+	if sanitized == "" {
+		return risks
+	}
+
+	queries := []struct {
+		table       string
+		field       string
+		riskType    string
+		description string
+	}{
+		{"SXS_INTER", "IMP_CLASS", "badi", "BAdI implementation registered for this class"},
+		{"MODSAP", "MEMBER", "user_exit", "User exit assignment referencing this object"},
+		{"TNAPR", "ROUTINE", "nace", "NACE output determination referencing this object"},
+	}
+
+	for _, q := range queries {
+		sql := fmt.Sprintf("SELECT * FROM %s WHERE %s LIKE '%%%s%%'", q.table, q.field, sanitized)
+		result, err := c.RunQuery(ctx, sql, 10)
+		if err != nil {
+			// RunQuery blocked by safety (SAP_BLOCK_FREE_SQL) or table doesn't exist — skip
+			continue
+		}
+		if result != nil && len(result.Rows) > 0 {
+			risks = append(risks, ConfigCallRisk{
+				Type:        q.riskType,
+				Name:        sanitized,
+				Description: fmt.Sprintf("%s: %s.%s has %d entries referencing '%s'", q.description, q.table, q.field, len(result.Rows), sanitized),
+				Source:      "table_query",
+			})
+		}
+	}
+
+	return risks
+}

--- a/pkg/adt/impact_test.go
+++ b/pkg/adt/impact_test.go
@@ -1,0 +1,250 @@
+package adt
+
+import (
+	"context"
+	"net/http"
+	"testing"
+)
+
+func TestGetImpactAnalysis_StaticOnly(t *testing.T) {
+	// Mock FindReferences response (real SAP ADT XML format)
+	refsXML := `<?xml version="1.0" encoding="UTF-8"?>
+<usageReferences:usageReferenceResult xmlns:usageReferences="http://www.sap.com/adt/ris/usageReferences" xmlns:adtcore="http://www.sap.com/adt/core">
+  <usageReferences:referencedObjects>
+    <usageReferences:referencedObject usageReferences:uri="/sap/bc/adt/programs/programs/zprog1" usageReferences:isResult="true">
+      <adtcore:adtObject adtcore:uri="/sap/bc/adt/programs/programs/zprog1" adtcore:type="PROG/P" adtcore:name="ZPROG1">
+        <adtcore:packageRef adtcore:name="$TMP"/>
+      </adtcore:adtObject>
+    </usageReferences:referencedObject>
+    <usageReferences:referencedObject usageReferences:uri="/sap/bc/adt/oo/classes/zcl_consumer" usageReferences:isResult="true">
+      <adtcore:adtObject adtcore:uri="/sap/bc/adt/oo/classes/zcl_consumer" adtcore:type="CLAS/OC" adtcore:name="ZCL_CONSUMER">
+        <adtcore:packageRef adtcore:name="$TMP"/>
+      </adtcore:adtObject>
+    </usageReferences:referencedObject>
+  </usageReferences:referencedObjects>
+</usageReferences:usageReferenceResult>`
+
+	mock := &mockTransportClient{
+		responses: map[string]*http.Response{
+			"usageReferences": newTestResponse(refsXML),
+			"discovery":       newTestResponse("OK"),
+		},
+	}
+	cfg := NewConfig("https://sap.example.com:44300", "user", "pass")
+	transport := NewTransportWithClient(cfg, mock)
+	transport.csrfToken = "test-token"
+	client := NewClientWithTransport(cfg, transport)
+
+	opts := ImpactAnalysisOptions{StaticRefs: true}
+	result, err := client.GetImpactAnalysis(context.Background(), "/sap/bc/adt/oo/classes/zcl_test", "ZCL_TEST", opts)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(result.DirectConsumers) == 0 {
+		t.Error("expected direct consumers from FindReferences")
+	}
+	if len(result.Layers) != 1 || result.Layers[0] != "static_references" {
+		t.Errorf("expected [static_references] layer, got %v", result.Layers)
+	}
+	if result.Summary.RiskLevel == "" {
+		t.Error("expected non-empty risk level")
+	}
+}
+
+func TestGetImpactAnalysis_EmptyResult(t *testing.T) {
+	emptyRefsXML := `<?xml version="1.0" encoding="UTF-8"?>
+<usageReferences:usageReferenceResult xmlns:usageReferences="http://www.sap.com/adt/ris/usageReferences">
+  <usageReferences:referencedObjects/>
+</usageReferences:usageReferenceResult>`
+
+	mock := &mockTransportClient{
+		responses: map[string]*http.Response{
+			"usageReferences": newTestResponse(emptyRefsXML),
+			"discovery":       newTestResponse("OK"),
+		},
+	}
+	cfg := NewConfig("https://sap.example.com:44300", "user", "pass")
+	transport := NewTransportWithClient(cfg, mock)
+	transport.csrfToken = "test-token"
+	client := NewClientWithTransport(cfg, transport)
+
+	opts := ImpactAnalysisOptions{StaticRefs: true}
+	result, err := client.GetImpactAnalysis(context.Background(), "/sap/bc/adt/oo/classes/zcl_orphan", "ZCL_ORPHAN", opts)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(result.DirectConsumers) != 0 {
+		t.Errorf("expected no consumers, got %d", len(result.DirectConsumers))
+	}
+	if result.Summary.RiskLevel != "low" {
+		t.Errorf("expected low risk, got %q", result.Summary.RiskLevel)
+	}
+}
+
+func TestGetImpactAnalysis_MaxResults(t *testing.T) {
+	// Create a response with many references (3 objects, cap at 2)
+	refsXML := `<?xml version="1.0" encoding="UTF-8"?>
+<usageReferences:usageReferenceResult xmlns:usageReferences="http://www.sap.com/adt/ris/usageReferences" xmlns:adtcore="http://www.sap.com/adt/core">
+  <usageReferences:referencedObjects>
+    <usageReferences:referencedObject usageReferences:uri="/sap/bc/adt/programs/programs/zprog1" usageReferences:isResult="true">
+      <adtcore:adtObject adtcore:uri="/sap/bc/adt/programs/programs/zprog1" adtcore:type="PROG/P" adtcore:name="ZPROG1">
+        <adtcore:packageRef adtcore:name="$TMP"/>
+      </adtcore:adtObject>
+    </usageReferences:referencedObject>
+    <usageReferences:referencedObject usageReferences:uri="/sap/bc/adt/programs/programs/zprog2" usageReferences:isResult="true">
+      <adtcore:adtObject adtcore:uri="/sap/bc/adt/programs/programs/zprog2" adtcore:type="PROG/P" adtcore:name="ZPROG2">
+        <adtcore:packageRef adtcore:name="$TMP"/>
+      </adtcore:adtObject>
+    </usageReferences:referencedObject>
+    <usageReferences:referencedObject usageReferences:uri="/sap/bc/adt/programs/programs/zprog3" usageReferences:isResult="true">
+      <adtcore:adtObject adtcore:uri="/sap/bc/adt/programs/programs/zprog3" adtcore:type="PROG/P" adtcore:name="ZPROG3">
+        <adtcore:packageRef adtcore:name="$TMP"/>
+      </adtcore:adtObject>
+    </usageReferences:referencedObject>
+  </usageReferences:referencedObjects>
+</usageReferences:usageReferenceResult>`
+
+	mock := &mockTransportClient{
+		responses: map[string]*http.Response{
+			"usageReferences": newTestResponse(refsXML),
+			"discovery":       newTestResponse("OK"),
+		},
+	}
+	cfg := NewConfig("https://sap.example.com:44300", "user", "pass")
+	transport := NewTransportWithClient(cfg, mock)
+	transport.csrfToken = "test-token"
+	client := NewClientWithTransport(cfg, transport)
+
+	opts := ImpactAnalysisOptions{StaticRefs: true, MaxResults: 2}
+	result, err := client.GetImpactAnalysis(context.Background(), "/sap/bc/adt/oo/classes/zcl_test", "ZCL_TEST", opts)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(result.DirectConsumers) > 2 {
+		t.Errorf("expected at most 2 consumers (MaxResults=2), got %d", len(result.DirectConsumers))
+	}
+	if !result.Summary.Truncated {
+		t.Error("expected Truncated=true when results are capped")
+	}
+}
+
+func TestDetectConfigPatterns_Source(t *testing.T) {
+	source := `CLASS zcl_test DEFINITION.
+  PUBLIC SECTION.
+    METHODS: do_something.
+ENDCLASS.
+
+CLASS zcl_test IMPLEMENTATION.
+  METHOD do_something.
+    DATA: lo_badi TYPE REF TO if_ex_something.
+    GET BADI lo_badi.
+    CALL BADI lo_badi->execute( ).
+    ENHANCEMENT-SECTION sec_01 SPOTS zspot_test.
+    ENDENHANCEMENT-SECTION.
+  ENDMETHOD.
+ENDCLASS.`
+
+	risks := DetectConfigPatterns(source, "ZCL_TEST")
+
+	types := make(map[string]bool)
+	for _, r := range risks {
+		types[r.Type] = true
+	}
+
+	if !types["badi"] {
+		t.Error("expected badi risk from GET BADI")
+	}
+	if !types["enhancement"] {
+		t.Error("expected enhancement risk from ENHANCEMENT-SECTION")
+	}
+}
+
+func TestDetectConfigPatterns_BAdIInterface(t *testing.T) {
+	source := `CLASS zcl_impl DEFINITION.
+  PUBLIC SECTION.
+    INTERFACES: if_ex_customer_check.
+ENDCLASS.`
+
+	risks := DetectConfigPatterns(source, "ZCL_IMPL")
+
+	found := false
+	for _, r := range risks {
+		if r.Type == "badi" && r.Source == "source_analysis" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("expected badi risk from IF_EX_ interface")
+	}
+}
+
+func TestDetectConfigPatterns_UserExit(t *testing.T) {
+	source := `FORM user_exit.
+  CALL FUNCTION 'EXIT_SAPLMR1M_001'
+    EXPORTING iv_param = lv_val.
+ENDFORM.`
+
+	risks := DetectConfigPatterns(source, "ZTEST_PROG")
+
+	found := false
+	for _, r := range risks {
+		if r.Type == "user_exit" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("expected user_exit risk from EXIT_ function call")
+	}
+}
+
+func TestSanitizeForSQL(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		{"ZCL_TEST", "ZCL_TEST"},
+		{"/NAMESPACE/CL_TEST", "/NAMESPACE/CL_TEST"},
+		{"ZCL_TEST'; DROP TABLE --", "ZCL_TESTDROPTABLE"},
+		{"", ""},
+		{"hello world", "helloworld"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			got := reSQLSanitize.ReplaceAllString(tt.input, "")
+			if got != tt.expected {
+				t.Errorf("sanitize(%q) = %q, want %q", tt.input, got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestImpactSummary_RiskLevel(t *testing.T) {
+	tests := []struct {
+		name          string
+		dynamic       int
+		config        int
+		total         int
+		expectedLevel string
+	}{
+		{"low", 0, 0, 5, "low"},
+		{"medium", 0, 0, 15, "medium"},
+		{"high", 0, 0, 60, "high"},
+		{"critical-dynamic", 1, 0, 5, "critical"},
+		{"critical-config", 0, 1, 5, "critical"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			level := CalculateRiskLevel(tt.dynamic, tt.config, tt.total)
+			if level != tt.expectedLevel {
+				t.Errorf("CalculateRiskLevel(%d, %d, %d) = %q, want %q",
+					tt.dynamic, tt.config, tt.total, level, tt.expectedLevel)
+			}
+		})
+	}
+}

--- a/pkg/adt/regression.go
+++ b/pkg/adt/regression.go
@@ -1,0 +1,358 @@
+package adt
+
+import (
+	"context"
+	"fmt"
+	"regexp"
+	"strings"
+	"time"
+)
+
+// RegressionResult is the output of regression analysis.
+type RegressionResult struct {
+	ObjectURI   string            `json:"objectUri"`
+	ObjectName  string            `json:"objectName,omitempty"`
+	ObjectType  string            `json:"objectType,omitempty"`
+	BaseVersion string            `json:"baseVersion"`
+	Findings    []CodeFinding     `json:"findings"`
+	Summary     RegressionSummary `json:"summary"`
+	Warnings    []string          `json:"warnings,omitempty"`
+}
+
+// RegressionSummary contains aggregate regression metrics.
+type RegressionSummary struct {
+	TotalFindings    int    `json:"totalFindings"`
+	CriticalCount    int    `json:"criticalCount"`
+	HighCount        int    `json:"highCount"`
+	RiskLevel        string `json:"riskLevel"` // "safe", "caution", "breaking"
+	SignatureChanges int    `json:"signatureChanges"`
+	RemovedMethods   int    `json:"removedMethods"`
+}
+
+// DetectSignatureChanges compares method signatures between old and new source.
+// Returns findings for changed parameter types or added required parameters.
+// Pure Go, exported for testing.
+func DetectSignatureChanges(oldSource, newSource string) []CodeFinding {
+	oldMethods := extractMethodDefs(oldSource)
+	newMethods := extractMethodDefs(newSource)
+
+	var findings []CodeFinding
+	for name, oldDef := range oldMethods {
+		newDef, exists := newMethods[name]
+		if !exists {
+			continue // handled by DetectRemovedPublicMethods
+		}
+		if normalizeMethodDef(oldDef) != normalizeMethodDef(newDef) {
+			findings = append(findings, CodeFinding{
+				Rule:        "changed_signature",
+				Category:    "robustness",
+				Severity:    "critical",
+				Line:        0,
+				Description: fmt.Sprintf("Method %s signature changed", name),
+				Match:       truncStmt(fmt.Sprintf("OLD: %s | NEW: %s", oldDef, newDef), 200),
+				Suggestion:  "Changing method signatures breaks all callers — add new optional params or create a new method",
+			})
+		}
+	}
+	return findings
+}
+
+// DetectRemovedPublicMethods finds public methods that exist in old source but not in new.
+// Pure Go, exported for testing.
+func DetectRemovedPublicMethods(oldSource, newSource string) []CodeFinding {
+	oldMethods := extractPublicMethods(oldSource)
+	newMethods := extractPublicMethods(newSource)
+
+	var findings []CodeFinding
+	for name := range oldMethods {
+		if _, exists := newMethods[name]; !exists {
+			findings = append(findings, CodeFinding{
+				Rule:        "removed_public_method",
+				Category:    "robustness",
+				Severity:    "critical",
+				Line:        0,
+				Description: fmt.Sprintf("Public method %s was removed", name),
+				Suggestion:  "Removing public methods breaks all callers — deprecate first or keep as empty wrapper",
+			})
+		}
+	}
+	return findings
+}
+
+// DetectInterfaceChanges detects any changes in INTERFACE definitions.
+// Pure Go, exported for testing.
+func DetectInterfaceChanges(oldSource, newSource string) []CodeFinding {
+	oldIface := extractInterfaceDef(oldSource)
+	newIface := extractInterfaceDef(newSource)
+
+	if oldIface == "" || newIface == "" {
+		return nil // not an interface, or can't extract
+	}
+	if normalizeWhitespace(oldIface) == normalizeWhitespace(newIface) {
+		return nil
+	}
+
+	return []CodeFinding{{
+		Rule:        "changed_interface_method",
+		Category:    "robustness",
+		Severity:    "critical",
+		Line:        0,
+		Description: "Interface definition changed — all implementing classes may need updates",
+		Suggestion:  "Interface changes break all implementors — consider adding methods to a new interface instead",
+	}}
+}
+
+// DetectExceptionChanges finds RAISING clause changes in method definitions.
+// Pure Go, exported for testing.
+func DetectExceptionChanges(oldSource, newSource string) []CodeFinding {
+	oldRaising := extractRaisingClauses(oldSource)
+	newRaising := extractRaisingClauses(newSource)
+
+	var findings []CodeFinding
+	for method, oldClause := range oldRaising {
+		newClause, exists := newRaising[method]
+		if !exists {
+			continue
+		}
+		if normalizeWhitespace(oldClause) != normalizeWhitespace(newClause) {
+			findings = append(findings, CodeFinding{
+				Rule:        "changed_exception_handling",
+				Category:    "robustness",
+				Severity:    "high",
+				Line:        0,
+				Description: fmt.Sprintf("RAISING clause changed for method %s", method),
+				Match:       truncStmt(fmt.Sprintf("OLD: %s | NEW: %s", oldClause, newClause), 200),
+				Suggestion:  "Changed RAISING clause may require callers to handle new exceptions",
+			})
+		}
+	}
+	return findings
+}
+
+// CheckRegression compares current source against a base version and detects breaking changes.
+func (c *Client) CheckRegression(ctx context.Context, objectURI, baseVersion string) (*RegressionResult, error) {
+	if err := c.checkSafety(OpRead, "CheckRegression"); err != nil {
+		return nil, err
+	}
+
+	if objectURI == "" {
+		return nil, fmt.Errorf("object_uri is required")
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+
+	result := &RegressionResult{
+		ObjectURI: objectURI,
+	}
+
+	// Parse object type and name from URI
+	objType, objName := parseObjectURIComponents(objectURI)
+	result.ObjectType = objType
+	result.ObjectName = objName
+
+	// Fetch current source
+	currentSource, err := c.getSourceForAnalysis(ctx, objectURI)
+	if err != nil {
+		return nil, fmt.Errorf("fetching current source: %w", err)
+	}
+
+	// Determine base version
+	var baseVersionURI string
+	if baseVersion != "" {
+		baseVersionURI = baseVersion
+	} else {
+		// Auto-detect: get revisions, pick second-newest
+		if objType == "" || objName == "" {
+			result.Warnings = append(result.Warnings, "Could not parse object type/name from URI — provide base_version explicitly")
+			result.Summary.RiskLevel = "unknown"
+			return result, nil
+		}
+		revisions, err := c.GetRevisions(ctx, objType, objName, nil)
+		if err != nil {
+			result.Warnings = append(result.Warnings, fmt.Sprintf("Could not fetch revisions: %v — provide base_version explicitly", err))
+			result.Summary.RiskLevel = "unknown"
+			return result, nil
+		}
+		if len(revisions) == 0 {
+			result.Warnings = append(result.Warnings, "No version history available — cannot detect regressions")
+			result.Summary.RiskLevel = "unknown"
+			return result, nil
+		}
+		if len(revisions) == 1 {
+			baseVersionURI = revisions[0].URI
+			result.Warnings = append(result.Warnings, "Only 1 revision found — comparing against it")
+		} else {
+			// Second-newest = index 1 (revisions sorted newest-first)
+			baseVersionURI = revisions[1].URI
+		}
+	}
+	result.BaseVersion = baseVersionURI
+
+	// Fetch base source
+	baseSource, err := c.GetRevisionSource(ctx, baseVersionURI)
+	if err != nil {
+		result.Warnings = append(result.Warnings, fmt.Sprintf("Could not fetch base version source: %v", err))
+		result.Summary.RiskLevel = "unknown"
+		return result, nil
+	}
+
+	// Run regression rules
+	result.Findings = append(result.Findings, DetectSignatureChanges(baseSource, currentSource)...)
+	result.Findings = append(result.Findings, DetectRemovedPublicMethods(baseSource, currentSource)...)
+	result.Findings = append(result.Findings, DetectInterfaceChanges(baseSource, currentSource)...)
+	result.Findings = append(result.Findings, DetectExceptionChanges(baseSource, currentSource)...)
+
+	// Build summary
+	sigChanges := 0
+	removedMethods := 0
+	criticalCount := 0
+	highCount := 0
+	for _, f := range result.Findings {
+		switch f.Rule {
+		case "changed_signature":
+			sigChanges++
+		case "removed_public_method":
+			removedMethods++
+		}
+		switch f.Severity {
+		case "critical":
+			criticalCount++
+		case "high":
+			highCount++
+		}
+	}
+
+	riskLevel := "safe"
+	if criticalCount > 0 {
+		riskLevel = "breaking"
+	} else if highCount > 0 {
+		riskLevel = "caution"
+	}
+
+	result.Summary = RegressionSummary{
+		TotalFindings:    len(result.Findings),
+		CriticalCount:    criticalCount,
+		HighCount:        highCount,
+		RiskLevel:        riskLevel,
+		SignatureChanges: sigChanges,
+		RemovedMethods:   removedMethods,
+	}
+
+	return result, nil
+}
+
+// --- Helper functions ---
+
+// extractMethodDefs extracts METHODS definitions from ABAP source.
+// Returns map of method_name → full definition line.
+func extractMethodDefs(source string) map[string]string {
+	result := make(map[string]string)
+	matches := reMethodDef.FindAllStringSubmatch(source, -1)
+	for _, m := range matches {
+		name := strings.ToUpper(m[1])
+		result[name] = strings.TrimSpace(m[0])
+	}
+	return result
+}
+
+// extractPublicMethods extracts method names from PUBLIC SECTION.
+func extractPublicMethods(source string) map[string]bool {
+	result := make(map[string]bool)
+	upper := strings.ToUpper(source)
+
+	// Find PUBLIC SECTION
+	pubIdx := strings.Index(upper, "PUBLIC SECTION")
+	if pubIdx < 0 {
+		return result
+	}
+
+	// Find the end (PROTECTED SECTION, PRIVATE SECTION, or ENDCLASS)
+	rest := upper[pubIdx:]
+	baseOffset := len("PUBLIC SECTION")
+	endIdx := len(rest)
+	for _, marker := range []string{"PROTECTED SECTION", "PRIVATE SECTION", "ENDCLASS"} {
+		if idx := strings.Index(rest[baseOffset:], marker); idx >= 0 {
+			absIdx := idx + baseOffset
+			if absIdx < endIdx {
+				endIdx = absIdx
+			}
+		}
+	}
+
+	publicBlock := upper[pubIdx : pubIdx+endIdx]
+	matches := reMethodName.FindAllStringSubmatch(publicBlock, -1)
+	for _, m := range matches {
+		result[strings.ToUpper(m[1])] = true
+	}
+	return result
+}
+
+// extractInterfaceDef extracts the interface definition block.
+func extractInterfaceDef(source string) string {
+	upper := strings.ToUpper(source)
+	startIdx := strings.Index(upper, "INTERFACE ")
+	if startIdx < 0 {
+		return ""
+	}
+	endIdx := strings.Index(upper[startIdx:], "ENDINTERFACE")
+	if endIdx < 0 {
+		return ""
+	}
+	return upper[startIdx : startIdx+endIdx+len("ENDINTERFACE")]
+}
+
+// extractRaisingClauses extracts RAISING clauses from method definitions.
+// Uses (?s) dot-all flag to handle multi-line METHODS definitions where
+// RAISING appears on a different line than the METHODS keyword.
+func extractRaisingClauses(source string) map[string]string {
+	result := make(map[string]string)
+	matches := reMethodRaising.FindAllStringSubmatch(source, -1)
+	for _, m := range matches {
+		name := strings.ToUpper(m[1])
+		result[name] = strings.TrimSpace(m[2])
+	}
+	return result
+}
+
+// parseObjectURIComponents extracts type and name from an ADT URI.
+func parseObjectURIComponents(uri string) (string, string) {
+	parts := strings.Split(uri, "/")
+	if len(parts) < 2 {
+		return "", ""
+	}
+
+	name := parts[len(parts)-1]
+
+	// Detect type from URI path
+	joined := strings.Join(parts, "/")
+	switch {
+	case strings.Contains(joined, "/oo/classes/"):
+		return "CLAS", strings.ToUpper(name)
+	case strings.Contains(joined, "/oo/interfaces/"):
+		return "INTF", strings.ToUpper(name)
+	case strings.Contains(joined, "/programs/programs/"):
+		return "PROG", strings.ToUpper(name)
+	case strings.Contains(joined, "/functions/groups/"):
+		return "FUGR", strings.ToUpper(name)
+	case strings.Contains(joined, "/ddic/ddl/sources/"):
+		return "DDLS", strings.ToUpper(name)
+	}
+	return "", strings.ToUpper(name)
+}
+
+func normalizeMethodDef(s string) string {
+	return normalizeWhitespace(strings.ToUpper(s))
+}
+
+// Pre-compiled regexes for regression analysis (compiled once at package init).
+var (
+	reWhitespace        = regexp.MustCompile(`\s+`)
+	reMethodDef         = regexp.MustCompile(`(?im)^\s*METHODS\s+(\w+)\b(.*)$`)
+	reMethodName        = regexp.MustCompile(`(?im)\bMETHODS\s+(\w+)`)
+	reMethodRaising     = regexp.MustCompile(`(?ims)METHODS\s+(\w+)\b[^.]*?(RAISING\s+[\w/\s]+?)\.`)
+)
+
+func normalizeWhitespace(s string) string {
+	return reWhitespace.ReplaceAllString(strings.TrimSpace(s), " ")
+}

--- a/pkg/adt/regression_test.go
+++ b/pkg/adt/regression_test.go
@@ -1,0 +1,276 @@
+package adt
+
+import (
+	"context"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+func TestDetectSignatureChanges_ParamAdded(t *testing.T) {
+	old := `CLASS zcl_test DEFINITION.
+  PUBLIC SECTION.
+    METHODS do_something IMPORTING iv_name TYPE string.
+ENDCLASS.`
+
+	new := `CLASS zcl_test DEFINITION.
+  PUBLIC SECTION.
+    METHODS do_something IMPORTING iv_name TYPE string iv_age TYPE i.
+ENDCLASS.`
+
+	findings := DetectSignatureChanges(old, new)
+	if len(findings) == 0 {
+		t.Error("expected changed_signature finding when parameter added")
+	}
+	if findings[0].Rule != "changed_signature" {
+		t.Errorf("expected rule changed_signature, got %s", findings[0].Rule)
+	}
+}
+
+func TestDetectSignatureChanges_ParamTypeChanged(t *testing.T) {
+	old := `CLASS zcl_test DEFINITION.
+  PUBLIC SECTION.
+    METHODS process IMPORTING iv_value TYPE string.
+ENDCLASS.`
+
+	new := `CLASS zcl_test DEFINITION.
+  PUBLIC SECTION.
+    METHODS process IMPORTING iv_value TYPE i.
+ENDCLASS.`
+
+	findings := DetectSignatureChanges(old, new)
+	if len(findings) == 0 {
+		t.Error("expected changed_signature finding when parameter type changed")
+	}
+}
+
+func TestDetectRemovedPublicMethods_Removed(t *testing.T) {
+	old := `CLASS zcl_test DEFINITION.
+  PUBLIC SECTION.
+    METHODS do_something.
+    METHODS do_other.
+ENDCLASS.`
+
+	new := `CLASS zcl_test DEFINITION.
+  PUBLIC SECTION.
+    METHODS do_other.
+ENDCLASS.`
+
+	findings := DetectRemovedPublicMethods(old, new)
+	if len(findings) == 0 {
+		t.Error("expected removed_public_method finding")
+	}
+	found := false
+	for _, f := range findings {
+		if f.Rule == "removed_public_method" {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("expected removed_public_method rule")
+	}
+}
+
+func TestDetectRemovedPublicMethods_Renamed(t *testing.T) {
+	old := `CLASS zcl_test DEFINITION.
+  PUBLIC SECTION.
+    METHODS old_method.
+ENDCLASS.`
+
+	new := `CLASS zcl_test DEFINITION.
+  PUBLIC SECTION.
+    METHODS new_method.
+ENDCLASS.`
+
+	findings := DetectRemovedPublicMethods(old, new)
+	if len(findings) == 0 {
+		t.Error("expected removed_public_method when method is renamed (detected as remove)")
+	}
+}
+
+func TestDetectInterfaceChanges_MethodAdded(t *testing.T) {
+	old := `INTERFACE zif_test PUBLIC.
+  METHODS do_something.
+ENDINTERFACE.`
+
+	new := `INTERFACE zif_test PUBLIC.
+  METHODS do_something.
+  METHODS do_other.
+ENDINTERFACE.`
+
+	findings := DetectInterfaceChanges(old, new)
+	if len(findings) == 0 {
+		t.Error("expected changed_interface_method finding when method added to interface")
+	}
+}
+
+func TestDetectExceptionChanges_RaisingChanged(t *testing.T) {
+	old := `CLASS zcl_test DEFINITION.
+  PUBLIC SECTION.
+    METHODS process RAISING cx_sy_open_sql_db.
+ENDCLASS.`
+
+	new := `CLASS zcl_test DEFINITION.
+  PUBLIC SECTION.
+    METHODS process RAISING cx_sy_open_sql_db cx_sy_dynamic_osql_error.
+ENDCLASS.`
+
+	findings := DetectExceptionChanges(old, new)
+	if len(findings) == 0 {
+		t.Error("expected changed_exception_handling finding when RAISING clause changes")
+	}
+}
+
+func TestDetectRegressions_NoChanges(t *testing.T) {
+	source := `CLASS zcl_test DEFINITION.
+  PUBLIC SECTION.
+    METHODS do_something IMPORTING iv_name TYPE string.
+ENDCLASS.`
+
+	findings := DetectSignatureChanges(source, source)
+	findings = append(findings, DetectRemovedPublicMethods(source, source)...)
+	findings = append(findings, DetectInterfaceChanges(source, source)...)
+	findings = append(findings, DetectExceptionChanges(source, source)...)
+
+	if len(findings) != 0 {
+		t.Errorf("expected 0 findings for identical sources, got %d", len(findings))
+	}
+}
+
+func TestDetectExceptionChanges_MultiLineRaising(t *testing.T) {
+	// Multi-line METHODS definition where RAISING is on a different line
+	old := `CLASS zcl_test DEFINITION.
+  PUBLIC SECTION.
+    METHODS process
+      IMPORTING iv_value TYPE string
+      RAISING cx_sy_open_sql_db.
+ENDCLASS.`
+
+	new := `CLASS zcl_test DEFINITION.
+  PUBLIC SECTION.
+    METHODS process
+      IMPORTING iv_value TYPE string
+      RAISING cx_sy_open_sql_db cx_sy_dynamic_osql_error.
+ENDCLASS.`
+
+	findings := DetectExceptionChanges(old, new)
+	if len(findings) == 0 {
+		t.Error("expected changed_exception_handling for multi-line METHODS with RAISING change")
+	}
+}
+
+func TestDetectExceptionChanges_MultiMethodNoFalseAttribution(t *testing.T) {
+	// Two methods: only second has RAISING. Ensure RAISING is attributed to correct method.
+	old := `CLASS zcl_test DEFINITION.
+  PUBLIC SECTION.
+    METHODS do_simple
+      IMPORTING iv_value TYPE string.
+    METHODS do_complex
+      IMPORTING iv_data TYPE ref to data
+      RAISING cx_sy_open_sql_db.
+ENDCLASS.`
+
+	new := `CLASS zcl_test DEFINITION.
+  PUBLIC SECTION.
+    METHODS do_simple
+      IMPORTING iv_value TYPE string.
+    METHODS do_complex
+      IMPORTING iv_data TYPE ref to data
+      RAISING cx_sy_open_sql_db cx_sy_dynamic_osql_error.
+ENDCLASS.`
+
+	findings := DetectExceptionChanges(old, new)
+	if len(findings) == 0 {
+		t.Error("expected changed_exception_handling finding for do_complex")
+	}
+	for _, f := range findings {
+		if strings.Contains(f.Description, "do_simple") || strings.Contains(strings.ToLower(f.Match), "do_simple") {
+			t.Errorf("RAISING wrongly attributed to do_simple: %s", f.Description)
+		}
+	}
+}
+
+func TestParseObjectURIComponents(t *testing.T) {
+	tests := []struct {
+		uri      string
+		wantType string
+		wantName string
+	}{
+		{"/sap/bc/adt/oo/classes/zcl_test", "CLAS", "ZCL_TEST"},
+		{"/sap/bc/adt/oo/interfaces/zif_test", "INTF", "ZIF_TEST"},
+		{"/sap/bc/adt/programs/programs/ztest", "PROG", "ZTEST"},
+		{"/sap/bc/adt/functions/groups/zfg_test", "FUGR", "ZFG_TEST"},
+		{"/sap/bc/adt/ddic/ddl/sources/zddls_test", "DDLS", "ZDDLS_TEST"},
+		{"/sap/bc/adt/unknown/path/zobject", "", "ZOBJECT"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.uri, func(t *testing.T) {
+			gotType, gotName := parseObjectURIComponents(tt.uri)
+			if gotType != tt.wantType {
+				t.Errorf("type = %q, want %q", gotType, tt.wantType)
+			}
+			if gotName != tt.wantName {
+				t.Errorf("name = %q, want %q", gotName, tt.wantName)
+			}
+		})
+	}
+}
+
+func TestClient_CheckRegression(t *testing.T) {
+	currentSource := `CLASS zcl_test DEFINITION.
+  PUBLIC SECTION.
+    METHODS process IMPORTING iv_value TYPE i.
+ENDCLASS.`
+
+	baseSource := `CLASS zcl_test DEFINITION.
+  PUBLIC SECTION.
+    METHODS process IMPORTING iv_value TYPE string.
+    METHODS old_method.
+ENDCLASS.`
+
+	revisionFeed := `<?xml version="1.0" encoding="UTF-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom">
+  <entry>
+    <id>2</id>
+    <title>Version 2</title>
+    <updated>2026-02-20T10:00:00Z</updated>
+    <author><name>TESTUSER</name></author>
+    <content type="text" src="/sap/bc/adt/oo/classes/zcl_test/includes/main/versions/2/content"/>
+  </entry>
+  <entry>
+    <id>1</id>
+    <title>Version 1</title>
+    <updated>2026-02-19T10:00:00Z</updated>
+    <author><name>TESTUSER</name></author>
+    <content type="text" src="/sap/bc/adt/oo/classes/zcl_test/includes/main/versions/1/content"/>
+  </entry>
+</feed>`
+
+	// Use full paths for exact matching to avoid ambiguous partial matches
+	mock := &mockTransportClient{
+		responses: map[string]*http.Response{
+			"/sap/bc/adt/oo/classes/zcl_test/source/main":                     newTestResponse(currentSource),
+			"/sap/bc/adt/oo/classes/ZCL_TEST/includes/main/versions":          newTestResponse(revisionFeed),
+			"/sap/bc/adt/oo/classes/zcl_test/includes/main/versions/1/content": newTestResponse(baseSource),
+			"discovery": newTestResponse("OK"),
+		},
+	}
+	cfg := NewConfig("https://sap.example.com:44300", "user", "pass")
+	transport := NewTransportWithClient(cfg, mock)
+	client := NewClientWithTransport(cfg, transport)
+
+	result, err := client.CheckRegression(context.Background(), "/sap/bc/adt/oo/classes/zcl_test", "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if result.Summary.RiskLevel != "breaking" {
+		t.Errorf("expected 'breaking' risk level, got %q", result.Summary.RiskLevel)
+	}
+	if result.Summary.SignatureChanges == 0 {
+		t.Error("expected signature changes")
+	}
+	if result.Summary.RemovedMethods == 0 {
+		t.Error("expected removed methods")
+	}
+}

--- a/pkg/adt/revisions.go
+++ b/pkg/adt/revisions.go
@@ -1,0 +1,193 @@
+package adt
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+)
+
+// --- Object Version History (Revisions) ---
+
+// GetRevisions retrieves the version history (revisions) of an ABAP object.
+// For classes, use opts.Include to get revisions of a specific include.
+//
+// Supported object types: PROG, CLAS, INTF, FUNC, INCL, DDLS, BDEF, SRVD
+func (c *Client) GetRevisions(ctx context.Context, objectType, name string, opts *GetSourceOptions) ([]Revision, error) {
+	if err := c.checkSafety(OpRead, "GetRevisions"); err != nil {
+		return nil, err
+	}
+
+	objectType = strings.ToUpper(objectType)
+	name = strings.ToUpper(name)
+	if opts == nil {
+		opts = &GetSourceOptions{}
+	}
+
+	revisionURL, err := c.resolveRevisionURL(objectType, name, opts)
+	if err != nil {
+		return nil, fmt.Errorf("resolving revision URL for %s %s: %w", objectType, name, err)
+	}
+
+	resp, err := c.transport.Request(ctx, revisionURL, &RequestOptions{
+		Method: http.MethodGet,
+		Accept: "application/atom+xml;type=feed",
+	})
+	if err != nil {
+		return nil, fmt.Errorf("getting revisions for %s %s: %w", objectType, name, err)
+	}
+
+	return ParseRevisionFeed(resp.Body)
+}
+
+// GetRevisionSource retrieves the source code of a specific object version.
+// The versionURI comes from GetRevisions output (the URI field of a Revision entry).
+func (c *Client) GetRevisionSource(ctx context.Context, versionURI string) (string, error) {
+	if err := c.checkSafety(OpRead, "GetRevisionSource"); err != nil {
+		return "", err
+	}
+
+	if versionURI == "" {
+		return "", fmt.Errorf("versionURI is required")
+	}
+
+	resp, err := c.transport.Request(ctx, versionURI, &RequestOptions{
+		Method: http.MethodGet,
+		Accept: "text/plain",
+	})
+	if err != nil {
+		return "", fmt.Errorf("getting revision source: %w", err)
+	}
+
+	return string(resp.Body), nil
+}
+
+// CompareVersions compares two versions of an ABAP object and returns a unified diff.
+// version1URI and version2URI are from GetRevisions output.
+// Use "current" as version2URI to compare against the active version.
+func (c *Client) CompareVersions(ctx context.Context, objectType, name string, version1URI, version2URI string, opts *GetSourceOptions) (*SourceDiff, error) {
+	if err := c.checkSafety(OpRead, "CompareVersions"); err != nil {
+		return nil, err
+	}
+
+	source1, err := c.GetRevisionSource(ctx, version1URI)
+	if err != nil {
+		return nil, fmt.Errorf("getting version 1 source: %w", err)
+	}
+
+	var source2 string
+	if version2URI == "current" {
+		source2, err = c.GetSource(ctx, objectType, name, opts)
+		if err != nil {
+			return nil, fmt.Errorf("getting current source: %w", err)
+		}
+	} else {
+		source2, err = c.GetRevisionSource(ctx, version2URI)
+		if err != nil {
+			return nil, fmt.Errorf("getting version 2 source: %w", err)
+		}
+	}
+
+	label1 := fmt.Sprintf("%s:%s@%s", objectType, name, extractVersionLabel(version1URI))
+	label2 := fmt.Sprintf("%s:%s@%s", objectType, name, extractVersionLabel(version2URI))
+
+	result := &SourceDiff{
+		Object1:   label1,
+		Object2:   label2,
+		Identical: source1 == source2,
+	}
+
+	if result.Identical {
+		result.Diff = "Sources are identical"
+		return result, nil
+	}
+
+	lines1 := strings.Split(source1, "\n")
+	lines2 := strings.Split(source2, "\n")
+	result.Diff = generateUnifiedDiff(label1, label2, lines1, lines2)
+
+	for _, line := range strings.Split(result.Diff, "\n") {
+		if strings.HasPrefix(line, "+") && !strings.HasPrefix(line, "+++") {
+			result.AddedLines++
+		} else if strings.HasPrefix(line, "-") && !strings.HasPrefix(line, "---") {
+			result.RemovedLines++
+		}
+	}
+
+	return result, nil
+}
+
+// resolveRevisionURL builds the ADT revision feed URL for a given object type.
+//
+// Key discovery: classes use /includes/{type}/versions (not /source/main/versions).
+// Programs and other source objects use /source/main/versions.
+// Interfaces also use /includes/main/versions (same pattern as classes).
+func (c *Client) resolveRevisionURL(objectType, name string, opts *GetSourceOptions) (string, error) {
+	encodedName := url.PathEscape(name)
+
+	switch objectType {
+	case "PROG":
+		return fmt.Sprintf("/sap/bc/adt/programs/programs/%s/source/main/versions", encodedName), nil
+	case "CLAS":
+		include := opts.Include
+		if include == "" {
+			include = "main"
+		}
+		// Classes always use /includes/{type}/versions — even for main
+		return fmt.Sprintf("/sap/bc/adt/oo/classes/%s/includes/%s/versions", encodedName, include), nil
+	case "INTF":
+		// Interfaces use the same /includes/main/versions pattern as classes
+		return fmt.Sprintf("/sap/bc/adt/oo/interfaces/%s/includes/main/versions", encodedName), nil
+	case "FUNC":
+		if opts.Parent == "" {
+			return "", fmt.Errorf("parent (function group name) is required for FUNC type")
+		}
+		encodedParent := url.PathEscape(strings.ToUpper(opts.Parent))
+		return fmt.Sprintf("/sap/bc/adt/functions/groups/%s/fmodules/%s/source/main/versions", encodedParent, encodedName), nil
+	case "INCL":
+		return fmt.Sprintf("/sap/bc/adt/programs/includes/%s/source/main/versions", encodedName), nil
+	case "DDLS":
+		return fmt.Sprintf("/sap/bc/adt/ddic/ddl/sources/%s/source/main/versions", encodedName), nil
+	case "BDEF":
+		return fmt.Sprintf("/sap/bc/adt/bo/behaviordefinitions/%s/source/main/versions", encodedName), nil
+	case "SRVD":
+		return fmt.Sprintf("/sap/bc/adt/ddic/srvd/sources/%s/source/main/versions", encodedName), nil
+	default:
+		return "", fmt.Errorf("unsupported object type for revisions: %s (supported: PROG, CLAS, INTF, FUNC, INCL, DDLS, BDEF, SRVD)", objectType)
+	}
+}
+
+// extractVersionLabel extracts a short label from a version URI for display.
+// Handles two URI formats:
+//   - PROG: .../source/main?version=5 → "v5"
+//   - CLAS: .../versions/20161212091747/00000/content → "v00000"
+func extractVersionLabel(uri string) string {
+	if uri == "current" {
+		return "current"
+	}
+	// Format 1: query param (programs)
+	if idx := strings.Index(uri, "version="); idx >= 0 {
+		rest := uri[idx+8:]
+		if end := strings.IndexAny(rest, "&;"); end >= 0 {
+			return "v" + rest[:end]
+		}
+		return "v" + rest
+	}
+	// Format 2: path-based (classes) — .../versions/{timestamp}/{version}/content
+	if idx := strings.Index(uri, "/versions/"); idx >= 0 {
+		rest := uri[idx+10:] // after "/versions/"
+		parts := strings.Split(rest, "/")
+		if len(parts) >= 2 {
+			return "v" + parts[1] // version number (e.g., "00000")
+		}
+		if len(parts) == 1 {
+			return "v" + parts[0]
+		}
+	}
+	parts := strings.Split(uri, "/")
+	if len(parts) > 0 {
+		return parts[len(parts)-1]
+	}
+	return uri
+}

--- a/pkg/adt/sqlperf.go
+++ b/pkg/adt/sqlperf.go
@@ -1,0 +1,356 @@
+package adt
+
+import (
+	"context"
+	"fmt"
+	"regexp"
+	"strings"
+	"time"
+)
+
+// SQLPerformanceAnalysis is the combined result of SQL performance analysis.
+type SQLPerformanceAnalysis struct {
+	Query         string                   `json:"query"`
+	PlanFindings  []SQLPerformanceFinding  `json:"planFindings,omitempty"`
+	TextFindings  []SQLPerformanceFinding  `json:"textFindings,omitempty"`
+	Summary       SQLPerfSummary           `json:"summary"`
+	HANAAvailable bool                     `json:"hanaAvailable"`
+	Warnings      []string                 `json:"warnings,omitempty"`
+}
+
+// SQLPerformanceFinding represents a single performance issue found in the SQL.
+type SQLPerformanceFinding struct {
+	Type        string  `json:"type"`        // e.g. "full_table_scan", "select_star"
+	Severity    string  `json:"severity"`    // "critical", "high", "medium", "info"
+	Description string  `json:"description"` // Human-readable explanation
+	Suggestion  string  `json:"suggestion"`  // How to fix
+	NodeID      int     `json:"nodeId,omitempty"`
+	Table       string  `json:"table,omitempty"`
+	Cost        float64 `json:"cost,omitempty"`
+	Rows        int     `json:"rows,omitempty"`
+}
+
+// SQLPerfSummary contains aggregate performance summary.
+type SQLPerfSummary struct {
+	TotalFindings int            `json:"totalFindings"`
+	BySeverity    map[string]int `json:"bySeverity"`
+	Score         string         `json:"score"` // "good", "warning", "critical"
+}
+
+// Pre-compiled regex patterns for SQL text analysis (compiled once at package init).
+var (
+	reSQLHostVar       = regexp.MustCompile(`@\w[\w~-]*`)
+	reSQLIntoTable     = regexp.MustCompile(`(?i)\b(INTO\s+(CORRESPONDING\s+FIELDS\s+OF\s+)?TABLE\s+\S+|APPENDING\s+(CORRESPONDING\s+FIELDS\s+OF\s+)?TABLE\s+\S+)`)
+	reSQLIntoTuple     = regexp.MustCompile(`(?i)\bINTO\s*\([^)]+\)`)
+	reSQLIntoSingle    = regexp.MustCompile(`(?i)\bINTO\s+\S+`)
+	reSQLUpToRows      = regexp.MustCompile(`(?i)\bUP\s+TO\s+\d+\s+ROWS\b`)
+	reSQLFAE           = regexp.MustCompile(`(?i)\bFOR\s+ALL\s+ENTRIES\s+IN\s+\S+`)
+	reSQLWhitespace    = regexp.MustCompile(`\s+`)
+	reSQLSelectStar    = regexp.MustCompile(`(?i)\bSELECT\s+(SINGLE\s+)?\*\s+FROM\b`)
+	reSQLSelectCount   = regexp.MustCompile(`(?i)\bSELECT\s+COUNT\b`)
+	reSQLClientSpec    = regexp.MustCompile(`(?i)\bCLIENT\s+SPECIFIED\b`)
+	reSQLSelectWord    = regexp.MustCompile(`(?i)\bSELECT\b`)
+	reSQLDistinct      = regexp.MustCompile(`(?i)\bDISTINCT\b`)
+)
+
+// AnalyzePlanNodes walks a SQL execution plan tree and detects performance issues.
+// Pure Go, no network calls. Exported for testing.
+func AnalyzePlanNodes(nodes []SQLPlanNode) []SQLPerformanceFinding {
+	var findings []SQLPerformanceFinding
+	var walk func(node SQLPlanNode)
+
+	walk = func(node SQLPlanNode) {
+		op := strings.ToUpper(node.Operator)
+
+		// full_table_scan / full_scan_small
+		if strings.Contains(op, "TABLE SCAN") && node.Index == "" {
+			if node.Rows > 1000 {
+				findings = append(findings, SQLPerformanceFinding{
+					Type:        "full_table_scan",
+					Severity:    "critical",
+					Description: fmt.Sprintf("Full table scan on %s (%d rows, no index)", node.Table, node.Rows),
+					Suggestion:  "Add an appropriate index or use a WHERE clause to limit the scan",
+					NodeID:      node.ID,
+					Table:       node.Table,
+					Cost:        node.Cost,
+					Rows:        node.Rows,
+				})
+			} else {
+				findings = append(findings, SQLPerformanceFinding{
+					Type:        "full_scan_small",
+					Severity:    "info",
+					Description: fmt.Sprintf("Full table scan on %s (%d rows) — small table, acceptable", node.Table, node.Rows),
+					Suggestion:  "Acceptable for small tables; consider indexing if data grows",
+					NodeID:      node.ID,
+					Table:       node.Table,
+					Cost:        node.Cost,
+					Rows:        node.Rows,
+				})
+			}
+		}
+
+		// missing_index
+		if node.Cost > 100 && node.Index == "" && node.Table != "" &&
+			!strings.Contains(op, "TABLE SCAN") {
+			findings = append(findings, SQLPerformanceFinding{
+				Type:        "missing_index",
+				Severity:    "high",
+				Description: fmt.Sprintf("High cost node (%v) on %s without index", node.Cost, node.Table),
+				Suggestion:  "Consider adding an index for the filtered columns",
+				NodeID:      node.ID,
+				Table:       node.Table,
+				Cost:        node.Cost,
+				Rows:        node.Rows,
+			})
+		}
+
+		// nested_loop_large
+		if strings.Contains(op, "NESTED LOOP") {
+			maxChildRows := 0
+			for _, child := range node.Children {
+				if child.Rows > maxChildRows {
+					maxChildRows = child.Rows
+				}
+			}
+			if maxChildRows > 10000 {
+				findings = append(findings, SQLPerformanceFinding{
+					Type:        "nested_loop_large",
+					Severity:    "high",
+					Description: fmt.Sprintf("Nested loop join with %d rows in child — may be slow", maxChildRows),
+					Suggestion:  "Consider HASH JOIN or add indexes to improve join performance",
+					NodeID:      node.ID,
+					Cost:        node.Cost,
+					Rows:        node.Rows,
+				})
+			}
+		}
+
+		// high_cost_node
+		if node.Cost > 1000 && !strings.Contains(op, "TABLE SCAN") &&
+			!strings.Contains(op, "NESTED LOOP") {
+			findings = append(findings, SQLPerformanceFinding{
+				Type:        "high_cost_node",
+				Severity:    "medium",
+				Description: fmt.Sprintf("High cost node: %s (cost: %v)", node.Operator, node.Cost),
+				Suggestion:  "Review this operation for optimization opportunities",
+				NodeID:      node.ID,
+				Cost:        node.Cost,
+				Rows:        node.Rows,
+			})
+		}
+
+		// cartesian_product
+		if strings.Contains(op, "CROSS JOIN") {
+			findings = append(findings, SQLPerformanceFinding{
+				Type:        "cartesian_product",
+				Severity:    "critical",
+				Description: fmt.Sprintf("Cartesian product (CROSS JOIN) detected at node %d", node.ID),
+				Suggestion:  "Add a join condition to prevent full cartesian product",
+				NodeID:      node.ID,
+				Cost:        node.Cost,
+				Rows:        node.Rows,
+			})
+		}
+
+		for _, child := range node.Children {
+			walk(child)
+		}
+	}
+
+	for _, node := range nodes {
+		walk(node)
+	}
+	return findings
+}
+
+// stripABAPSQLSyntax removes ABAP SQL-specific syntax to produce a cleaner SQL
+// for text analysis. Does NOT produce valid native SQL — only for pattern matching.
+func stripABAPSQLSyntax(abapSQL string) string {
+	s := abapSQL
+
+	// Remove host variable markers (@)
+	s = reSQLHostVar.ReplaceAllStringFunc(s, func(m string) string {
+		return m[1:] // strip leading @
+	})
+
+	// Remove INTO TABLE / INTO CORRESPONDING FIELDS OF TABLE / APPENDING TABLE clauses
+	s = reSQLIntoTable.ReplaceAllString(s, "")
+
+	// Remove INTO (target, target, ...) single-row results
+	s = reSQLIntoTuple.ReplaceAllString(s, "")
+	// Remove INTO @struct / INTO @DATA(...)
+	s = reSQLIntoSingle.ReplaceAllString(s, "")
+
+	// Remove UP TO n ROWS
+	s = reSQLUpToRows.ReplaceAllString(s, "")
+
+	// Remove FOR ALL ENTRIES IN clause (the IN @itab part)
+	s = reSQLFAE.ReplaceAllString(s, "")
+
+	// Remove trailing period (ABAP statement terminator)
+	s = strings.TrimRight(strings.TrimSpace(s), ".")
+
+	// Collapse multiple spaces
+	s = reSQLWhitespace.ReplaceAllString(s, " ")
+
+	return strings.TrimSpace(s)
+}
+
+// AnalyzeSQLText performs text-based analysis of a SQL query string.
+// Handles both ABAP SQL and native SQL syntax.
+// Pure Go, no network calls. Exported for testing.
+func AnalyzeSQLText(sqlQuery string) []SQLPerformanceFinding {
+	var findings []SQLPerformanceFinding
+
+	if strings.TrimSpace(sqlQuery) == "" {
+		return findings
+	}
+
+	// Normalize: strip ABAP-specific syntax for pattern analysis
+	cleaned := stripABAPSQLSyntax(sqlQuery)
+	upper := strings.ToUpper(cleaned)
+
+	// select_star: SELECT * or SELECT SINGLE *
+	if reSQLSelectStar.MatchString(cleaned) {
+		findings = append(findings, SQLPerformanceFinding{
+			Type:        "select_star",
+			Severity:    "info",
+			Description: "SELECT * fetches all columns — prefer explicit field list",
+			Suggestion:  "List only the fields you need to reduce data transfer",
+		})
+	}
+
+	// missing_where: SELECT without WHERE (after stripping INTO/FAE)
+	if strings.Contains(upper, "SELECT") && strings.Contains(upper, "FROM") &&
+		!strings.Contains(upper, "WHERE") &&
+		!reSQLSelectCount.MatchString(cleaned) {
+		findings = append(findings, SQLPerformanceFinding{
+			Type:        "missing_where",
+			Severity:    "high",
+			Description: "SELECT without WHERE clause — may read entire table",
+			Suggestion:  "Add a WHERE clause to limit the result set",
+		})
+	}
+
+	// client_specified: CLIENT SPECIFIED — cross-client data access
+	if reSQLClientSpec.MatchString(sqlQuery) {
+		findings = append(findings, SQLPerformanceFinding{
+			Type:        "client_specified",
+			Severity:    "medium",
+			Description: "CLIENT SPECIFIED bypasses automatic client handling — cross-client data access",
+			Suggestion:  "Use CLIENT SPECIFIED only when cross-client access is intentional",
+		})
+	}
+
+	// nested_subquery: SELECT inside SELECT
+	selectCount := len(reSQLSelectWord.FindAllString(cleaned, -1))
+	if selectCount > 1 {
+		findings = append(findings, SQLPerformanceFinding{
+			Type:        "nested_subquery",
+			Severity:    "medium",
+			Description: fmt.Sprintf("Nested subquery detected (%d SELECT statements)", selectCount),
+			Suggestion:  "Consider using JOINs instead of subqueries for better performance",
+		})
+	}
+
+	// no_up_to_rows: large table SELECT without UP TO n ROWS (ABAP SQL specific)
+	// Check original query (before stripping) for UP TO
+	upperOrig := strings.ToUpper(sqlQuery)
+	if strings.Contains(upperOrig, "SELECT") && strings.Contains(upperOrig, "FROM") &&
+		!strings.Contains(upperOrig, "UP TO") &&
+		!strings.Contains(upperOrig, "SINGLE") &&
+		!strings.Contains(upperOrig, "COUNT") &&
+		!strings.Contains(upperOrig, "LIMIT") {
+		findings = append(findings, SQLPerformanceFinding{
+			Type:        "no_up_to_rows",
+			Severity:    "info",
+			Description: "SELECT without row limit (UP TO n ROWS / LIMIT) — may return large result set",
+			Suggestion:  "Consider adding UP TO n ROWS if you don't need all rows",
+		})
+	}
+
+	// distinct_usage: DISTINCT often indicates missing WHERE or design issue
+	if reSQLDistinct.MatchString(cleaned) {
+		findings = append(findings, SQLPerformanceFinding{
+			Type:        "distinct_usage",
+			Severity:    "info",
+			Description: "DISTINCT may indicate missing WHERE clause or data model issue",
+			Suggestion:  "Review if DISTINCT is necessary — it forces a sort operation",
+		})
+	}
+
+	return findings
+}
+
+// calculateSQLScore determines the overall performance score based on findings.
+func calculateSQLScore(findings []SQLPerformanceFinding) string {
+	hasCritical := false
+	hasHigh := false
+	for _, f := range findings {
+		switch f.Severity {
+		case "critical":
+			hasCritical = true
+		case "high":
+			hasHigh = true
+		}
+	}
+	if hasCritical {
+		return "critical"
+	}
+	if hasHigh {
+		return "warning"
+	}
+	return "good"
+}
+
+// AnalyzeSQLPerformance performs comprehensive SQL performance analysis.
+// Always runs text analysis on the input query.
+// If hanaAvailable is true, also attempts GetSQLExplainPlan for HANA execution plan analysis.
+func (c *Client) AnalyzeSQLPerformance(ctx context.Context, sqlQuery string, hanaAvailable bool) (*SQLPerformanceAnalysis, error) {
+	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+
+	if err := c.checkSafety(OpRead, "AnalyzeSQLPerformance"); err != nil {
+		return nil, err
+	}
+
+	if strings.TrimSpace(sqlQuery) == "" {
+		return nil, fmt.Errorf("sql_query is required")
+	}
+
+	result := &SQLPerformanceAnalysis{
+		Query:         sqlQuery,
+		HANAAvailable: hanaAvailable,
+	}
+
+	// Always run text-based analysis
+	result.TextFindings = AnalyzeSQLText(sqlQuery)
+
+	// If HANA available, attempt explain plan
+	if hanaAvailable {
+		plan, err := c.GetSQLExplainPlan(ctx, sqlQuery)
+		if err != nil {
+			result.Warnings = append(result.Warnings, fmt.Sprintf("HANA explain plan failed: %v — using text analysis only", err))
+		} else if plan != nil && len(plan.Nodes) > 0 {
+			result.PlanFindings = AnalyzePlanNodes(plan.Nodes)
+		}
+	} else {
+		result.Warnings = append(result.Warnings, "HANA not available — using text analysis only (no execution plan)")
+	}
+
+	// Merge all findings for summary (avoid aliasing result.PlanFindings slice)
+	allFindings := make([]SQLPerformanceFinding, 0, len(result.PlanFindings)+len(result.TextFindings))
+	allFindings = append(allFindings, result.PlanFindings...)
+	allFindings = append(allFindings, result.TextFindings...)
+	bySeverity := map[string]int{}
+	for _, f := range allFindings {
+		bySeverity[f.Severity]++
+	}
+	result.Summary = SQLPerfSummary{
+		TotalFindings: len(allFindings),
+		BySeverity:    bySeverity,
+		Score:         calculateSQLScore(allFindings),
+	}
+
+	return result, nil
+}

--- a/pkg/adt/sqlperf_test.go
+++ b/pkg/adt/sqlperf_test.go
@@ -1,0 +1,317 @@
+package adt
+
+import (
+	"context"
+	"net/http"
+	"testing"
+)
+
+func TestAnalyzePlanNodes_FullTableScan(t *testing.T) {
+	nodes := []SQLPlanNode{
+		{
+			ID:       1,
+			Operator: "TABLE SCAN",
+			Table:    "MARA",
+			Rows:     50000,
+			Cost:     500,
+		},
+	}
+	findings := AnalyzePlanNodes(nodes)
+	if len(findings) == 0 {
+		t.Fatal("expected findings for full table scan on large table")
+	}
+
+	found := false
+	for _, f := range findings {
+		if f.Type == "full_table_scan" && f.Severity == "critical" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("expected critical full_table_scan finding")
+	}
+}
+
+func TestAnalyzePlanNodes_SmallTableScan(t *testing.T) {
+	nodes := []SQLPlanNode{
+		{
+			ID:       1,
+			Operator: "TABLE SCAN",
+			Table:    "T000",
+			Rows:     5,
+			Cost:     1,
+		},
+	}
+	findings := AnalyzePlanNodes(nodes)
+	if len(findings) == 0 {
+		t.Fatal("expected finding for small table scan")
+	}
+
+	found := false
+	for _, f := range findings {
+		if f.Type == "full_scan_small" && f.Severity == "info" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("expected info full_scan_small finding")
+	}
+}
+
+func TestAnalyzePlanNodes_NestedLoopLarge(t *testing.T) {
+	nodes := []SQLPlanNode{
+		{
+			ID:       1,
+			Operator: "NESTED LOOP JOIN",
+			Cost:     2000,
+			Rows:     100000,
+			Children: []SQLPlanNode{
+				{ID: 2, Operator: "INDEX SCAN", Table: "BKPF", Rows: 50000, Cost: 100},
+				{ID: 3, Operator: "INDEX SCAN", Table: "BSEG", Rows: 200000, Cost: 1500},
+			},
+		},
+	}
+	findings := AnalyzePlanNodes(nodes)
+
+	found := false
+	for _, f := range findings {
+		if f.Type == "nested_loop_large" && f.Severity == "high" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("expected high nested_loop_large finding")
+	}
+}
+
+func TestAnalyzePlanNodes_GoodPlan(t *testing.T) {
+	nodes := []SQLPlanNode{
+		{
+			ID:       1,
+			Operator: "INDEX SCAN",
+			Table:    "MARA",
+			Index:    "MARA~001",
+			Rows:     10,
+			Cost:     5,
+		},
+	}
+	findings := AnalyzePlanNodes(nodes)
+	if len(findings) != 0 {
+		t.Errorf("expected no findings for good plan, got %d: %+v", len(findings), findings)
+	}
+}
+
+func TestAnalyzePlanNodes_Empty(t *testing.T) {
+	findings := AnalyzePlanNodes(nil)
+	if len(findings) != 0 {
+		t.Errorf("expected no findings for empty nodes, got %d", len(findings))
+	}
+	findings = AnalyzePlanNodes([]SQLPlanNode{})
+	if len(findings) != 0 {
+		t.Errorf("expected no findings for empty slice, got %d", len(findings))
+	}
+}
+
+func TestAnalyzeSQLText_ABAPSelectStar(t *testing.T) {
+	query := `SELECT * FROM mara WHERE matnr = @lv_matnr INTO TABLE @lt_result.`
+	findings := AnalyzeSQLText(query)
+
+	found := false
+	for _, f := range findings {
+		if f.Type == "select_star" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("expected select_star finding for SELECT * FROM mara")
+	}
+}
+
+func TestAnalyzeSQLText_ABAPMissingWhere(t *testing.T) {
+	query := `SELECT matnr maktx FROM mara INTO TABLE @lt_result.`
+	findings := AnalyzeSQLText(query)
+
+	found := false
+	for _, f := range findings {
+		if f.Type == "missing_where" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("expected missing_where finding for SELECT without WHERE")
+	}
+}
+
+func TestStripABAPSQLSyntax(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{
+			name:  "host variables",
+			input: `SELECT matnr FROM mara WHERE matnr = @lv_matnr`,
+			want:  `SELECT matnr FROM mara WHERE matnr = lv_matnr`,
+		},
+		{
+			name:  "INTO TABLE",
+			input: `SELECT matnr FROM mara INTO TABLE @lt_result.`,
+			want:  `SELECT matnr FROM mara`,
+		},
+		{
+			name:  "UP TO n ROWS",
+			input: `SELECT matnr FROM mara UP TO 100 ROWS WHERE matnr LIKE 'A%'`,
+			want:  `SELECT matnr FROM mara WHERE matnr LIKE 'A%'`,
+		},
+		{
+			name:  "APPENDING TABLE",
+			input: `SELECT matnr FROM mara APPENDING TABLE @lt_result WHERE matnr = 'X'.`,
+			want:  `SELECT matnr FROM mara WHERE matnr = 'X'`,
+		},
+		{
+			name:  "FOR ALL ENTRIES",
+			input: `SELECT matnr FROM mara FOR ALL ENTRIES IN @lt_keys WHERE matnr = @lt_keys-matnr`,
+			want:  `SELECT matnr FROM mara WHERE matnr = lt_keys-matnr`,
+		},
+		{
+			name:  "combined",
+			input: `SELECT matnr maktx FROM mara INTO CORRESPONDING FIELDS OF TABLE @lt_result UP TO 50 ROWS WHERE matnr IN @lt_range.`,
+			want:  `SELECT matnr maktx FROM mara WHERE matnr IN lt_range`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := stripABAPSQLSyntax(tt.input)
+			if got != tt.want {
+				t.Errorf("stripABAPSQLSyntax(%q)\n  got:  %q\n  want: %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCalculateSQLScore(t *testing.T) {
+	tests := []struct {
+		name     string
+		findings []SQLPerformanceFinding
+		want     string
+	}{
+		{
+			name:     "no findings",
+			findings: nil,
+			want:     "good",
+		},
+		{
+			name: "info only",
+			findings: []SQLPerformanceFinding{
+				{Severity: "info"},
+			},
+			want: "good",
+		},
+		{
+			name: "has high",
+			findings: []SQLPerformanceFinding{
+				{Severity: "info"},
+				{Severity: "high"},
+			},
+			want: "warning",
+		},
+		{
+			name: "has critical",
+			findings: []SQLPerformanceFinding{
+				{Severity: "critical"},
+				{Severity: "info"},
+			},
+			want: "critical",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := calculateSQLScore(tt.findings)
+			if got != tt.want {
+				t.Errorf("calculateSQLScore() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestClient_AnalyzeSQLPerformance(t *testing.T) {
+	// Test with HANA unavailable (text-only path)
+	t.Run("non-HANA", func(t *testing.T) {
+		mock := &mockTransportClient{
+			responses: map[string]*http.Response{},
+		}
+		cfg := NewConfig("https://sap.example.com:44300", "user", "pass")
+		transport := NewTransportWithClient(cfg, mock)
+		client := NewClientWithTransport(cfg, transport)
+
+		result, err := client.AnalyzeSQLPerformance(context.Background(),
+			`SELECT * FROM mara INTO TABLE @lt_result.`, false)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		if result == nil {
+			t.Fatal("expected non-nil result")
+		}
+		if result.HANAAvailable {
+			t.Error("expected HANAAvailable=false")
+		}
+		if len(result.Warnings) == 0 {
+			t.Error("expected warning about HANA not available")
+		}
+		if len(result.TextFindings) == 0 {
+			t.Error("expected text findings for SELECT *")
+		}
+		if result.Summary.Score == "" {
+			t.Error("expected non-empty score")
+		}
+	})
+
+	// Test with HANA available (plan + text)
+	t.Run("HANA", func(t *testing.T) {
+		planXML := `<?xml version="1.0" encoding="utf-8"?>
+<explainResult>
+  <node id="1" operator="TABLE SCAN" tableName="MARA" cost="500" outputRowCount="50000">
+  </node>
+</explainResult>`
+
+		mock := &mockTransportClient{
+			responses: map[string]*http.Response{
+				"datapreview": newTestResponse(planXML),
+				"discovery":   newTestResponse("OK"),
+			},
+		}
+		cfg := NewConfig("https://sap.example.com:44300", "user", "pass")
+		transport := NewTransportWithClient(cfg, mock)
+		// Pre-set CSRF token to avoid CSRF fetch in tests (POST requires it).
+		// newTestResponse uses non-canonical http.Header literal which Header.Get() can't find.
+		transport.csrfToken = "test-token"
+		client := NewClientWithTransport(cfg, transport)
+
+		result, err := client.AnalyzeSQLPerformance(context.Background(),
+			`SELECT * FROM MARA`, true)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		if !result.HANAAvailable {
+			t.Error("expected HANAAvailable=true")
+		}
+		if len(result.PlanFindings) == 0 {
+			t.Error("expected plan findings for full table scan")
+		}
+		if len(result.TextFindings) == 0 {
+			t.Error("expected text findings for SELECT *")
+		}
+		if result.Summary.Score != "critical" {
+			t.Errorf("expected critical score, got %q", result.Summary.Score)
+		}
+	})
+}

--- a/pkg/adt/testing.go
+++ b/pkg/adt/testing.go
@@ -1,0 +1,440 @@
+package adt
+
+import (
+	"context"
+	"encoding/xml"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+)
+
+// --- Code Coverage ---
+
+// CoverageResult contains line-level coverage data from a test run.
+type CoverageResult struct {
+	Statements    CoverageStats          `json:"statements"`
+	Branches      CoverageStats          `json:"branches,omitempty"`
+	Procedures    CoverageStats          `json:"procedures,omitempty"`
+	SourceCoverage map[string]*SourceCoverage `json:"sourceCoverage,omitempty"`
+}
+
+// CoverageStats contains aggregate coverage statistics.
+type CoverageStats struct {
+	Total   int     `json:"total"`
+	Covered int     `json:"covered"`
+	Percent float64 `json:"percent"`
+}
+
+// SourceCoverage contains coverage data for a single source file.
+type SourceCoverage struct {
+	URI          string        `json:"uri"`
+	Type         string        `json:"type,omitempty"`
+	Name         string        `json:"name,omitempty"`
+	Statements   CoverageStats `json:"statements"`
+	CoveredLines []CoveredLine `json:"coveredLines,omitempty"`
+}
+
+// CoveredLine represents coverage info for a single line.
+type CoveredLine struct {
+	Line     int  `json:"line"`
+	Executed bool `json:"executed"`
+}
+
+// GetCodeCoverage runs unit tests with coverage enabled and returns coverage data.
+// objectURL is the ADT URL of the object to test.
+func (c *Client) GetCodeCoverage(ctx context.Context, objectURL string, flags *UnitTestRunFlags) (*CoverageResult, error) {
+	if flags == nil {
+		defaultFlags := DefaultUnitTestFlags()
+		flags = &defaultFlags
+	}
+
+	body := fmt.Sprintf(`<?xml version="1.0" encoding="UTF-8"?>
+<aunit:runConfiguration xmlns:aunit="http://www.sap.com/adt/aunit">
+  <external>
+    <coverage active="true"/>
+  </external>
+  <options>
+    <uriType value="semantic"/>
+    <testDeterminationStrategy sameProgram="true" assignedTests="false"/>
+    <testRiskLevels harmless="%t" dangerous="%t" critical="%t"/>
+    <testDurations short="%t" medium="%t" long="%t"/>
+    <withNavigationUri enabled="true"/>
+  </options>
+  <adtcore:objectSets xmlns:adtcore="http://www.sap.com/adt/core">
+    <objectSet kind="inclusive">
+      <adtcore:objectReferences>
+        <adtcore:objectReference adtcore:uri="%s"/>
+      </adtcore:objectReferences>
+    </objectSet>
+  </adtcore:objectSets>
+</aunit:runConfiguration>`,
+		flags.Harmless, flags.Dangerous, flags.Critical,
+		flags.Short, flags.Medium, flags.Long,
+		objectURL)
+
+	resp, err := c.transport.Request(ctx, "/sap/bc/adt/abapunit/testruns", &RequestOptions{
+		Method:      http.MethodPost,
+		Body:        []byte(body),
+		ContentType: "application/*",
+		Accept:      "application/*",
+	})
+	if err != nil {
+		return nil, fmt.Errorf("running unit tests with coverage: %w", err)
+	}
+
+	return parseCoverageResult(resp.Body)
+}
+
+func parseCoverageResult(data []byte) (*CoverageResult, error) {
+	if len(data) == 0 {
+		return &CoverageResult{}, nil
+	}
+
+	xmlStr := string(data)
+	xmlStr = strings.ReplaceAll(xmlStr, "aunit:", "")
+	xmlStr = strings.ReplaceAll(xmlStr, "adtcore:", "")
+	xmlStr = strings.ReplaceAll(xmlStr, `xmlns:aunit="http://www.sap.com/adt/aunit"`, "")
+	xmlStr = strings.ReplaceAll(xmlStr, `xmlns:adtcore="http://www.sap.com/adt/core"`, "")
+
+	// Parse coverage section from the response
+	type coverageNode struct {
+		URI        string `xml:"uri,attr"`
+		Type       string `xml:"type,attr"`
+		Name       string `xml:"name,attr"`
+		Total      int    `xml:"total,attr"`
+		Covered    int    `xml:"covered,attr"`
+		Percentage string `xml:"percentage,attr"`
+	}
+
+	type coverageSection struct {
+		Statement []coverageNode `xml:"statement>node"`
+		Branch    []coverageNode `xml:"branch>node"`
+		Procedure []coverageNode `xml:"procedure>node"`
+	}
+
+	type coverageResponse struct {
+		XMLName  xml.Name        `xml:"runResult"`
+		Coverage coverageSection `xml:"coverage"`
+	}
+
+	var resp coverageResponse
+	if err := xml.Unmarshal([]byte(xmlStr), &resp); err != nil {
+		// If coverage data isn't in expected format, return empty
+		return &CoverageResult{
+			Statements: CoverageStats{},
+		}, nil
+	}
+
+	result := &CoverageResult{
+		SourceCoverage: make(map[string]*SourceCoverage),
+	}
+
+	// Aggregate statement coverage
+	for _, node := range resp.Coverage.Statement {
+		result.Statements.Total += node.Total
+		result.Statements.Covered += node.Covered
+
+		if node.URI != "" {
+			sc := &SourceCoverage{
+				URI:  node.URI,
+				Type: node.Type,
+				Name: node.Name,
+				Statements: CoverageStats{
+					Total:   node.Total,
+					Covered: node.Covered,
+				},
+			}
+			if node.Total > 0 {
+				sc.Statements.Percent = float64(node.Covered) / float64(node.Total) * 100
+			}
+			result.SourceCoverage[node.URI] = sc
+		}
+	}
+
+	if result.Statements.Total > 0 {
+		result.Statements.Percent = float64(result.Statements.Covered) / float64(result.Statements.Total) * 100
+	}
+
+	// Aggregate branch coverage
+	for _, node := range resp.Coverage.Branch {
+		result.Branches.Total += node.Total
+		result.Branches.Covered += node.Covered
+	}
+	if result.Branches.Total > 0 {
+		result.Branches.Percent = float64(result.Branches.Covered) / float64(result.Branches.Total) * 100
+	}
+
+	// Aggregate procedure coverage
+	for _, node := range resp.Coverage.Procedure {
+		result.Procedures.Total += node.Total
+		result.Procedures.Covered += node.Covered
+	}
+	if result.Procedures.Total > 0 {
+		result.Procedures.Percent = float64(result.Procedures.Covered) / float64(result.Procedures.Total) * 100
+	}
+
+	return result, nil
+}
+
+// --- SQL Explain Plan ---
+
+// SQLExplainPlan represents the execution plan for a SQL query.
+type SQLExplainPlan struct {
+	Query    string          `json:"query"`
+	Nodes    []SQLPlanNode   `json:"nodes"`
+	TotalCost float64        `json:"totalCost,omitempty"`
+}
+
+// SQLPlanNode represents a single node in the execution plan tree.
+type SQLPlanNode struct {
+	ID        int           `json:"id"`
+	Operator  string        `json:"operator"`
+	Table     string        `json:"table,omitempty"`
+	Index     string        `json:"index,omitempty"`
+	Cost      float64       `json:"cost,omitempty"`
+	Rows      int           `json:"rows,omitempty"`
+	Children  []SQLPlanNode `json:"children,omitempty"`
+}
+
+// GetSQLExplainPlan returns the execution plan for a SQL query (HANA only).
+func (c *Client) GetSQLExplainPlan(ctx context.Context, sqlQuery string) (*SQLExplainPlan, error) {
+	if err := c.checkSafety(OpRead, "GetSQLExplainPlan"); err != nil {
+		return nil, err
+	}
+
+	if sqlQuery == "" {
+		return nil, fmt.Errorf("SQL query is required")
+	}
+
+	q := url.Values{}
+	q.Set("rowNumber", "0") // We don't need actual data, just the plan
+
+	resp, err := c.transport.Request(ctx, "/sap/bc/adt/datapreview/freestyle", &RequestOptions{
+		Method:      http.MethodPost,
+		Query:       q,
+		Body:        []byte("EXPLAIN PLAN FOR " + sqlQuery),
+		ContentType: "text/plain",
+		Accept:      "application/xml",
+	})
+	if err != nil {
+		// Fallback: try the dedicated explain endpoint
+		resp, err = c.transport.Request(ctx, "/sap/bc/adt/datapreview/ddlServices/explain", &RequestOptions{
+			Method:      http.MethodPost,
+			Body:        []byte(sqlQuery),
+			ContentType: "text/plain",
+			Accept:      "application/xml",
+		})
+		if err != nil {
+			return nil, fmt.Errorf("SQL explain plan failed: %w", err)
+		}
+	}
+
+	return parseSQLExplainPlan(resp.Body, sqlQuery)
+}
+
+func parseSQLExplainPlan(data []byte, query string) (*SQLExplainPlan, error) {
+	if len(data) == 0 {
+		return &SQLExplainPlan{Query: query}, nil
+	}
+
+	xmlStr := string(data)
+	// Strip common ADT namespace prefixes
+	xmlStr = strings.ReplaceAll(xmlStr, "datapreview:", "")
+
+	type planNode struct {
+		XMLName  xml.Name   `xml:"node"`
+		ID       int        `xml:"id,attr"`
+		Operator string     `xml:"operator,attr"`
+		Table    string     `xml:"tableName,attr"`
+		Index    string     `xml:"indexName,attr"`
+		Cost     float64    `xml:"cost,attr"`
+		Rows     int        `xml:"outputRowCount,attr"`
+		Children []planNode `xml:"node"`
+	}
+
+	type explainResult struct {
+		XMLName xml.Name   `xml:"explainResult"`
+		Nodes   []planNode `xml:"node"`
+	}
+
+	// Try structured XML first
+	var resp explainResult
+	if err := xml.Unmarshal([]byte(xmlStr), &resp); err != nil {
+		// If XML parsing fails, return the raw response as a single-node plan
+		return &SQLExplainPlan{
+			Query: query,
+			Nodes: []SQLPlanNode{
+				{
+					ID:       0,
+					Operator: "RAW_RESPONSE",
+					Table:    truncate(string(data), 500),
+				},
+			},
+		}, nil
+	}
+
+	plan := &SQLExplainPlan{Query: query}
+	var convertNodes func(nodes []planNode) []SQLPlanNode
+	convertNodes = func(nodes []planNode) []SQLPlanNode {
+		var result []SQLPlanNode
+		for _, n := range nodes {
+			node := SQLPlanNode{
+				ID:       n.ID,
+				Operator: n.Operator,
+				Table:    n.Table,
+				Index:    n.Index,
+				Cost:     n.Cost,
+				Rows:     n.Rows,
+				Children: convertNodes(n.Children),
+			}
+			result = append(result, node)
+		}
+		return result
+	}
+
+	plan.Nodes = convertNodes(resp.Nodes)
+
+	// Calculate total cost from root nodes
+	for _, n := range plan.Nodes {
+		plan.TotalCost += n.Cost
+	}
+
+	return plan, nil
+}
+
+// --- Enhanced Check Run Results ---
+
+// CheckRunResult represents detailed results from a check run.
+type CheckRunResult struct {
+	CheckRunID string            `json:"checkRunId"`
+	Status     string            `json:"status"`
+	Messages   []CheckRunMessage `json:"messages"`
+	Summary    CheckRunSummary   `json:"summary"`
+}
+
+// CheckRunMessage represents a single message from a check run.
+type CheckRunMessage struct {
+	URI      string `json:"uri"`
+	Type     string `json:"type"`      // E=Error, W=Warning, I=Info
+	Line     int    `json:"line"`
+	Column   int    `json:"column"`
+	Text     string `json:"text"`
+	Category string `json:"category,omitempty"` // syntax, semantic, etc.
+}
+
+// CheckRunSummary contains summary counts of check results.
+type CheckRunSummary struct {
+	Errors   int `json:"errors"`
+	Warnings int `json:"warnings"`
+	Info     int `json:"info"`
+	Total    int `json:"total"`
+}
+
+// GetCheckRunResults retrieves detailed results for a specific check run.
+// checkRunID is typically from a SyntaxCheck or other check operation.
+func (c *Client) GetCheckRunResults(ctx context.Context, checkRunID string) (*CheckRunResult, error) {
+	if err := c.checkSafety(OpRead, "GetCheckRunResults"); err != nil {
+		return nil, err
+	}
+
+	path := fmt.Sprintf("/sap/bc/adt/checkruns/%s", url.PathEscape(checkRunID))
+
+	resp, err := c.transport.Request(ctx, path, &RequestOptions{
+		Method: http.MethodGet,
+		Accept: "application/xml",
+	})
+	if err != nil {
+		return nil, fmt.Errorf("get check run results failed: %w", err)
+	}
+
+	return parseCheckRunResult(resp.Body, checkRunID)
+}
+
+func parseCheckRunResult(data []byte, checkRunID string) (*CheckRunResult, error) {
+	if len(data) == 0 {
+		return &CheckRunResult{
+			CheckRunID: checkRunID,
+			Status:     "empty",
+		}, nil
+	}
+
+	xmlStr := string(data)
+	xmlStr = strings.ReplaceAll(xmlStr, "chkrun:", "")
+	xmlStr = strings.ReplaceAll(xmlStr, "adtcore:", "")
+
+	type checkMessage struct {
+		URI       string `xml:"uri,attr"`
+		Type      string `xml:"type,attr"`
+		Line      int    `xml:"line,attr"`
+		Column    int    `xml:"column,attr"`
+		ShortText string `xml:"shortText"`
+		Category  string `xml:"category,attr"`
+	}
+
+	type checkMessageList struct {
+		Messages []checkMessage `xml:"checkMessage"`
+	}
+
+	type checkReport struct {
+		URI         string           `xml:"uri,attr"`
+		Status      string           `xml:"status,attr"`
+		Reporter    string           `xml:"reporter,attr"`
+		MessageList checkMessageList `xml:"checkMessageList"`
+	}
+
+	type checkReports struct {
+		XMLName xml.Name      `xml:"checkRunReports"`
+		Reports []checkReport `xml:"checkReport"`
+	}
+
+	var resp checkReports
+	if err := xml.Unmarshal([]byte(xmlStr), &resp); err != nil {
+		return nil, fmt.Errorf("parsing check run results: %w", err)
+	}
+
+	result := &CheckRunResult{
+		CheckRunID: checkRunID,
+		Status:     "completed",
+	}
+
+	for _, report := range resp.Reports {
+		if report.Status != "" {
+			result.Status = report.Status
+		}
+		for _, msg := range report.MessageList.Messages {
+			crMsg := CheckRunMessage{
+				URI:      msg.URI,
+				Type:     msg.Type,
+				Line:     msg.Line,
+				Column:   msg.Column,
+				Text:     msg.ShortText,
+				Category: msg.Category,
+			}
+			result.Messages = append(result.Messages, crMsg)
+
+			switch msg.Type {
+			case "E":
+				result.Summary.Errors++
+			case "W":
+				result.Summary.Warnings++
+			case "I":
+				result.Summary.Info++
+			}
+			result.Summary.Total++
+		}
+	}
+
+	return result, nil
+}
+
+// truncate shortens a string to maxLen characters, appending "..." if truncated.
+func truncate(s string, maxLen int) string {
+	if len(s) <= maxLen {
+		return s
+	}
+	if maxLen <= 3 {
+		return s[:maxLen]
+	}
+	return s[:maxLen-3] + "..."
+}

--- a/pkg/adt/xml.go
+++ b/pkg/adt/xml.go
@@ -29,6 +29,7 @@ type Link struct {
 	Rel     string   `xml:"rel,attr"`
 	Type    string   `xml:"type,attr,omitempty"`
 	Title   string   `xml:"title,attr,omitempty"`
+	Name    string   `xml:"http://www.sap.com/adt/core name,attr,omitempty"` // adtcore:name attribute
 }
 
 // AtomEntry represents an Atom feed entry.
@@ -324,4 +325,65 @@ func ExtractSourceLink(links []Link) string {
 		}
 	}
 	return ""
+}
+
+// --- Revision (Version History) Types ---
+
+// Revision represents a single version of an ABAP object in the revision history.
+type Revision struct {
+	URI          string `json:"uri"`
+	Version      string `json:"version"`
+	VersionTitle string `json:"versionTitle"`
+	Date         string `json:"date"`
+	Author       string `json:"author"`
+	Transport    string `json:"transport,omitempty"`
+}
+
+type revisionFeedEntry struct {
+	XMLName xml.Name `xml:"entry"`
+	ID      string   `xml:"id"`
+	Title   string   `xml:"title"`
+	Updated string   `xml:"updated"`
+	Author  struct {
+		Name string `xml:"name"`
+	} `xml:"author"`
+	Content struct {
+		Src  string `xml:"src,attr"`
+		Type string `xml:"type,attr"`
+	} `xml:"content"`
+	Links []Link `xml:"link"`
+}
+
+type revisionFeed struct {
+	XMLName xml.Name            `xml:"feed"`
+	Title   string              `xml:"title"`
+	Entries []revisionFeedEntry `xml:"entry"`
+}
+
+// ParseRevisionFeed parses an ADT versions Atom feed into Revision entries.
+func ParseRevisionFeed(data []byte) ([]Revision, error) {
+	var feed revisionFeed
+	if err := xml.Unmarshal(data, &feed); err != nil {
+		return nil, fmt.Errorf("parsing revision feed: %w", err)
+	}
+	revisions := make([]Revision, 0, len(feed.Entries))
+	for _, entry := range feed.Entries {
+		rev := Revision{
+			URI:          entry.Content.Src,
+			VersionTitle: entry.Title,
+			Date:         entry.Updated,
+			Version:      entry.ID,
+			Author:       entry.Author.Name,
+		}
+		for _, link := range entry.Links {
+			if strings.Contains(link.Type, "transportrequests") {
+				if link.Name != "" {
+					rev.Transport = link.Name
+				}
+				break
+			}
+		}
+		revisions = append(revisions, rev)
+	}
+	return revisions, nil
 }


### PR DESCRIPTION
## Summary

Add server-side intelligence tools for automated code review and analysis — 4 new tools with 46 unit tests:

- **AnalyzeSQLPerformance** — text-based SQL analysis (SELECT *, missing WHERE, CLIENT SPECIFIED) + HANA execution plan analysis (full table scans, nested loops, missing indexes)
- **GetImpactAnalysis** — 4-layer blast radius analysis:
  - Layer 1: static cross-references (FindReferences)
  - Layer 2: transitive callers (call graph)
  - Layer 3: dynamic call risk (string literal search)
  - Layer 4: config-driven calls (BAdI, enhancements, user exits)
- **AnalyzeABAPCode** — 21-rule source analysis across 4 categories (performance, security, robustness, quality) with two-pass statement assembler
- **CheckRegression** — diff-based breaking change detection (method signatures, removed public methods, interface changes, RAISING clauses)

**Note:** This PR includes `revisions.go` and `testing.go` as dependencies (used by CheckRegression and AnalyzeSQLPerformance respectively). If PR #2 and PR #3 are merged first, these files can be dropped from this PR.

## Files

| File | Lines | Description |
|------|-------|-------------|
| `pkg/adt/codeanalysis.go` | 835 | 21-rule ABAP code analyzer |
| `pkg/adt/codeanalysis_test.go` | 414 | Tests for code analysis rules |
| `pkg/adt/sqlperf.go` | 356 | SQL performance analyzer (text + plan) |
| `pkg/adt/sqlperf_test.go` | 317 | Tests for SQL analysis |
| `pkg/adt/impact.go` | 374 | 4-layer impact analysis |
| `pkg/adt/impact_test.go` | 250 | Tests for impact analysis |
| `pkg/adt/regression.go` | 358 | Breaking change detector |
| `pkg/adt/regression_test.go` | 276 | Tests for regression detection |
| `pkg/adt/revisions.go` | 193 | (dependency) Version history |
| `pkg/adt/testing.go` | 440 | (dependency) SQL explain plan types |
| `pkg/adt/xml.go` | +62 | Revision types for regression detection |
| `internal/mcp/handlers_intelligence.go` | 85 | Handlers for impact + regression |
| `internal/mcp/handlers_codeanalysis.go` | 56 | Handlers for code + SQL analysis |
| `internal/mcp/tools_register.go` | +71 | Tool registration |
| `internal/mcp/tools_focused.go` | +6 | Focused mode whitelist |

## Architecture

All 4 tools run analysis **server-side in Go** — no SAP roundtrip needed for most rules. Only `GetImpactAnalysis` and `CheckRegression` call ADT APIs for cross-references and version history.

The code analysis rules are intentionally conservative (low false-positive rate) and focus on patterns that are unambiguously problematic in ABAP.

## Test plan

- [x] `go build ./cmd/vsp` compiles clean
- [x] `go test ./pkg/adt/` — 46 new tests pass, no regressions
- [ ] Integration test with SAP system (for Layer 1-2 of impact analysis)