### PR TITLE
feat: SAML SSO authentication for S/4HANA Public Cloud

### DIFF
--- a/cmd/vsp/main.go
+++ b/cmd/vsp/main.go
@@ -522,7 +522,7 @@ func processBrowserAuth(cmd *cobra.Command) error {
 		browserExec = viper.GetString("BROWSER_EXEC")
 	}
 
-	ctx := context.Background()
+	ctx := cmd.Context()
 	cookies, err := adt.BrowserLogin(ctx, cfg.BaseURL, cfg.InsecureSkipVerify, timeout, browserExec, cfg.Verbose)
 	if err != nil {
 		return fmt.Errorf("browser authentication failed: %w", err)
@@ -612,7 +612,7 @@ func processSAMLAuth(cmd *cobra.Command) error {
 		}
 	}
 
-	ctx := context.Background()
+	ctx := cmd.Context()
 	cookies, err := adt.SAMLLogin(ctx, cfg.BaseURL, credProvider, cfg.InsecureSkipVerify, cfg.Verbose)
 	if err != nil {
 		return fmt.Errorf("SAML authentication failed: %w", err)

--- a/cmd/vsp/main.go
+++ b/cmd/vsp/main.go
@@ -112,6 +112,11 @@ func init() {
 	rootCmd.Flags().String("browser-exec", "", "Path to Chromium-based browser (default: auto-detect Edge, Chrome, Chromium)")
 	rootCmd.Flags().String("cookie-save", "", "Save browser auth cookies to file for reuse with --cookie-file")
 
+	// Programmatic SAML SSO authentication (no browser required)
+	rootCmd.Flags().Bool("saml-auth", false, "Authenticate via programmatic SAML SSO (no browser, no MFA)")
+	rootCmd.Flags().String("saml-user", "", "SAML/IAS username (email)")
+	rootCmd.Flags().String("saml-password", "", "SAML/IAS password")
+
 	// Session keep-alive
 	rootCmd.Flags().Duration("keepalive", 5*time.Minute, "Session keep-alive interval (e.g., 60s, 5m). Prevents session timeout during idle periods. 0 = disabled")
 
@@ -160,6 +165,9 @@ func init() {
 	viper.BindPFlag("cookie-string", rootCmd.Flags().Lookup("cookie-string"))
 	viper.BindPFlag("browser-auth", rootCmd.Flags().Lookup("browser-auth"))
 	viper.BindPFlag("browser-auth-timeout", rootCmd.Flags().Lookup("browser-auth-timeout"))
+	viper.BindPFlag("saml-auth", rootCmd.Flags().Lookup("saml-auth"))
+	viper.BindPFlag("saml-user", rootCmd.Flags().Lookup("saml-user"))
+	viper.BindPFlag("saml-password", rootCmd.Flags().Lookup("saml-password"))
 	viper.BindPFlag("browser-exec", rootCmd.Flags().Lookup("browser-exec"))
 	viper.BindPFlag("cookie-save", rootCmd.Flags().Lookup("cookie-save"))
 	viper.BindPFlag("keepalive", rootCmd.Flags().Lookup("keepalive"))
@@ -207,6 +215,11 @@ func runServer(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
+	// Programmatic SAML SSO authentication (must run before processCookieAuth)
+	if err := processSAMLAuth(cmd); err != nil {
+		return err
+	}
+
 	// Process cookie authentication
 	if err := processCookieAuth(cmd); err != nil {
 		return err
@@ -223,6 +236,8 @@ func runServer(cmd *cobra.Command, args []string) error {
 		fmt.Fprintf(os.Stderr, "[VERBOSE] SAP Language: %s\n", cfg.Language)
 		if cfg.Username != "" {
 			fmt.Fprintf(os.Stderr, "[VERBOSE] Auth: Basic (user: %s)\n", cfg.Username)
+		} else if cfg.ReauthFunc != nil {
+			fmt.Fprintf(os.Stderr, "[VERBOSE] Auth: SAML (%d cookies, re-auth on 401)\n", len(cfg.Cookies))
 		} else if len(cfg.Cookies) > 0 {
 			fmt.Fprintf(os.Stderr, "[VERBOSE] Auth: Cookie (%d cookies)\n", len(cfg.Cookies))
 		}
@@ -306,7 +321,9 @@ func resolveConfig(cmd *cobra.Command) {
 	cookieAuthViaEnv := viper.GetString("COOKIE_FILE") != "" || viper.GetString("COOKIE_STRING") != ""
 	browserAuth, _ := cmd.Flags().GetBool("browser-auth")
 	hasBrowserAuth := browserAuth || viper.GetBool("BROWSER_AUTH")
-	hasCookieAuth := cookieAuthViaCLI || cookieAuthViaEnv || hasBrowserAuth
+	samlAuth, _ := cmd.Flags().GetBool("saml-auth")
+	hasSAMLAuth := samlAuth || viper.GetBool("SAML_AUTH")
+	hasCookieAuth := cookieAuthViaCLI || cookieAuthViaEnv || hasBrowserAuth || hasSAMLAuth
 
 	// URL: flag > SAP_URL env
 	if cfg.BaseURL == "" {
@@ -526,6 +543,74 @@ func processBrowserAuth(cmd *cobra.Command) error {
 	return nil
 }
 
+func processSAMLAuth(cmd *cobra.Command) error {
+	samlAuth, _ := cmd.Flags().GetBool("saml-auth")
+	if !samlAuth && !viper.GetBool("SAML_AUTH") {
+		return nil
+	}
+
+	if cfg.BaseURL == "" {
+		return fmt.Errorf("--saml-auth requires --url to be set")
+	}
+
+	samlUser, _ := cmd.Flags().GetString("saml-user")
+	if samlUser == "" {
+		samlUser = viper.GetString("SAML_USER")
+	}
+	samlPassword, _ := cmd.Flags().GetString("saml-password")
+	if samlPassword == "" {
+		samlPassword = viper.GetString("SAML_PASSWORD")
+	}
+
+	if samlUser == "" || samlPassword == "" {
+		return fmt.Errorf("--saml-auth requires --saml-user and --saml-password (or SAP_SAML_USER / SAP_SAML_PASSWORD env vars)")
+	}
+
+	// Build credential provider that re-reads env vars on each call.
+	// This supports credential rotation and avoids long-term retention.
+	flagUser := samlUser
+	flagPassword := samlPassword
+	credProvider := func(ctx context.Context) ([]byte, []byte, error) {
+		u := os.Getenv("SAP_SAML_USER")
+		if u == "" {
+			u = flagUser
+		}
+		p := os.Getenv("SAP_SAML_PASSWORD")
+		if p == "" {
+			p = flagPassword
+		}
+		return []byte(u), []byte(p), nil
+	}
+
+	ctx := context.Background()
+	cookies, err := adt.SAMLLogin(ctx, cfg.BaseURL, credProvider, cfg.InsecureSkipVerify, cfg.Verbose)
+	if err != nil {
+		return fmt.Errorf("SAML authentication failed: %w", err)
+	}
+
+	cfg.Cookies = cookies
+
+	// Set re-auth function for 401 recovery.
+	cfg.ReauthFunc = func(ctx context.Context) (map[string]string, error) {
+		return adt.SAMLLogin(ctx, cfg.BaseURL, credProvider, cfg.InsecureSkipVerify, cfg.Verbose)
+	}
+
+	// Save cookies if requested.
+	cookieSave, _ := cmd.Flags().GetString("cookie-save")
+	if cookieSave == "" {
+		cookieSave = viper.GetString("COOKIE_SAVE")
+	}
+	if cookieSave != "" {
+		if err := adt.SaveCookiesToFile(cookies, cfg.BaseURL, cookieSave); err != nil {
+			fmt.Fprintf(os.Stderr, "[SAML-AUTH] Warning: failed to save cookies: %v\n", err)
+		} else {
+			fmt.Fprintf(os.Stderr, "[SAML-AUTH] Cookies saved to %s (reuse with --cookie-file)\n", cookieSave)
+		}
+	}
+
+	return nil
+}
+
 func processCookieAuth(cmd *cobra.Command) error {
 	cookieFile, _ := cmd.Flags().GetString("cookie-file")
 	cookieString, _ := cmd.Flags().GetString("cookie-string")
@@ -555,11 +640,11 @@ func processCookieAuth(cmd *cobra.Command) error {
 	}
 
 	if authMethods > 1 {
-		return fmt.Errorf("only one authentication method can be used at a time (basic auth, cookie-file, cookie-string, or browser-auth)")
+		return fmt.Errorf("only one authentication method can be used at a time (basic auth, cookie-file, cookie-string, browser-auth, or saml-auth)")
 	}
 
 	if authMethods == 0 {
-		return fmt.Errorf("authentication required. Use --user/--password, --cookie-file, --cookie-string, or --browser-auth")
+		return fmt.Errorf("authentication required. Use --user/--password, --cookie-file, --cookie-string, --browser-auth, or --saml-auth")
 	}
 
 	// If cookies already set by browser auth, we're done

--- a/cmd/vsp/main.go
+++ b/cmd/vsp/main.go
@@ -116,6 +116,8 @@ func init() {
 	rootCmd.Flags().Bool("saml-auth", false, "Authenticate via programmatic SAML SSO (no browser, no MFA)")
 	rootCmd.Flags().String("saml-user", "", "SAML/IAS username (email)")
 	rootCmd.Flags().String("saml-password", "", "SAML/IAS password")
+	rootCmd.Flags().String("credential-cmd", "", "External command returning JSON {\"username\":...,\"password\":...} (space-separated argv, no shell)")
+
 
 	// Session keep-alive
 	rootCmd.Flags().Duration("keepalive", 5*time.Minute, "Session keep-alive interval (e.g., 60s, 5m). Prevents session timeout during idle periods. 0 = disabled")
@@ -168,6 +170,7 @@ func init() {
 	viper.BindPFlag("saml-auth", rootCmd.Flags().Lookup("saml-auth"))
 	viper.BindPFlag("saml-user", rootCmd.Flags().Lookup("saml-user"))
 	viper.BindPFlag("saml-password", rootCmd.Flags().Lookup("saml-password"))
+	viper.BindPFlag("credential-cmd", rootCmd.Flags().Lookup("credential-cmd"))
 	viper.BindPFlag("browser-exec", rootCmd.Flags().Lookup("browser-exec"))
 	viper.BindPFlag("cookie-save", rootCmd.Flags().Lookup("cookie-save"))
 	viper.BindPFlag("keepalive", rootCmd.Flags().Lookup("keepalive"))
@@ -553,33 +556,60 @@ func processSAMLAuth(cmd *cobra.Command) error {
 		return fmt.Errorf("--saml-auth requires --url to be set")
 	}
 
-	samlUser, _ := cmd.Flags().GetString("saml-user")
-	if samlUser == "" {
-		samlUser = viper.GetString("SAML_USER")
-	}
-	samlPassword, _ := cmd.Flags().GetString("saml-password")
-	if samlPassword == "" {
-		samlPassword = viper.GetString("SAML_PASSWORD")
+	// Resolve credential source. Priority: credential-cmd > env vars > flags.
+	credCmdStr, _ := cmd.Flags().GetString("credential-cmd")
+	if credCmdStr == "" {
+		credCmdStr = viper.GetString("CREDENTIAL_CMD")
+		if credCmdStr != "" && cfg.Verbose {
+			fmt.Fprintf(os.Stderr, "[SAML-AUTH] Warning: credential-cmd sourced from environment variable\n")
+		}
 	}
 
-	if samlUser == "" || samlPassword == "" {
-		return fmt.Errorf("--saml-auth requires --saml-user and --saml-password (or SAP_SAML_USER / SAP_SAML_PASSWORD env vars)")
-	}
+	var credProvider adt.CredentialProvider
 
-	// Build credential provider that re-reads env vars on each call.
-	// This supports credential rotation and avoids long-term retention.
-	flagUser := samlUser
-	flagPassword := samlPassword
-	credProvider := func(ctx context.Context) ([]byte, []byte, error) {
-		u := os.Getenv("SAP_SAML_USER")
-		if u == "" {
-			u = flagUser
+	if credCmdStr != "" {
+		// Credential command mode: parse and execute external command on each auth.
+		credArgs := adt.ParseCredentialCmd(credCmdStr)
+		if len(credArgs) == 0 {
+			return fmt.Errorf("--credential-cmd: empty command after parsing")
 		}
-		p := os.Getenv("SAP_SAML_PASSWORD")
-		if p == "" {
-			p = flagPassword
+		credProvider = func(ctx context.Context) ([]byte, []byte, error) {
+			user, pass, err := adt.RunCredentialCmd(ctx, credArgs, cfg.Verbose)
+			if err != nil {
+				return nil, nil, err
+			}
+			return []byte(user), []byte(pass), nil
 		}
-		return []byte(u), []byte(p), nil
+	} else {
+		// Direct credentials mode: env vars > flags.
+		samlUser, _ := cmd.Flags().GetString("saml-user")
+		if samlUser == "" {
+			samlUser = viper.GetString("SAML_USER")
+		}
+		samlPassword, _ := cmd.Flags().GetString("saml-password")
+		if samlPassword == "" {
+			samlPassword = viper.GetString("SAML_PASSWORD")
+		}
+
+		if samlUser == "" || samlPassword == "" {
+			return fmt.Errorf("--saml-auth requires credentials: use --credential-cmd, --saml-user/--saml-password, or SAP_SAML_USER/SAP_SAML_PASSWORD env vars")
+		}
+
+		// Build credential provider that re-reads env vars on each call.
+		// This supports credential rotation and avoids long-term retention.
+		flagUser := samlUser
+		flagPassword := samlPassword
+		credProvider = func(ctx context.Context) ([]byte, []byte, error) {
+			u := os.Getenv("SAP_SAML_USER")
+			if u == "" {
+				u = flagUser
+			}
+			p := os.Getenv("SAP_SAML_PASSWORD")
+			if p == "" {
+				p = flagPassword
+			}
+			return []byte(u), []byte(p), nil
+		}
 	}
 
 	ctx := context.Background()

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,6 @@
 module github.com/oisee/vibing-steampunk
 
-go 1.24.0
-
-toolchain go1.24.10
+go 1.25.0
 
 require (
 	github.com/chromedp/cdproto v0.0.0-20250803210736-d308e07a266d
@@ -15,6 +13,7 @@ require (
 	github.com/spf13/viper v1.21.0
 	github.com/tetratelabs/wazero v1.11.0
 	github.com/yuin/gopher-lua v1.1.1
+	golang.org/x/net v0.52.0
 	gopkg.in/yaml.v3 v3.0.1
 )
 
@@ -38,6 +37,6 @@ require (
 	github.com/subosito/gotenv v1.6.0 // indirect
 	github.com/yosida95/uritemplate/v3 v3.0.2 // indirect
 	go.yaml.in/yaml/v3 v3.0.4 // indirect
-	golang.org/x/sys v0.38.0 // indirect
-	golang.org/x/text v0.28.0 // indirect
+	golang.org/x/sys v0.42.0 // indirect
+	golang.org/x/text v0.35.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -79,11 +79,13 @@ github.com/yuin/gopher-lua v1.1.1 h1:kYKnWBjvbNP4XLT3+bPEwAXJx262OhaHDWDVOPjL46M
 github.com/yuin/gopher-lua v1.1.1/go.mod h1:GBR0iDaNXjAgGg9zfCvksxSRnQx76gclCIb7kdAd1Pw=
 go.yaml.in/yaml/v3 v3.0.4 h1:tfq32ie2Jv2UxXFdLJdh3jXuOzWiL1fo0bu/FbuKpbc=
 go.yaml.in/yaml/v3 v3.0.4/go.mod h1:DhzuOOF2ATzADvBadXxruRBLzYTpT36CKvDb3+aBEFg=
+golang.org/x/net v0.52.0 h1:He/TN1l0e4mmR3QqHMT2Xab3Aj3L9qjbhRm78/6jrW0=
+golang.org/x/net v0.52.0/go.mod h1:R1MAz7uMZxVMualyPXb+VaqGSa3LIaUqk0eEt3w36Sw=
 golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.38.0 h1:3yZWxaJjBmCWXqhN1qh02AkOnCQ1poK6oF+a7xWL6Gc=
-golang.org/x/sys v0.38.0/go.mod h1:OgkHotnGiDImocRcuBABYBEXf8A9a87e/uXjp9XT3ks=
-golang.org/x/text v0.28.0 h1:rhazDwis8INMIwQ4tpjLDzUhx6RlXqZNPEM0huQojng=
-golang.org/x/text v0.28.0/go.mod h1:U8nCwOR8jO/marOQ0QbDiOngZVEBB7MAiitBuMjXiNU=
+golang.org/x/sys v0.42.0 h1:omrd2nAlyT5ESRdCLYdm3+fMfNFE/+Rf4bDIQImRJeo=
+golang.org/x/sys v0.42.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
+golang.org/x/text v0.35.0 h1:JOVx6vVDFokkpaq1AEptVzLTpDe9KGpj5tR4/X+ybL8=
+golang.org/x/text v0.35.0/go.mod h1:khi/HExzZJ2pGnjenulevKNX1W67CUy0AsXcNubPGCA=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 h1:YR8cESwS4TdDjEe65xsg0ogRM/Nc3DYOhEAlW+xobZo=
 gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -90,6 +90,10 @@ type Config struct {
 	// Debugger configuration
 	TerminalID string // SAP GUI terminal ID for cross-tool breakpoint sharing
 
+	// ReauthFunc is called on 401 to re-authenticate (e.g., re-run SAML dance).
+	// Returns fresh cookies. Passed through to adt.Config.
+	ReauthFunc func(ctx context.Context) (map[string]string, error)
+
 	// Session keep-alive interval (0 = disabled)
 	// Sends periodic pings to prevent session timeout during idle periods.
 	// Useful for cookie/browser-auth where sessions expire server-side.
@@ -121,6 +125,9 @@ func NewServer(cfg *Config) *Server {
 	}
 	if cfg.Verbose {
 		opts = append(opts, adt.WithVerbose())
+	}
+	if cfg.ReauthFunc != nil {
+		opts = append(opts, adt.WithReauthFunc(cfg.ReauthFunc))
 	}
 
 	// Configure safety settings

--- a/pkg/adt/browser_auth.go
+++ b/pkg/adt/browser_auth.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/chromedp/cdproto/network"
+	"github.com/chromedp/cdproto/page"
 	"github.com/chromedp/chromedp"
 )
 
@@ -114,7 +115,12 @@ func BrowserLogin(ctx context.Context, sapURL string, insecure bool, timeout tim
 	// We use the ADT root which returns an HTML page after auth.
 	// The /sap/bc/adt/core/discovery endpoint returns XML which browsers
 	// try to download as a file, breaking the flow.
-	targetURL := strings.TrimRight(sapURL, "/") + "/sap/bc/adt/"
+	// Build from parsed URL to handle sapURL with query/fragment correctly.
+	adtURL := *u
+	adtURL.Path = "/sap/bc/adt/"
+	adtURL.RawQuery = ""
+	adtURL.Fragment = ""
+	targetURL := adtURL.String()
 
 	// Create a headed (non-headless) browser context
 	opts := append(chromedp.DefaultExecAllocatorOptions[:],
@@ -172,6 +178,26 @@ func BrowserLogin(ctx context.Context, sapURL string, insecure bool, timeout tim
 	fmt.Fprintf(os.Stderr, "[BROWSER-AUTH] Opening %s for SSO login: %s\n", browserName, targetURL)
 	fmt.Fprintf(os.Stderr, "[BROWSER-AUTH] Complete login in the browser window. Timeout: %s\n", timeout)
 
+	// In verbose mode, listen for navigation events to track SAML redirect chain.
+	// This logs URL path + host for each redirect hop — never cookie values or SAML assertion bodies.
+	// Query parameters are stripped to prevent leaking SAMLRequest/SAMLResponse in redirect-binding flows.
+	if verbose {
+		chromedp.ListenTarget(timeoutCtx, func(ev any) {
+			switch e := ev.(type) {
+			case *page.EventFrameNavigated:
+				if e.Frame != nil && e.Frame.URL != "" {
+					safeURL := sanitizeURLForLog(e.Frame.URL)
+					fmt.Fprintf(os.Stderr, "[BROWSER-AUTH] Navigated → %s\n", safeURL)
+				}
+			case *network.EventResponseReceived:
+				if e.Response != nil && e.Response.Status >= 300 && e.Response.Status < 400 {
+					safeURL := sanitizeURLForLog(e.Response.URL)
+					fmt.Fprintf(os.Stderr, "[BROWSER-AUTH] Redirect %d → %s\n", e.Response.Status, safeURL)
+				}
+			}
+		})
+	}
+
 	// Navigate to the target URL (this triggers SSO redirect).
 	// SSO flows (Kerberos 401, SAML redirect, etc.) often cause the initial
 	// navigation to report ERR_ABORTED or similar — this is expected.
@@ -208,16 +234,28 @@ func BrowserLogin(ctx context.Context, sapURL string, insecure bool, timeout tim
 	return cookies, nil
 }
 
-// pollForSAPCookies polls the browser for SAP-specific cookies at 1-second intervals.
+// samlPollInterval is the cookie polling interval.
+// SAML SSO flows involve multi-hop redirects (SAP → IAS → SAP) that can take
+// several seconds. A 500ms interval provides responsive detection without
+// excessive CDP calls.
+const samlPollInterval = 500 * time.Millisecond
+
+// pollForSAPCookies polls the browser for SAP-specific cookies.
+// It uses a faster poll interval (500ms) for responsive SAML cookie detection
+// and logs each poll cycle in verbose mode for debugging redirect chains.
 func pollForSAPCookies(ctx context.Context, sapURL string, verbose bool) (map[string]string, error) {
-	ticker := time.NewTicker(1 * time.Second)
+	ticker := time.NewTicker(samlPollInterval)
 	defer ticker.Stop()
 
+	start := time.Now()
 	pollCount := 0
+	lastCookieCount := -1
+
 	for {
 		select {
 		case <-ctx.Done():
-			return nil, fmt.Errorf("browser auth timed out — login was not completed in time")
+			elapsed := time.Since(start)
+			return nil, fmt.Errorf("browser auth timed out after %s — login was not completed in time", elapsed.Truncate(time.Second))
 		case <-ticker.C:
 			pollCount++
 			cookies, found, err := extractSAPCookies(ctx, sapURL)
@@ -226,22 +264,69 @@ func pollForSAPCookies(ctx context.Context, sapURL string, verbose bool) (map[st
 					return nil, fmt.Errorf("browser was closed before authentication completed")
 				}
 				if verbose {
-					fmt.Fprintf(os.Stderr, "[BROWSER-AUTH] Poll #%d: error reading cookies: %v\n", pollCount, err)
+					fmt.Fprintf(os.Stderr, "[BROWSER-AUTH] Poll #%d (%.1fs): error reading cookies: %v\n",
+						pollCount, time.Since(start).Seconds(), err)
 				}
 				continue
 			}
-			if verbose {
+
+			// Log in verbose mode, but only when cookie count changes or periodically
+			if verbose && (len(cookies) != lastCookieCount || pollCount%10 == 0) {
 				names := make([]string, 0, len(cookies))
 				for name := range cookies {
 					names = append(names, name)
 				}
-				fmt.Fprintf(os.Stderr, "[BROWSER-AUTH] Poll #%d: %d cookies [%s]\n", pollCount, len(cookies), strings.Join(names, ", "))
+				fmt.Fprintf(os.Stderr, "[BROWSER-AUTH] Poll #%d (%.1fs): %d cookies [%s]\n",
+					pollCount, time.Since(start).Seconds(), len(cookies), strings.Join(names, ", "))
+				lastCookieCount = len(cookies)
 			}
+
 			if found {
+				if verbose {
+					fmt.Fprintf(os.Stderr, "[BROWSER-AUTH] Auth cookies detected after %d polls (%.1fs)\n",
+						pollCount, time.Since(start).Seconds())
+				}
 				return cookies, nil
 			}
 		}
 	}
+}
+
+// sanitizeURLForLog returns a URL safe for verbose logging.
+// It strips query parameters to prevent leaking SAMLRequest/SAMLResponse
+// values that may appear in redirect-binding flows. Returns "scheme://host/path".
+func sanitizeURLForLog(rawURL string) string {
+	parsed, err := url.Parse(rawURL)
+	if err != nil {
+		return "(unparseable URL)"
+	}
+	// Reconstruct without query or fragment — only scheme + host + path
+	safe := fmt.Sprintf("%s://%s%s", parsed.Scheme, parsed.Host, parsed.Path)
+	return safe
+}
+
+// cookieURLsForSAP returns the set of URLs to query for cookies.
+// SAML SSO flows often set cookies scoped to specific paths (e.g. /sap/bc/adt/)
+// rather than the root domain. Querying multiple URL paths ensures we capture
+// cookies regardless of their path scope.
+// Uses proper URL parsing to handle sapURL with query/fragment correctly.
+func cookieURLsForSAP(sapURL string) []string {
+	u, err := url.Parse(sapURL)
+	if err != nil || u.Scheme == "" || u.Host == "" {
+		return []string{sapURL}
+	}
+	u.RawQuery = ""
+	u.Fragment = ""
+	base := *u
+
+	paths := []string{"", "/sap/", "/sap/bc/", "/sap/bc/adt/"}
+	urls := make([]string, 0, len(paths))
+	for _, p := range paths {
+		tmp := base
+		tmp.Path = p
+		urls = append(urls, tmp.String())
+	}
+	return urls
 }
 
 // extractSAPCookies retrieves all cookies from the browser and checks for SAP auth cookies.
@@ -250,9 +335,10 @@ func extractSAPCookies(ctx context.Context, sapURL string) (map[string]string, b
 
 	if err := chromedp.Run(ctx, chromedp.ActionFunc(func(ctx context.Context) error {
 		var err error
-		// Request cookies for the SAP URL explicitly, so they are returned
-		// even when the browser page is in a download/redirect state.
-		browserCookies, err = network.GetCookies().WithURLs([]string{sapURL}).Do(ctx)
+		// Request cookies for multiple SAP URL paths explicitly.
+		// SAML flows may set cookies scoped to /sap/bc/adt/ or /sap/bc/
+		// rather than the root, so we query all relevant paths.
+		browserCookies, err = network.GetCookies().WithURLs(cookieURLsForSAP(sapURL)).Do(ctx)
 		return err
 	})); err != nil {
 		return nil, false, err
@@ -275,6 +361,27 @@ func extractSAPCookies(ctx context.Context, sapURL string) (map[string]string, b
 	}
 
 	return result, hasAuthCookie, nil
+}
+
+// matchesSAPAuthCookie checks whether a cookie name matches any known SAP auth cookie prefix.
+// Exported as a testable helper for unit tests.
+func matchesSAPAuthCookie(name string) bool {
+	for _, prefix := range sapAuthCookieNames {
+		if strings.HasPrefix(name, prefix) {
+			return true
+		}
+	}
+	return false
+}
+
+// matchesSAPWeakCookie checks whether a cookie name matches any known SAP weak cookie prefix.
+func matchesSAPWeakCookie(name string) bool {
+	for _, prefix := range sapWeakCookieNames {
+		if strings.HasPrefix(name, prefix) {
+			return true
+		}
+	}
+	return false
 }
 
 // SaveCookiesToFile writes cookies in Netscape cookie file format.

--- a/pkg/adt/browser_auth_integration_test.go
+++ b/pkg/adt/browser_auth_integration_test.go
@@ -131,25 +131,32 @@ func TestBrowserAuth_SAMLRedirectChain(t *testing.T) {
 }
 
 // TestBrowserAuth_PollDetectsCookies verifies that pollForSAPCookies
-// correctly detects cookies that appear after a delay (simulating slow
-// SAML redirect chains).
+// correctly detects cookies that appear after a delayed redirect chain
+// (simulating slow SAML IdP responses).
+//
+// The test uses a multi-step redirect: initial page → delayed redirect →
+// final page that sets cookies. This ensures cookies land in the browser's
+// cookie jar where network.GetCookies (CDP) can read them.
 func TestBrowserAuth_PollDetectsCookies(t *testing.T) {
-	// Server that sets auth cookies only on the second request to /check
-	requestCount := 0
 	mux := http.NewServeMux()
 
+	// Step 1: Initial page with a meta-refresh that triggers a delayed redirect.
+	// This simulates a slow IAS login page that eventually redirects.
 	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
-		requestCount++
-		if requestCount >= 3 {
-			// After a few requests, set auth cookies (simulates delayed SAML completion)
-			http.SetCookie(w, &http.Cookie{
-				Name:  "MYSAPSSO2",
-				Value: "delayed_sso_token",
-				Path:  "/",
-			})
-		}
 		w.WriteHeader(http.StatusOK)
-		fmt.Fprint(w, "<html><body>Loading...</body></html>")
+		// Meta-refresh after 1 second to simulate delayed SAML redirect
+		fmt.Fprint(w, `<html><head><meta http-equiv="refresh" content="1;url=/auth-complete"></head><body>Authenticating...</body></html>`)
+	})
+
+	// Step 2: Auth complete — sets SAP cookies
+	mux.HandleFunc("/auth-complete", func(w http.ResponseWriter, r *http.Request) {
+		http.SetCookie(w, &http.Cookie{
+			Name:  "MYSAPSSO2",
+			Value: "delayed_sso_token",
+			Path:  "/",
+		})
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprint(w, "<html><body>Welcome</body></html>")
 	})
 
 	ts := httptest.NewServer(mux)
@@ -174,19 +181,19 @@ func TestBrowserAuth_PollDetectsCookies(t *testing.T) {
 	ctx, cancel := context.WithTimeout(browserCtx, 15*time.Second)
 	defer cancel()
 
-	// Navigate to the test server
+	// Navigate to the test server (triggers delayed redirect)
 	if err := chromedp.Run(ctx, chromedp.Navigate(ts.URL)); err != nil {
 		t.Fatalf("navigation failed: %v", err)
 	}
 
-	// Poll for cookies — should eventually find MYSAPSSO2
+	// Poll for cookies — should eventually find MYSAPSSO2 after the meta-refresh
 	cookies, err := pollForSAPCookies(ctx, ts.URL, true)
 	if err != nil {
 		t.Fatalf("pollForSAPCookies failed: %v", err)
 	}
 
 	if _, ok := cookies["MYSAPSSO2"]; !ok {
-		t.Error("expected MYSAPSSO2 cookie to be found by polling")
+		t.Error("expected MYSAPSSO2 cookie to be found by polling after delayed redirect")
 	}
 }
 

--- a/pkg/adt/browser_auth_integration_test.go
+++ b/pkg/adt/browser_auth_integration_test.go
@@ -1,0 +1,200 @@
+//go:build integration
+
+package adt
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/chromedp/chromedp"
+)
+
+// TestBrowserAuth_SAMLRedirectChain simulates a SAML-like redirect chain
+// with an httptest server and verifies that extractSAPCookies correctly
+// captures session cookies after multi-hop redirects.
+//
+// Run with: go test -tags=integration -run TestBrowserAuth_SAMLRedirectChain -v ./pkg/adt/
+//
+// Requires a Chromium-based browser installed (Edge, Chrome, Chromium).
+func TestBrowserAuth_SAMLRedirectChain(t *testing.T) {
+	// Create a test server simulating SAML SSO:
+	// GET /sap/bc/adt/ → 302 to /saml/idp (simulates SAP→IAS redirect)
+	// GET /saml/idp → 302 to /saml/callback?SAMLResponse=mock (simulates IAS→SAP)
+	// GET /saml/callback → sets MYSAPSSO2 + SAP_SESSIONID cookies, returns 200
+	mux := http.NewServeMux()
+
+	mux.HandleFunc("/sap/bc/adt/", func(w http.ResponseWriter, r *http.Request) {
+		// Step 1: SAP redirects to IAS for SAML authentication
+		http.Redirect(w, r, "/saml/idp", http.StatusFound)
+	})
+
+	mux.HandleFunc("/saml/idp", func(w http.ResponseWriter, r *http.Request) {
+		// Step 2: IAS "authenticates" and redirects back with SAMLResponse
+		http.Redirect(w, r, "/saml/callback?SAMLResponse=mock_assertion", http.StatusFound)
+	})
+
+	mux.HandleFunc("/saml/callback", func(w http.ResponseWriter, r *http.Request) {
+		// Step 3: SAP processes SAMLResponse and sets session cookies
+		http.SetCookie(w, &http.Cookie{
+			Name:  "MYSAPSSO2",
+			Value: "test_sso_token_abc123",
+			Path:  "/",
+		})
+		http.SetCookie(w, &http.Cookie{
+			Name:  "SAP_SESSIONID_TST_001",
+			Value: "test_session_xyz789",
+			Path:  "/sap/bc/",
+		})
+		http.SetCookie(w, &http.Cookie{
+			Name:  "sap-usercontext",
+			Value: "sap-client=001",
+			Path:  "/sap/",
+		})
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprint(w, "<html><body>ADT Welcome Page</body></html>")
+	})
+
+	ts := httptest.NewServer(mux)
+	defer ts.Close()
+
+	// Create headless browser context
+	opts := append(chromedp.DefaultExecAllocatorOptions[:],
+		chromedp.Flag("headless", true),
+		chromedp.Flag("disable-gpu", true),
+		chromedp.Flag("no-sandbox", true),
+	)
+
+	// Use auto-detected browser
+	if found, _ := FindBrowser(); found != "" {
+		opts = append(opts, chromedp.ExecPath(found))
+	}
+
+	allocCtx, allocCancel := chromedp.NewExecAllocator(context.Background(), opts...)
+	defer allocCancel()
+
+	browserCtx, browserCancel := chromedp.NewContext(allocCtx)
+	defer browserCancel()
+
+	ctx, cancel := context.WithTimeout(browserCtx, 30*time.Second)
+	defer cancel()
+
+	// Navigate to the SAP ADT endpoint (triggers redirect chain)
+	targetURL := ts.URL + "/sap/bc/adt/"
+	if err := chromedp.Run(ctx, chromedp.Navigate(targetURL)); err != nil {
+		t.Fatalf("navigation failed: %v", err)
+	}
+
+	// Wait briefly for cookies to be set after redirect chain
+	time.Sleep(500 * time.Millisecond)
+
+	// Extract cookies using our function
+	cookies, hasAuth, err := extractSAPCookies(ctx, ts.URL)
+	if err != nil {
+		t.Fatalf("extractSAPCookies failed: %v", err)
+	}
+
+	// Verify auth cookie detection
+	if !hasAuth {
+		t.Error("expected hasAuth=true after SAML redirect chain, got false")
+		t.Logf("cookies found: %v", cookieNames(cookies))
+	}
+
+	// Verify specific cookies
+	if _, ok := cookies["MYSAPSSO2"]; !ok {
+		t.Error("expected MYSAPSSO2 cookie after SAML authentication")
+	}
+
+	// Verify path-scoped cookie is also captured (this is the T1.1 fix)
+	if _, ok := cookies["SAP_SESSIONID_TST_001"]; !ok {
+		t.Error("expected SAP_SESSIONID_TST_001 cookie (path-scoped to /sap/bc/) — cookieURLsForSAP fix required")
+	}
+
+	// Verify weak cookie is present but doesn't affect auth detection
+	if _, ok := cookies["sap-usercontext"]; !ok {
+		t.Error("expected sap-usercontext cookie to be captured")
+	}
+
+	// Verify cookie classification
+	for name := range cookies {
+		if matchesSAPAuthCookie(name) {
+			t.Logf("strong auth cookie: %s", name)
+		} else if matchesSAPWeakCookie(name) {
+			t.Logf("weak cookie: %s", name)
+		} else {
+			t.Logf("other cookie: %s", name)
+		}
+	}
+}
+
+// TestBrowserAuth_PollDetectsCookies verifies that pollForSAPCookies
+// correctly detects cookies that appear after a delay (simulating slow
+// SAML redirect chains).
+func TestBrowserAuth_PollDetectsCookies(t *testing.T) {
+	// Server that sets auth cookies only on the second request to /check
+	requestCount := 0
+	mux := http.NewServeMux()
+
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		if requestCount >= 3 {
+			// After a few requests, set auth cookies (simulates delayed SAML completion)
+			http.SetCookie(w, &http.Cookie{
+				Name:  "MYSAPSSO2",
+				Value: "delayed_sso_token",
+				Path:  "/",
+			})
+		}
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprint(w, "<html><body>Loading...</body></html>")
+	})
+
+	ts := httptest.NewServer(mux)
+	defer ts.Close()
+
+	opts := append(chromedp.DefaultExecAllocatorOptions[:],
+		chromedp.Flag("headless", true),
+		chromedp.Flag("disable-gpu", true),
+		chromedp.Flag("no-sandbox", true),
+	)
+
+	if found, _ := FindBrowser(); found != "" {
+		opts = append(opts, chromedp.ExecPath(found))
+	}
+
+	allocCtx, allocCancel := chromedp.NewExecAllocator(context.Background(), opts...)
+	defer allocCancel()
+
+	browserCtx, browserCancel := chromedp.NewContext(allocCtx)
+	defer browserCancel()
+
+	ctx, cancel := context.WithTimeout(browserCtx, 15*time.Second)
+	defer cancel()
+
+	// Navigate to the test server
+	if err := chromedp.Run(ctx, chromedp.Navigate(ts.URL)); err != nil {
+		t.Fatalf("navigation failed: %v", err)
+	}
+
+	// Poll for cookies — should eventually find MYSAPSSO2
+	cookies, err := pollForSAPCookies(ctx, ts.URL, true)
+	if err != nil {
+		t.Fatalf("pollForSAPCookies failed: %v", err)
+	}
+
+	if _, ok := cookies["MYSAPSSO2"]; !ok {
+		t.Error("expected MYSAPSSO2 cookie to be found by polling")
+	}
+}
+
+func cookieNames(cookies map[string]string) []string {
+	names := make([]string, 0, len(cookies))
+	for name := range cookies {
+		names = append(names, name)
+	}
+	return names
+}
+

--- a/pkg/adt/browser_auth_test.go
+++ b/pkg/adt/browser_auth_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 )
@@ -28,7 +29,7 @@ func TestSaveCookiesToFile(t *testing.T) {
 	if err != nil {
 		t.Fatalf("cannot stat cookie file: %v", err)
 	}
-	if info.Mode().Perm() != 0600 {
+	if runtime.GOOS != "windows" && info.Mode().Perm() != 0600 {
 		t.Errorf("expected permissions 0600, got %o", info.Mode().Perm())
 	}
 

--- a/pkg/adt/browser_auth_test.go
+++ b/pkg/adt/browser_auth_test.go
@@ -302,11 +302,17 @@ func TestSanitizeURLForLog(t *testing.T) {
 }
 
 func TestEmptyCookieJar(t *testing.T) {
-	// Verify that no cookie names from an empty set produce false positives
-	names := []string{}
-	for _, name := range names {
+	// Verify that unrelated cookie names don't trigger false positives
+	unrelatedCookies := []string{
+		"_ga", "PHPSESSID", "csrf_token", "__cfduid",
+		"connect.sid", "laravel_session", "rack.session",
+	}
+	for _, name := range unrelatedCookies {
 		if matchesSAPAuthCookie(name) {
-			t.Errorf("empty jar should have no auth cookies, but %q matched", name)
+			t.Errorf("unrelated cookie %q should not match as SAP auth cookie", name)
+		}
+		if matchesSAPWeakCookie(name) {
+			t.Errorf("unrelated cookie %q should not match as SAP weak cookie", name)
 		}
 	}
 }

--- a/pkg/adt/browser_auth_test.go
+++ b/pkg/adt/browser_auth_test.go
@@ -1,6 +1,7 @@
 package adt
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"strings"
@@ -88,13 +89,224 @@ func TestSaveCookiesToFile_InvalidURL(t *testing.T) {
 }
 
 func TestBrowserLogin_InvalidURL(t *testing.T) {
-	_, err := BrowserLogin(nil, "", false, 0, "", false)
+	ctx := context.TODO()
+	_, err := BrowserLogin(ctx, "", false, 0, "", false)
 	if err == nil {
 		t.Error("expected error for empty URL")
 	}
 
-	_, err = BrowserLogin(nil, "not-a-url", false, 0, "", false)
+	_, err = BrowserLogin(ctx, "not-a-url", false, 0, "", false)
 	if err == nil {
 		t.Error("expected error for invalid URL")
+	}
+}
+
+// --- T1.4: Cookie filtering unit tests ---
+
+func TestCookieURLsForSAP(t *testing.T) {
+	tests := []struct {
+		name     string
+		sapURL   string
+		wantURLs []string
+	}{
+		{
+			name:   "standard HTTPS URL",
+			sapURL: "https://my413862.s4hana.cloud.sap",
+			wantURLs: []string{
+				"https://my413862.s4hana.cloud.sap",
+				"https://my413862.s4hana.cloud.sap/sap/",
+				"https://my413862.s4hana.cloud.sap/sap/bc/",
+				"https://my413862.s4hana.cloud.sap/sap/bc/adt/",
+			},
+		},
+		{
+			name:   "URL with trailing slash",
+			sapURL: "https://sap.example.com:44300/",
+			wantURLs: []string{
+				"https://sap.example.com:44300",
+				"https://sap.example.com:44300/sap/",
+				"https://sap.example.com:44300/sap/bc/",
+				"https://sap.example.com:44300/sap/bc/adt/",
+			},
+		},
+		{
+			name:   "URL with port no trailing slash",
+			sapURL: "https://sap.example.com:44300",
+			wantURLs: []string{
+				"https://sap.example.com:44300",
+				"https://sap.example.com:44300/sap/",
+				"https://sap.example.com:44300/sap/bc/",
+				"https://sap.example.com:44300/sap/bc/adt/",
+			},
+		},
+		{
+			name:   "URL with query params (sap-client) stripped correctly",
+			sapURL: "https://sap.example.com:44300?sap-client=100",
+			wantURLs: []string{
+				"https://sap.example.com:44300",
+				"https://sap.example.com:44300/sap/",
+				"https://sap.example.com:44300/sap/bc/",
+				"https://sap.example.com:44300/sap/bc/adt/",
+			},
+		},
+		{
+			name:   "URL with path and fragment stripped",
+			sapURL: "https://sap.example.com/some/path#section",
+			wantURLs: []string{
+				"https://sap.example.com",
+				"https://sap.example.com/sap/",
+				"https://sap.example.com/sap/bc/",
+				"https://sap.example.com/sap/bc/adt/",
+			},
+		},
+		{
+			name:     "invalid URL returns input as-is",
+			sapURL:   "not-a-url",
+			wantURLs: []string{"not-a-url"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := cookieURLsForSAP(tt.sapURL)
+			if len(got) != len(tt.wantURLs) {
+				t.Fatalf("cookieURLsForSAP(%q) returned %d URLs, want %d\ngot: %v", tt.sapURL, len(got), len(tt.wantURLs), got)
+			}
+			for i, want := range tt.wantURLs {
+				if got[i] != want {
+					t.Errorf("cookieURLsForSAP(%q)[%d] = %q, want %q", tt.sapURL, i, got[i], want)
+				}
+			}
+		})
+	}
+}
+
+func TestMatchesSAPAuthCookie(t *testing.T) {
+	tests := []struct {
+		name string
+		want bool
+	}{
+		// Strong auth cookies — should match
+		{"MYSAPSSO2", true},
+		{"SAP_SESSIONID_NPL_001", true},
+		{"SAP_SESSIONID", true},
+		{"JSESSIONID", true},
+		{"JSESSIONID_abc123", true},
+
+		// Weak cookies — should NOT match
+		{"sap-usercontext", false},
+
+		// Unrelated cookies — should NOT match
+		{"_ga", false},
+		{"PHPSESSID", false},
+		{"", false},
+		{"mysapsso2", false}, // case-sensitive: lowercase should not match
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := matchesSAPAuthCookie(tt.name); got != tt.want {
+				t.Errorf("matchesSAPAuthCookie(%q) = %v, want %v", tt.name, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestMatchesSAPWeakCookie(t *testing.T) {
+	tests := []struct {
+		name string
+		want bool
+	}{
+		{"sap-usercontext", true},
+		{"sap-usercontext=sap-client=001", true}, // prefix match
+		{"MYSAPSSO2", false},
+		{"SAP_SESSIONID_NPL_001", false},
+		{"", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := matchesSAPWeakCookie(tt.name); got != tt.want {
+				t.Errorf("matchesSAPWeakCookie(%q) = %v, want %v", tt.name, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestSAPCookieClassification(t *testing.T) {
+	// Verify that strong and weak cookie sets are disjoint and comprehensive
+	// for the known SAP cookie names.
+	knownStrong := []string{"MYSAPSSO2", "SAP_SESSIONID_NPL_001", "JSESSIONID"}
+	knownWeak := []string{"sap-usercontext"}
+
+	for _, name := range knownStrong {
+		if !matchesSAPAuthCookie(name) {
+			t.Errorf("expected %q to be a strong auth cookie", name)
+		}
+		if matchesSAPWeakCookie(name) {
+			t.Errorf("strong cookie %q should not match as weak", name)
+		}
+	}
+
+	for _, name := range knownWeak {
+		if matchesSAPAuthCookie(name) {
+			t.Errorf("weak cookie %q should not match as strong auth", name)
+		}
+		if !matchesSAPWeakCookie(name) {
+			t.Errorf("expected %q to be a weak cookie", name)
+		}
+	}
+}
+
+func TestSanitizeURLForLog(t *testing.T) {
+	tests := []struct {
+		name    string
+		rawURL  string
+		want    string
+	}{
+		{
+			name:   "strips SAMLResponse query param",
+			rawURL: "https://sap.example.com/saml/callback?SAMLResponse=PHNhbWw%3D&RelayState=abc",
+			want:   "https://sap.example.com/saml/callback",
+		},
+		{
+			name:   "strips SAMLRequest query param",
+			rawURL: "https://ias.example.com/saml2/idp/sso?SAMLRequest=base64data&SigAlg=rsa",
+			want:   "https://ias.example.com/saml2/idp/sso",
+		},
+		{
+			name:   "preserves clean URL without query",
+			rawURL: "https://sap.example.com/sap/bc/adt/",
+			want:   "https://sap.example.com/sap/bc/adt/",
+		},
+		{
+			name:   "strips fragment too",
+			rawURL: "https://sap.example.com/page#token=secret",
+			want:   "https://sap.example.com/page",
+		},
+		{
+			name:   "handles URL with port",
+			rawURL: "https://sap.example.com:44300/sap/bc/?sap-client=001",
+			want:   "https://sap.example.com:44300/sap/bc/",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := sanitizeURLForLog(tt.rawURL)
+			if got != tt.want {
+				t.Errorf("sanitizeURLForLog(%q) = %q, want %q", tt.rawURL, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestEmptyCookieJar(t *testing.T) {
+	// Verify that no cookie names from an empty set produce false positives
+	names := []string{}
+	for _, name := range names {
+		if matchesSAPAuthCookie(name) {
+			t.Errorf("empty jar should have no auth cookies, but %q matched", name)
+		}
 	}
 }

--- a/pkg/adt/config.go
+++ b/pkg/adt/config.go
@@ -2,6 +2,7 @@
 package adt
 
 import (
+	"context"
 	"crypto/tls"
 	"fmt"
 	"net/http"
@@ -49,6 +50,10 @@ type Config struct {
 	Features FeatureConfig
 	// TerminalID for debugger session (shared with SAP GUI for cross-tool debugging)
 	TerminalID string
+
+	// ReauthFunc is called on 401 to re-authenticate (e.g., re-run SAML dance).
+	// Returns fresh cookies for the SAP system. Only used when HasBasicAuth() is false.
+	ReauthFunc func(ctx context.Context) (map[string]string, error)
 }
 
 // Option is a functional option for configuring the ADT client.
@@ -201,6 +206,14 @@ func NewConfig(baseURL, username, password string, opts ...Option) *Config {
 func WithFeatures(features FeatureConfig) Option {
 	return func(c *Config) {
 		c.Features = features
+	}
+}
+
+// WithReauthFunc sets the re-authentication function for 401 recovery.
+// Used by SAML auth to re-run the SAML dance when the session expires.
+func WithReauthFunc(f func(ctx context.Context) (map[string]string, error)) Option {
+	return func(c *Config) {
+		c.ReauthFunc = f
 	}
 }
 

--- a/pkg/adt/credential_cmd.go
+++ b/pkg/adt/credential_cmd.go
@@ -1,0 +1,82 @@
+package adt
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+// credentialCmdTimeout is the default timeout for external credential commands.
+const credentialCmdTimeout = 30 * time.Second
+
+// credentialResult is the expected JSON output from a credential command.
+type credentialResult struct {
+	Username string `json:"username"`
+	Password string `json:"password"`
+}
+
+// RunCredentialCmd executes an external credential command and parses JSON output.
+//
+// The command is executed via exec.Command (argv-based, no shell) to prevent
+// shell injection when the command is sourced from env/config. The command must
+// write JSON to stdout: {"username": "...", "password": "..."}.
+//
+// Stderr from the command is discarded (never logged, may contain secrets).
+// Stdout is read into a byte buffer and zeroed after JSON parsing.
+func RunCredentialCmd(ctx context.Context, args []string, verbose bool) (username, password string, err error) {
+	if len(args) == 0 {
+		return "", "", fmt.Errorf("credential-cmd: empty command")
+	}
+
+	// Apply timeout to the context.
+	ctx, cancel := context.WithTimeout(ctx, credentialCmdTimeout)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, args[0], args[1:]...)
+	cmd.Stderr = io.Discard // Discard stderr — may contain secrets.
+	cmd.Stdin = nil  // No stdin — non-interactive.
+
+	if verbose {
+		fmt.Fprintf(os.Stderr, "[CREDENTIAL-CMD] Executing: %s (%d args)\n", args[0], len(args)-1)
+	}
+
+	output, err := cmd.Output()
+	defer zeroBytes(output) // Zero buffer after parsing, even on error paths.
+	if err != nil {
+		if ctx.Err() == context.DeadlineExceeded {
+			return "", "", fmt.Errorf("credential-cmd: timed out after %s", credentialCmdTimeout)
+		}
+		// Never include output in error — may contain partial secrets.
+		return "", "", fmt.Errorf("credential-cmd: command failed: %w", err)
+	}
+
+	var result credentialResult
+	if err := json.Unmarshal(output, &result); err != nil {
+		return "", "", fmt.Errorf("credential-cmd: invalid JSON output: %w", err)
+	}
+
+	if result.Username == "" {
+		return "", "", fmt.Errorf("credential-cmd: missing 'username' field in JSON output")
+	}
+	if result.Password == "" {
+		return "", "", fmt.Errorf("credential-cmd: missing 'password' field in JSON output")
+	}
+
+	if verbose {
+		fmt.Fprintf(os.Stderr, "[CREDENTIAL-CMD] Credentials received for user: %s\n", result.Username)
+	}
+
+	return result.Username, result.Password, nil
+}
+
+// ParseCredentialCmd splits a credential command string into argv tokens.
+// Uses strings.Fields (whitespace splitting) — no shell quoting support.
+// For complex quoting, use a wrapper script.
+func ParseCredentialCmd(cmdStr string) []string {
+	return strings.Fields(cmdStr)
+}

--- a/pkg/adt/credential_cmd_test.go
+++ b/pkg/adt/credential_cmd_test.go
@@ -1,0 +1,190 @@
+package adt
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+)
+
+// writeCredHelper writes a helper script to tmpDir that outputs the given text.
+// Returns the command args to execute it.
+func writeCredHelper(t *testing.T, tmpDir, output string) []string {
+	t.Helper()
+	if runtime.GOOS == "windows" {
+		script := filepath.Join(tmpDir, "cred.cmd")
+		// Use @echo off + echo to avoid cmd noise. Note: echo in batch
+		// does not interpret JSON special chars.
+		content := "@echo off\r\necho " + output + "\r\n"
+		if err := os.WriteFile(script, []byte(content), 0600); err != nil {
+			t.Fatalf("failed to write helper script: %v", err)
+		}
+		return []string{"cmd", "/c", script}
+	}
+	script := filepath.Join(tmpDir, "cred.sh")
+	content := fmt.Sprintf("#!/bin/sh\nprintf '%%s' '%s'\n", output)
+	if err := os.WriteFile(script, []byte(content), 0755); err != nil {
+		t.Fatalf("failed to write helper script: %v", err)
+	}
+	return []string{"sh", script}
+}
+
+// writeFailHelper writes a helper script that exits with a non-zero code.
+func writeFailHelper(t *testing.T, tmpDir string, exitCode int) []string {
+	t.Helper()
+	if runtime.GOOS == "windows" {
+		script := filepath.Join(tmpDir, "fail.cmd")
+		content := fmt.Sprintf("@exit /b %d\r\n", exitCode)
+		if err := os.WriteFile(script, []byte(content), 0600); err != nil {
+			t.Fatalf("failed to write fail script: %v", err)
+		}
+		return []string{"cmd", "/c", script}
+	}
+	script := filepath.Join(tmpDir, "fail.sh")
+	content := fmt.Sprintf("#!/bin/sh\nexit %d\n", exitCode)
+	if err := os.WriteFile(script, []byte(content), 0755); err != nil {
+		t.Fatalf("failed to write fail script: %v", err)
+	}
+	return []string{"sh", script}
+}
+
+func TestCredentialCmd_ValidJSON(t *testing.T) {
+	tmpDir := t.TempDir()
+	args := writeCredHelper(t, tmpDir, `{"username":"admin@example.com","password":"secret123"}`)
+
+	user, pass, err := RunCredentialCmd(context.Background(), args, false)
+	if err != nil {
+		t.Fatalf("RunCredentialCmd failed: %v", err)
+	}
+	if user != "admin@example.com" {
+		t.Errorf("expected username admin@example.com, got %q", user)
+	}
+	if pass != "secret123" {
+		t.Errorf("expected password secret123, got %q", pass)
+	}
+}
+
+func TestCredentialCmd_InvalidJSON(t *testing.T) {
+	tmpDir := t.TempDir()
+	args := writeCredHelper(t, tmpDir, "not-json-at-all")
+
+	_, _, err := RunCredentialCmd(context.Background(), args, false)
+	if err == nil {
+		t.Fatal("expected error for invalid JSON, got nil")
+	}
+	if !strings.Contains(err.Error(), "invalid JSON") {
+		t.Errorf("expected 'invalid JSON' error, got: %v", err)
+	}
+}
+
+func TestCredentialCmd_Timeout(t *testing.T) {
+	// Use an immediately-expired context.
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Millisecond)
+	defer cancel()
+	time.Sleep(5 * time.Millisecond) // Ensure context is expired.
+
+	var args []string
+	if runtime.GOOS == "windows" {
+		args = []string{"cmd", "/c", "ping", "-n", "10", "127.0.0.1"}
+	} else {
+		args = []string{"sleep", "10"}
+	}
+
+	_, _, err := RunCredentialCmd(ctx, args, false)
+	if err == nil {
+		t.Fatal("expected error for timeout, got nil")
+	}
+	if !strings.Contains(err.Error(), "command failed") && !strings.Contains(err.Error(), "timed out") {
+		t.Errorf("expected timeout or command failed error, got: %v", err)
+	}
+}
+
+func TestCredentialCmd_NonZeroExit(t *testing.T) {
+	tmpDir := t.TempDir()
+	args := writeFailHelper(t, tmpDir, 1)
+
+	_, _, err := RunCredentialCmd(context.Background(), args, false)
+	if err == nil {
+		t.Fatal("expected error for non-zero exit, got nil")
+	}
+	if !strings.Contains(err.Error(), "command failed") {
+		t.Errorf("expected 'command failed' error, got: %v", err)
+	}
+}
+
+func TestCredentialCmd_MissingFields(t *testing.T) {
+	tests := []struct {
+		name string
+		json string
+		want string
+	}{
+		{"missing username", `{"password":"pass"}`, "missing 'username'"},
+		{"missing password", `{"username":"user"}`, "missing 'password'"},
+		{"empty username", `{"username":"","password":"pass"}`, "missing 'username'"},
+		{"empty password", `{"username":"user","password":""}`, "missing 'password'"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tmpDir := t.TempDir()
+			args := writeCredHelper(t, tmpDir, tt.json)
+
+			_, _, err := RunCredentialCmd(context.Background(), args, false)
+			if err == nil {
+				t.Fatal("expected error, got nil")
+			}
+			if !strings.Contains(err.Error(), tt.want) {
+				t.Errorf("expected error containing %q, got: %v", tt.want, err)
+			}
+		})
+	}
+}
+
+func TestCredentialCmd_EmptyCommand(t *testing.T) {
+	_, _, err := RunCredentialCmd(context.Background(), nil, false)
+	if err == nil {
+		t.Fatal("expected error for empty command, got nil")
+	}
+	if !strings.Contains(err.Error(), "empty command") {
+		t.Errorf("expected 'empty command' error, got: %v", err)
+	}
+}
+
+func TestParseCredentialCmd(t *testing.T) {
+	tests := []struct {
+		input string
+		want  int
+	}{
+		{"keepassxc-cli show -s db.kdbx SAP/K0B", 5},
+		{"simple-cmd", 1},
+		{"cmd arg1 arg2", 3},
+		{"", 0},
+		{"  spaced  cmd  ", 2},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			got := ParseCredentialCmd(tt.input)
+			if len(got) != tt.want {
+				t.Errorf("ParseCredentialCmd(%q) = %d args, want %d", tt.input, len(got), tt.want)
+			}
+		})
+	}
+}
+
+func TestCredentialCmd_VerboseMode(t *testing.T) {
+	tmpDir := t.TempDir()
+	args := writeCredHelper(t, tmpDir, `{"username":"user","password":"pass"}`)
+
+	user, pass, err := RunCredentialCmd(context.Background(), args, true)
+	if err != nil {
+		t.Fatalf("RunCredentialCmd (verbose) failed: %v", err)
+	}
+	if user != "user" || pass != "pass" {
+		t.Errorf("unexpected credentials: user=%q pass=%q", user, pass)
+	}
+}

--- a/pkg/adt/http.go
+++ b/pkg/adt/http.go
@@ -10,6 +10,7 @@ import (
 	"net/url"
 	"strings"
 	"sync"
+	"time"
 )
 
 // HTTPDoer is an interface for executing HTTP requests.
@@ -31,6 +32,15 @@ type Transport struct {
 	// Session management
 	sessionID string
 	sessionMu sync.RWMutex
+
+	// Cookie access protection: guards config.Cookies against concurrent
+	// read (Request/retryRequest) and write (callReauthFunc) access.
+	cookiesMu sync.RWMutex
+
+	// Re-auth stampede protection: prevents concurrent 401 handlers
+	// from triggering simultaneous SAML dances.
+	reauthMu   sync.Mutex
+	lastReauth time.Time
 }
 
 // NewTransport creates a new Transport with the given configuration.
@@ -111,9 +121,7 @@ func (t *Transport) Request(ctx context.Context, path string, opts *RequestOptio
 	}
 
 	// Add user-provided cookies for cookie-based authentication
-	for name, value := range t.config.Cookies {
-		req.AddCookie(&http.Cookie{Name: name, Value: value})
-	}
+	t.addCookies(req)
 
 	// Set default headers
 	t.setDefaultHeaders(req, opts)
@@ -192,10 +200,17 @@ func (t *Transport) Request(ctx context.Context, path string, opts *RequestOptio
 		if resp.StatusCode == http.StatusUnauthorized {
 			t.setCSRFToken("")
 			t.setSessionID("")
-			if err := t.fetchCSRFToken(ctx); err != nil {
-				// Return both errors: re-auth failure wraps the original 401 context
-				// so callers can see which endpoint triggered the expiry.
-				return nil, fmt.Errorf("re-authenticating after 401 on %s: %w (original error: %v)", path, err, apiErr)
+
+			if !t.config.HasBasicAuth() && t.config.ReauthFunc != nil {
+				// Cookie/SAML auth: re-run full auth dance to get fresh cookies.
+				if err := t.callReauthFunc(ctx); err != nil {
+					return nil, fmt.Errorf("re-authenticating after 401 on %s: %w (original error: %v)", path, err, apiErr)
+				}
+			} else {
+				// Basic auth: just refresh CSRF token.
+				if err := t.fetchCSRFToken(ctx); err != nil {
+					return nil, fmt.Errorf("re-authenticating after 401 on %s: %w (original error: %v)", path, err, apiErr)
+				}
 			}
 			return t.retryRequest(ctx, path, opts)
 		}
@@ -231,9 +246,7 @@ func (t *Transport) retryRequest(ctx context.Context, path string, opts *Request
 	if t.config.HasBasicAuth() {
 		req.SetBasicAuth(t.config.Username, t.config.Password)
 	}
-	for name, value := range t.config.Cookies {
-		req.AddCookie(&http.Cookie{Name: name, Value: value})
-	}
+	t.addCookies(req)
 	t.setDefaultHeaders(req, opts)
 	req.Header.Set("X-CSRF-Token", t.getCSRFToken())
 
@@ -286,9 +299,7 @@ func (t *Transport) fetchCSRFToken(ctx context.Context) error {
 	if t.config.HasBasicAuth() {
 		req.SetBasicAuth(t.config.Username, t.config.Password)
 	}
-	for name, value := range t.config.Cookies {
-		req.AddCookie(&http.Cookie{Name: name, Value: value})
-	}
+	t.addCookies(req)
 	req.Header.Set("X-CSRF-Token", "fetch")
 	req.Header.Set("Accept", "*/*")
 
@@ -501,4 +512,43 @@ func IsSessionExpiredError(err error) bool {
 // It refreshes the CSRF token as a side effect.
 func (t *Transport) Ping(ctx context.Context) error {
 	return t.fetchCSRFToken(ctx)
+}
+
+// reauthCooldown prevents concurrent 401 handlers from triggering simultaneous
+// SAML dances. If a re-auth completed within this window, skip the duplicate.
+const reauthCooldown = 5 * time.Second
+
+// callReauthFunc invokes config.ReauthFunc with stampede protection.
+// Multiple goroutines hitting 401 simultaneously will serialize through the mutex;
+// the first one performs the re-auth, subsequent ones within the cooldown window skip it.
+func (t *Transport) callReauthFunc(ctx context.Context) error {
+	t.reauthMu.Lock()
+	defer t.reauthMu.Unlock()
+
+	// Another goroutine already re-authed while we waited for the lock.
+	if !t.lastReauth.IsZero() && time.Since(t.lastReauth) < reauthCooldown {
+		return nil
+	}
+
+	cookies, err := t.config.ReauthFunc(ctx)
+	if err != nil {
+		return err
+	}
+
+	t.cookiesMu.Lock()
+	t.config.Cookies = cookies
+	t.cookiesMu.Unlock()
+	t.lastReauth = time.Now()
+
+	// Fetch CSRF token with the new cookies.
+	return t.fetchCSRFToken(ctx)
+}
+
+// addCookies adds user-provided cookies to a request under cookiesMu read lock.
+func (t *Transport) addCookies(req *http.Request) {
+	t.cookiesMu.RLock()
+	defer t.cookiesMu.RUnlock()
+	for name, value := range t.config.Cookies {
+		req.AddCookie(&http.Cookie{Name: name, Value: value})
+	}
 }

--- a/pkg/adt/http.go
+++ b/pkg/adt/http.go
@@ -538,10 +538,15 @@ func (t *Transport) callReauthFunc(ctx context.Context) error {
 	t.cookiesMu.Lock()
 	t.config.Cookies = cookies
 	t.cookiesMu.Unlock()
-	t.lastReauth = time.Now()
 
 	// Fetch CSRF token with the new cookies.
-	return t.fetchCSRFToken(ctx)
+	// Set lastReauth only after CSRF succeeds — if it fails, the next
+	// goroutine should retry rather than hitting the cooldown skip.
+	if err := t.fetchCSRFToken(ctx); err != nil {
+		return err
+	}
+	t.lastReauth = time.Now()
+	return nil
 }
 
 // addCookies adds user-provided cookies to a request under cookiesMu read lock.

--- a/pkg/adt/saml_auth.go
+++ b/pkg/adt/saml_auth.go
@@ -1,0 +1,324 @@
+package adt
+
+import (
+	"bytes"
+	"context"
+	"crypto/tls"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/cookiejar"
+	"net/url"
+	"os"
+	"strings"
+	"time"
+
+	"golang.org/x/net/html"
+)
+
+// CredentialProvider returns fresh credentials for SAML authentication.
+// Called on each auth attempt (initial + re-auth on 401).
+// Caller zeroes returned byte slices after use.
+type CredentialProvider func(ctx context.Context) (username, password []byte, err error)
+
+// formData represents an extracted HTML form with its action URL and input fields.
+type formData struct {
+	Action string
+	Method string
+	Fields map[string]string
+}
+
+// maxSAMLHops limits the number of form-based POST redirects in the SAML chain.
+const maxSAMLHops = 10
+
+// SAMLLogin performs programmatic SAML SSO authentication against SAP S/4HANA via IAS.
+//
+// The 4-step dance:
+//  1. GET SAP target URL → follow redirects → arrive at IdP (IAS) login page
+//  2. Parse IAS login form, fill in credentials, POST to IAS
+//  3. Parse SAMLResponse form from IAS response
+//  4. Follow form POST chain (up to 10 hops) back to SAP → extract session cookies
+//
+// MFA is not supported — use --browser-auth for MFA-protected systems.
+func SAMLLogin(ctx context.Context, sapURL string, credProvider CredentialProvider, insecure, verbose bool) (map[string]string, error) {
+	username, password, err := credProvider(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("credential provider: %w", err)
+	}
+	defer zeroBytes(username)
+	defer zeroBytes(password)
+
+	jar, _ := cookiejar.New(nil)
+	client := &http.Client{
+		Jar: jar,
+		Transport: &http.Transport{
+			Proxy: http.ProxyFromEnvironment,
+			TLSClientConfig: &tls.Config{
+				InsecureSkipVerify: insecure, //nolint:gosec // User-controlled via --insecure flag
+			},
+		},
+		CheckRedirect: func(req *http.Request, via []*http.Request) error {
+			if len(via) >= maxSAMLHops {
+				return fmt.Errorf("SAML redirect loop: exceeded %d hops", maxSAMLHops)
+			}
+			if verbose {
+				fmt.Fprintf(os.Stderr, "[SAML-AUTH] Redirect → %s\n", sanitizeURLForLog(req.URL.String()))
+			}
+			return nil
+		},
+		Timeout: 60 * time.Second,
+	}
+
+	u, err := url.Parse(sapURL)
+	if err != nil {
+		return nil, fmt.Errorf("invalid SAP URL: %w", err)
+	}
+	if u.Scheme == "" || u.Host == "" {
+		return nil, fmt.Errorf("invalid SAP URL (missing scheme or host): %s", sapURL)
+	}
+
+	// Target the ADT root — requires authentication, triggers SAML redirect.
+	target := *u
+	target.Path = "/sap/bc/adt/"
+	target.RawQuery = ""
+	target.Fragment = ""
+
+	if verbose {
+		fmt.Fprintf(os.Stderr, "[SAML-AUTH] Step 1: GET %s\n", target.String())
+	}
+
+	// Step 1: GET SAP target → HTTP client follows redirects → arrives at IdP login page.
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, target.String(), nil)
+	if err != nil {
+		return nil, fmt.Errorf("creating step 1 request: %w", err)
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("SAML step 1 (GET target): %w", err)
+	}
+	body, err := io.ReadAll(resp.Body)
+	resp.Body.Close()
+	if err != nil {
+		return nil, fmt.Errorf("reading step 1 response: %w", err)
+	}
+
+	// Step 2: Parse IdP login form and fill in credentials.
+	form, err := extractFormData(body, resp.Request.URL)
+	if err != nil {
+		return nil, fmt.Errorf("SAML step 1: no login form found in IdP response (status %d from %s): %w",
+			resp.StatusCode, sanitizeURLForLog(resp.Request.URL.String()), err)
+	}
+
+	if verbose {
+		fmt.Fprintf(os.Stderr, "[SAML-AUTH] Step 2: Found login form → %s (%d fields)\n",
+			sanitizeURLForLog(form.Action), len(form.Fields))
+	}
+
+	// Validate that credentials are sent to the same host as the IdP page
+	// to prevent exfiltration via a crafted form action.
+	actionURL, err := url.Parse(form.Action)
+	if err != nil {
+		return nil, fmt.Errorf("invalid login form action URL: %w", err)
+	}
+	if actionURL.Host != "" && actionURL.Host != resp.Request.URL.Host {
+		return nil, fmt.Errorf("refusing to send credentials to different host (%s vs %s)",
+			sanitizeURLForLog(form.Action), sanitizeURLForLog(resp.Request.URL.String()))
+	}
+	if resp.Request.URL.Scheme == "https" && actionURL.Scheme == "http" {
+		return nil, fmt.Errorf("refusing to send credentials over HTTP downgrade: %s",
+			sanitizeURLForLog(form.Action))
+	}
+
+	// Build form values with credentials added directly — never store credentials
+	// in form.Fields (Go strings are immutable and cannot be zeroed).
+	credValues := url.Values{}
+	for k, v := range form.Fields {
+		credValues.Set(k, v)
+	}
+	credValues.Set("j_username", string(username))
+	credValues.Set("j_password", string(password))
+
+	resp, err = submitFormValues(ctx, client, form.Action, credValues)
+	if err != nil {
+		return nil, fmt.Errorf("SAML step 2 (POST credentials to IdP): %w", err)
+	}
+	body, err = io.ReadAll(resp.Body)
+	resp.Body.Close()
+	if err != nil {
+		return nil, fmt.Errorf("reading step 2 response: %w", err)
+	}
+
+	// Steps 3-4: Follow SAMLResponse form chain back to SAP.
+	for i := 0; i < maxSAMLHops; i++ {
+		form, err = extractFormData(body, resp.Request.URL)
+		if err != nil {
+			// No more forms to submit — check cookies below.
+			break
+		}
+
+		if verbose {
+			fmt.Fprintf(os.Stderr, "[SAML-AUTH] Step %d: Following form → %s\n",
+				i+3, sanitizeURLForLog(form.Action))
+		}
+
+		resp, err = submitForm(ctx, client, form)
+		if err != nil {
+			return nil, fmt.Errorf("SAML step %d (POST form): %w", i+3, err)
+		}
+		body, err = io.ReadAll(resp.Body)
+		resp.Body.Close()
+		if err != nil {
+			return nil, fmt.Errorf("reading step %d response: %w", i+3, err)
+		}
+	}
+
+	// Extract SAP cookies from the jar.
+	sapCookies := extractSAPCookiesFromJar(jar, u)
+	if len(sapCookies) == 0 {
+		return nil, fmt.Errorf("SAML authentication completed but no SAP cookies received "+
+			"(last status: %d from %s)", resp.StatusCode, sanitizeURLForLog(resp.Request.URL.String()))
+	}
+
+	hasAuth := false
+	for name := range sapCookies {
+		if matchesSAPAuthCookie(name) {
+			hasAuth = true
+			break
+		}
+	}
+	if !hasAuth {
+		return nil, fmt.Errorf("SAML authentication completed but no SAP auth cookies " +
+			"(MYSAPSSO2/SAP_SESSIONID) found — check username/password")
+	}
+
+	if verbose {
+		fmt.Fprintf(os.Stderr, "[SAML-AUTH] Authentication successful — %d cookies extracted\n", len(sapCookies))
+		for name := range sapCookies {
+			fmt.Fprintf(os.Stderr, "[SAML-AUTH]   cookie: %s\n", name)
+		}
+	}
+
+	return sapCookies, nil
+}
+
+// submitForm submits an HTML form using the method specified in the form data.
+func submitForm(ctx context.Context, client *http.Client, form *formData) (*http.Response, error) {
+	values := url.Values{}
+	for k, v := range form.Fields {
+		values.Set(k, v)
+	}
+	return submitFormValues(ctx, client, form.Action, values)
+}
+
+// submitFormValues POSTs URL-encoded form values to the given action URL.
+func submitFormValues(ctx context.Context, client *http.Client, action string, values url.Values) (*http.Response, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, action, strings.NewReader(values.Encode()))
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	return client.Do(req)
+}
+
+// extractFormData parses the first HTML <form> from body using the x/net/html tokenizer.
+// Resolves relative action URLs against baseURL. Returns all hidden and text/password
+// input fields; excludes submit/button/image inputs.
+func extractFormData(body []byte, baseURL *url.URL) (*formData, error) {
+	tokenizer := html.NewTokenizer(bytes.NewReader(body))
+
+	var form *formData
+	inForm := false
+
+	for {
+		tt := tokenizer.Next()
+		switch tt {
+		case html.ErrorToken:
+			if form != nil {
+				return form, nil
+			}
+			return nil, fmt.Errorf("no HTML form found")
+
+		case html.StartTagToken, html.SelfClosingTagToken:
+			tn, hasAttr := tokenizer.TagName()
+			tagName := string(tn)
+
+			if tagName == "form" && hasAttr && !inForm {
+				form = &formData{
+					Method: "POST",
+					Fields: make(map[string]string),
+				}
+				inForm = true
+				for {
+					key, val, more := tokenizer.TagAttr()
+					switch string(key) {
+					case "action":
+						action := string(val)
+						if baseURL != nil {
+							if resolved, err := baseURL.Parse(action); err == nil {
+								action = resolved.String()
+							}
+						}
+						form.Action = action
+					case "method":
+						form.Method = strings.ToUpper(string(val))
+					}
+					if !more {
+						break
+					}
+				}
+			}
+
+			if inForm && tagName == "input" && hasAttr {
+				var name, value, inputType string
+				for {
+					key, val, more := tokenizer.TagAttr()
+					switch string(key) {
+					case "name":
+						name = string(val)
+					case "value":
+						value = string(val)
+					case "type":
+						inputType = strings.ToLower(string(val))
+					}
+					if !more {
+						break
+					}
+				}
+				if name != "" && inputType != "submit" && inputType != "button" && inputType != "image" {
+					form.Fields[name] = value
+				}
+			}
+
+		case html.EndTagToken:
+			tn, _ := tokenizer.TagName()
+			if string(tn) == "form" && inForm {
+				return form, nil
+			}
+		}
+	}
+}
+
+// extractSAPCookiesFromJar extracts all cookies for the SAP domain from the cookie jar.
+// Queries multiple paths to catch path-scoped cookies (same approach as browser_auth.go).
+func extractSAPCookiesFromJar(jar http.CookieJar, sapURL *url.URL) map[string]string {
+	result := make(map[string]string)
+	paths := []string{"", "/sap/", "/sap/bc/", "/sap/bc/adt/"}
+	for _, p := range paths {
+		u := *sapURL
+		u.Path = p
+		u.RawQuery = ""
+		u.Fragment = ""
+		for _, c := range jar.Cookies(&u) {
+			result[c.Name] = c.Value
+		}
+	}
+	return result
+}
+
+// zeroBytes overwrites a byte slice with zeros to prevent credential leakage.
+func zeroBytes(b []byte) {
+	for i := range b {
+		b[i] = 0
+	}
+}

--- a/pkg/adt/saml_auth.go
+++ b/pkg/adt/saml_auth.go
@@ -102,6 +102,37 @@ func SAMLLogin(ctx context.Context, sapURL string, credProvider CredentialProvid
 		return nil, fmt.Errorf("reading step 1 response: %w", err)
 	}
 
+	// Step 1b: SP-initiated SAML — SAP may respond with a SAMLRequest auto-submit form
+	// instead of HTTP 302 redirect. Follow it to reach the actual IdP login page.
+	// Distinguish from IdP login form: SP form has SAMLRequest but no credential fields.
+	if spForm, ferr := extractFormData(body, resp.Request.URL); ferr == nil {
+		_, hasSAMLRequest := spForm.Fields["SAMLRequest"]
+		_, hasUsername := spForm.Fields["j_username"]
+		if hasSAMLRequest && !hasUsername {
+			// SAMLRequest form goes from SAP to IdP — cross-host is expected.
+			// Only reject HTTPS→HTTP downgrade (no credential data, but signed artifact).
+			if spActionURL, perr := url.Parse(spForm.Action); perr == nil {
+				if resp.Request.URL.Scheme == "https" && spActionURL.Scheme == "http" {
+					return nil, fmt.Errorf("SAML step 1b: refusing HTTP downgrade: %s",
+						sanitizeURLForLog(spForm.Action))
+				}
+			}
+			if verbose {
+				fmt.Fprintf(os.Stderr, "[SAML-AUTH] Step 1b: Following SAMLRequest form → %s\n",
+					sanitizeURLForLog(spForm.Action))
+			}
+			resp, err = submitForm(ctx, client, spForm)
+			if err != nil {
+				return nil, fmt.Errorf("SAML step 1b (SAMLRequest to IdP): %w", err)
+			}
+			body, err = io.ReadAll(resp.Body)
+			resp.Body.Close()
+			if err != nil {
+				return nil, fmt.Errorf("reading step 1b response: %w", err)
+			}
+		}
+	}
+
 	// Step 2: Parse IdP login form and fill in credentials.
 	form, err := extractFormData(body, resp.Request.URL)
 	if err != nil {

--- a/pkg/adt/saml_auth.go
+++ b/pkg/adt/saml_auth.go
@@ -61,6 +61,13 @@ func SAMLLogin(ctx context.Context, sapURL string, credProvider CredentialProvid
 			if len(via) >= maxSAMLHops {
 				return fmt.Errorf("SAML redirect loop: exceeded %d hops", maxSAMLHops)
 			}
+			// Block HTTPS→HTTP downgrade on redirects to prevent credential/assertion leakage.
+			if len(via) > 0 {
+				prev := via[len(via)-1].URL
+				if prev.Scheme == "https" && req.URL.Scheme == "http" {
+					return fmt.Errorf("refusing HTTPS→HTTP redirect downgrade: %s", sanitizeURLForLog(req.URL.String()))
+				}
+			}
 			if verbose {
 				fmt.Fprintf(os.Stderr, "[SAML-AUTH] Redirect → %s\n", sanitizeURLForLog(req.URL.String()))
 			}
@@ -147,13 +154,21 @@ func SAMLLogin(ctx context.Context, sapURL string, credProvider CredentialProvid
 
 	// Validate that credentials are sent to the same host as the IdP page
 	// to prevent exfiltration via a crafted form action.
+	// Use canonicalHost for case-insensitive, port-normalized comparison
+	// (consistent with validateFormAction in Steps 3-4).
 	actionURL, err := url.Parse(form.Action)
 	if err != nil {
 		return nil, fmt.Errorf("invalid login form action URL: %w", err)
 	}
-	if actionURL.Host != "" && actionURL.Host != resp.Request.URL.Host {
-		return nil, fmt.Errorf("refusing to send credentials to different host (%s vs %s)",
-			sanitizeURLForLog(form.Action), sanitizeURLForLog(resp.Request.URL.String()))
+	if actionURL.Host != "" {
+		actionScheme := actionURL.Scheme
+		if actionScheme == "" {
+			actionScheme = resp.Request.URL.Scheme
+		}
+		if canonicalHost(actionURL.Host, actionScheme) != canonicalHost(resp.Request.URL.Host, resp.Request.URL.Scheme) {
+			return nil, fmt.Errorf("refusing to send credentials to different host (%s vs %s)",
+				sanitizeURLForLog(form.Action), sanitizeURLForLog(resp.Request.URL.String()))
+		}
 	}
 	if resp.Request.URL.Scheme == "https" && actionURL.Scheme == "http" {
 		return nil, fmt.Errorf("refusing to send credentials over HTTP downgrade: %s",

--- a/pkg/adt/saml_auth.go
+++ b/pkg/adt/saml_auth.go
@@ -149,11 +149,18 @@ func SAMLLogin(ctx context.Context, sapURL string, credProvider CredentialProvid
 	}
 
 	// Steps 3-4: Follow SAMLResponse form chain back to SAP.
+	// Allow form actions only to the current page host or the original SAP host,
+	// and reject HTTPS→HTTP downgrades to prevent assertion exfiltration.
 	for i := 0; i < maxSAMLHops; i++ {
 		form, err = extractFormData(body, resp.Request.URL)
 		if err != nil {
 			// No more forms to submit — check cookies below.
 			break
+		}
+
+		// Validate form action host/scheme to prevent SAMLResponse exfiltration.
+		if err := validateFormAction(resp.Request.URL, form.Action, u.Host); err != nil {
+			return nil, fmt.Errorf("SAML step %d: %w", i+3, err)
 		}
 
 		if verbose {
@@ -199,6 +206,44 @@ func SAMLLogin(ctx context.Context, sapURL string, credProvider CredentialProvid
 	}
 
 	return sapCookies, nil
+}
+
+// canonicalHost normalizes a host string for comparison: lowercase and strip
+// default ports (:443 for HTTPS, :80 for HTTP).
+func canonicalHost(host, scheme string) string {
+	h := strings.ToLower(host)
+	if scheme == "https" && strings.HasSuffix(h, ":443") {
+		h = h[:len(h)-4]
+	} else if scheme == "http" && strings.HasSuffix(h, ":80") {
+		h = h[:len(h)-3]
+	}
+	return h
+}
+
+// validateFormAction checks that a form action URL is safe to POST to.
+// It allows the current page host and the original SAP host, and rejects
+// HTTPS→HTTP downgrades. This prevents exfiltration of SAMLResponse assertions
+// or other sensitive form data to attacker-controlled hosts.
+// Host comparison is case-insensitive and ignores default ports.
+func validateFormAction(currentPageURL *url.URL, action string, sapHost string) error {
+	a, err := url.Parse(action)
+	if err != nil {
+		return fmt.Errorf("invalid form action URL: %w", err)
+	}
+	// Relative URLs (empty host) are safe — they target the current host.
+	if a.Host != "" {
+		actionHost := canonicalHost(a.Host, a.Scheme)
+		currentHost := canonicalHost(currentPageURL.Host, currentPageURL.Scheme)
+		sapHostNorm := canonicalHost(sapHost, currentPageURL.Scheme)
+		if actionHost != currentHost && actionHost != sapHostNorm {
+			return fmt.Errorf("refusing to POST form to different host (%s vs %s/%s)",
+				sanitizeURLForLog(action), sanitizeURLForLog(currentPageURL.String()), sapHost)
+		}
+	}
+	if currentPageURL.Scheme == "https" && a.Scheme == "http" {
+		return fmt.Errorf("refusing HTTP downgrade: %s", sanitizeURLForLog(action))
+	}
+	return nil
 }
 
 // submitForm submits an HTML form using the method specified in the form data.

--- a/pkg/adt/saml_auth_test.go
+++ b/pkg/adt/saml_auth_test.go
@@ -275,6 +275,52 @@ func TestSAMLLogin_ReauthConcurrent(t *testing.T) {
 	}
 }
 
+func TestSAMLLogin_HostMismatch(t *testing.T) {
+	// IdP returns a login form with action pointing to a different host.
+	// The security guard should refuse to send credentials.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/html")
+		fmt.Fprintf(w, `<html><body>
+			<form method="POST" action="https://evil.example.com/steal">
+				<input type="text" name="j_username" value=""/>
+				<input type="password" name="j_password" value=""/>
+			</form>
+		</body></html>`)
+	}))
+	defer srv.Close()
+
+	_, err := SAMLLogin(context.Background(), srv.URL, testCredProvider("u", "p"), false, false)
+	if err == nil {
+		t.Fatal("expected error for host mismatch, got nil")
+	}
+	if !strings.Contains(err.Error(), "refusing to send credentials to different host") {
+		t.Errorf("expected 'refusing to send credentials to different host' error, got: %v", err)
+	}
+}
+
+func TestSAMLLogin_HTTPDowngrade(t *testing.T) {
+	// IdP on HTTPS returns a login form with HTTP action — should be rejected.
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/html")
+		// Action uses http:// while the server is HTTPS — downgrade attack.
+		fmt.Fprintf(w, `<html><body>
+			<form method="POST" action="http://%s/login">
+				<input type="text" name="j_username" value=""/>
+				<input type="password" name="j_password" value=""/>
+			</form>
+		</body></html>`, r.Host)
+	}))
+	defer srv.Close()
+
+	_, err := SAMLLogin(context.Background(), srv.URL, testCredProvider("u", "p"), true, false)
+	if err == nil {
+		t.Fatal("expected error for HTTP downgrade, got nil")
+	}
+	if !strings.Contains(err.Error(), "HTTP downgrade") {
+		t.Errorf("expected 'HTTP downgrade' error, got: %v", err)
+	}
+}
+
 // --- extractFormData unit tests ---
 
 func TestExtractFormData_BasicForm(t *testing.T) {

--- a/pkg/adt/saml_auth_test.go
+++ b/pkg/adt/saml_auth_test.go
@@ -321,6 +321,72 @@ func TestSAMLLogin_HTTPDowngrade(t *testing.T) {
 	}
 }
 
+func TestSAMLLogin_SPInitiated(t *testing.T) {
+	// SAP responds with a SAMLRequest auto-submit form (HTTP-POST binding)
+	// instead of HTTP 302 redirect. Step 1b should follow it to reach the IdP.
+	mux := http.NewServeMux()
+
+	// SAP SP: responds with SAMLRequest form (SP-initiated, no redirect)
+	mux.HandleFunc("/sap/bc/adt/", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodGet {
+			w.Header().Set("Content-Type", "text/html")
+			fmt.Fprintf(w, `<html><body>
+				<form method="POST" action="http://%s/idp/sso">
+					<input type="hidden" name="SAMLRequest" value="base64samlrequest"/>
+					<input type="hidden" name="RelayState" value="relay"/>
+				</form>
+				<script>document.forms[0].submit();</script>
+			</body></html>`, r.Host)
+			return
+		}
+	})
+
+	// IdP SSO endpoint: shows login form
+	mux.HandleFunc("/idp/sso", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/html")
+		fmt.Fprintf(w, `<form method="POST" action="/idp/authenticate">
+			<input type="hidden" name="SAMLRequest" value="base64req"/>
+			<input type="text" name="j_username" value=""/>
+			<input type="password" name="j_password" value=""/>
+		</form>`)
+	})
+
+	// IdP auth: returns SAMLResponse
+	mux.HandleFunc("/idp/authenticate", func(w http.ResponseWriter, r *http.Request) {
+		if err := r.ParseForm(); err != nil {
+			http.Error(w, "bad form", http.StatusBadRequest)
+			return
+		}
+		if r.FormValue("j_username") != "user" || r.FormValue("j_password") != "pass" {
+			http.Error(w, "bad creds", http.StatusUnauthorized)
+			return
+		}
+		w.Header().Set("Content-Type", "text/html")
+		fmt.Fprintf(w, `<form method="POST" action="/sap/saml2/sp/acs">
+			<input type="hidden" name="SAMLResponse" value="base64resp"/>
+		</form>`)
+	})
+
+	// SAP ACS: sets cookies
+	mux.HandleFunc("/sap/saml2/sp/acs", func(w http.ResponseWriter, r *http.Request) {
+		http.SetCookie(w, &http.Cookie{Name: "MYSAPSSO2", Value: "token", Path: "/"})
+		http.SetCookie(w, &http.Cookie{Name: "SAP_SESSIONID_X_001", Value: "sess", Path: "/sap/"})
+		w.Header().Set("Content-Type", "text/html")
+		fmt.Fprintf(w, `<html><body>OK</body></html>`)
+	})
+
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	cookies, err := SAMLLogin(context.Background(), srv.URL, testCredProvider("user", "pass"), false, true)
+	if err != nil {
+		t.Fatalf("SAMLLogin (SP-initiated) failed: %v", err)
+	}
+	if cookies["MYSAPSSO2"] != "token" {
+		t.Errorf("expected MYSAPSSO2=token, got %q", cookies["MYSAPSSO2"])
+	}
+}
+
 func TestSAMLLogin_FormChainHostMismatch(t *testing.T) {
 	// After successful login, the IdP returns a SAMLResponse form that points
 	// to an evil host instead of the SAP ACS. The chain validation should reject this.

--- a/pkg/adt/saml_auth_test.go
+++ b/pkg/adt/saml_auth_test.go
@@ -321,6 +321,46 @@ func TestSAMLLogin_HTTPDowngrade(t *testing.T) {
 	}
 }
 
+func TestSAMLLogin_FormChainHostMismatch(t *testing.T) {
+	// After successful login, the IdP returns a SAMLResponse form that points
+	// to an evil host instead of the SAP ACS. The chain validation should reject this.
+	mux := http.NewServeMux()
+
+	// SAP SP: redirect to IdP
+	mux.HandleFunc("/sap/bc/adt/", func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, "http://"+r.Host+"/idp/login", http.StatusFound)
+	})
+
+	// IdP login page
+	mux.HandleFunc("/idp/login", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/html")
+		fmt.Fprintf(w, `<form method="POST" action="/idp/authenticate">
+			<input type="hidden" name="SAMLRequest" value="req"/>
+			<input type="text" name="j_username" value=""/>
+			<input type="password" name="j_password" value=""/>
+		</form>`)
+	})
+
+	// IdP returns SAMLResponse form pointing to evil host
+	mux.HandleFunc("/idp/authenticate", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/html")
+		fmt.Fprintf(w, `<form method="POST" action="https://evil.example.com/steal">
+			<input type="hidden" name="SAMLResponse" value="stolen_assertion"/>
+		</form>`)
+	})
+
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	_, err := SAMLLogin(context.Background(), srv.URL, testCredProvider("u", "p"), false, false)
+	if err == nil {
+		t.Fatal("expected error for form chain host mismatch, got nil")
+	}
+	if !strings.Contains(err.Error(), "refusing to POST form to different host") {
+		t.Errorf("expected 'refusing to POST form to different host' error, got: %v", err)
+	}
+}
+
 // --- extractFormData unit tests ---
 
 func TestExtractFormData_BasicForm(t *testing.T) {

--- a/pkg/adt/saml_auth_test.go
+++ b/pkg/adt/saml_auth_test.go
@@ -1,0 +1,407 @@
+package adt
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/cookiejar"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// mockSAMLServer creates an httptest server simulating a 4-step SAML flow:
+//   - SAP SP: redirects to IdP
+//   - IdP: login form → validates credentials → returns SAMLResponse form
+//   - SAP ACS: consumes SAMLResponse → sets session cookies
+func mockSAMLServer(t *testing.T, expectedUser, expectedPassword string) *httptest.Server {
+	t.Helper()
+	mux := http.NewServeMux()
+
+	// SAP SP: redirect to IdP login
+	mux.HandleFunc("/sap/bc/adt/", func(w http.ResponseWriter, r *http.Request) {
+		idpURL := "http://" + r.Host + "/idp/login?SAMLRequest=base64encodedrequest"
+		http.Redirect(w, r, idpURL, http.StatusFound)
+	})
+
+	// IdP login page
+	mux.HandleFunc("/idp/login", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodGet {
+			w.Header().Set("Content-Type", "text/html")
+			fmt.Fprintf(w, `<html><body>
+				<form method="POST" action="/idp/authenticate">
+					<input type="hidden" name="SAMLRequest" value="base64request"/>
+					<input type="hidden" name="RelayState" value="relay123"/>
+					<input type="text" name="j_username" value=""/>
+					<input type="password" name="j_password" value=""/>
+					<input type="submit" name="login" value="Log In"/>
+				</form>
+			</body></html>`)
+			return
+		}
+	})
+
+	// IdP authentication endpoint
+	mux.HandleFunc("/idp/authenticate", func(w http.ResponseWriter, r *http.Request) {
+		if err := r.ParseForm(); err != nil {
+			http.Error(w, "bad form", http.StatusBadRequest)
+			return
+		}
+		user := r.FormValue("j_username")
+		pass := r.FormValue("j_password")
+
+		if user != expectedUser || pass != expectedPassword {
+			w.Header().Set("Content-Type", "text/html")
+			w.WriteHeader(http.StatusOK)
+			fmt.Fprintf(w, `<html><body><p class="error">Invalid username or password</p></body></html>`)
+			return
+		}
+
+		// Return SAMLResponse form targeting SAP ACS
+		w.Header().Set("Content-Type", "text/html")
+		fmt.Fprintf(w, `<html><body>
+			<form method="POST" action="/sap/saml2/sp/acs">
+				<input type="hidden" name="SAMLResponse" value="base64samlresponse"/>
+				<input type="hidden" name="RelayState" value="relay123"/>
+				<input type="submit" value="Continue"/>
+			</form>
+			<script>document.forms[0].submit();</script>
+		</body></html>`)
+	})
+
+	// SAP ACS endpoint: consumes SAMLResponse, sets cookies
+	mux.HandleFunc("/sap/saml2/sp/acs", func(w http.ResponseWriter, r *http.Request) {
+		if err := r.ParseForm(); err != nil {
+			http.Error(w, "bad form", http.StatusBadRequest)
+			return
+		}
+		if r.FormValue("SAMLResponse") == "" {
+			http.Error(w, "missing SAMLResponse", http.StatusBadRequest)
+			return
+		}
+
+		http.SetCookie(w, &http.Cookie{Name: "MYSAPSSO2", Value: "sso2token", Path: "/"})
+		http.SetCookie(w, &http.Cookie{Name: "SAP_SESSIONID_ABC_001", Value: "sess123", Path: "/sap/"})
+		http.SetCookie(w, &http.Cookie{Name: "sap-usercontext", Value: "sap-client=001", Path: "/"})
+		w.Header().Set("Content-Type", "text/html")
+		fmt.Fprintf(w, `<html><body>Authenticated</body></html>`)
+	})
+
+	return httptest.NewServer(mux)
+}
+
+func testCredProvider(user, pass string) CredentialProvider {
+	return func(ctx context.Context) ([]byte, []byte, error) {
+		return []byte(user), []byte(pass), nil
+	}
+}
+
+func TestSAMLLogin_FullFlow(t *testing.T) {
+	srv := mockSAMLServer(t, "admin@example.com", "secret123")
+	defer srv.Close()
+
+	cookies, err := SAMLLogin(context.Background(), srv.URL, testCredProvider("admin@example.com", "secret123"), false, false)
+	if err != nil {
+		t.Fatalf("SAMLLogin failed: %v", err)
+	}
+
+	if cookies["MYSAPSSO2"] != "sso2token" {
+		t.Errorf("expected MYSAPSSO2=sso2token, got %q", cookies["MYSAPSSO2"])
+	}
+	if _, ok := cookies["SAP_SESSIONID_ABC_001"]; !ok {
+		t.Error("expected SAP_SESSIONID_ABC_001 cookie")
+	}
+	if _, ok := cookies["sap-usercontext"]; !ok {
+		t.Error("expected sap-usercontext cookie")
+	}
+}
+
+func TestSAMLLogin_WrongPassword(t *testing.T) {
+	srv := mockSAMLServer(t, "admin@example.com", "secret123")
+	defer srv.Close()
+
+	_, err := SAMLLogin(context.Background(), srv.URL, testCredProvider("admin@example.com", "wrongpass"), false, false)
+	if err == nil {
+		t.Fatal("expected error for wrong password, got nil")
+	}
+	if !strings.Contains(err.Error(), "no SAP auth cookies") && !strings.Contains(err.Error(), "no SAP cookies") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestSAMLLogin_IASUnavailable(t *testing.T) {
+	// Use a URL that will refuse connections.
+	_, err := SAMLLogin(context.Background(), "http://127.0.0.1:1", testCredProvider("u", "p"), false, false)
+	if err == nil {
+		t.Fatal("expected error for unreachable server, got nil")
+	}
+	if !strings.Contains(err.Error(), "SAML step 1") {
+		t.Errorf("expected step 1 error, got: %v", err)
+	}
+}
+
+func TestSAMLLogin_MalformedSAML(t *testing.T) {
+	// Server returns HTML without any forms after redirect.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/html")
+		fmt.Fprintf(w, `<html><body><p>No forms here</p></body></html>`)
+	}))
+	defer srv.Close()
+
+	_, err := SAMLLogin(context.Background(), srv.URL, testCredProvider("u", "p"), false, false)
+	if err == nil {
+		t.Fatal("expected error for missing form, got nil")
+	}
+	if !strings.Contains(err.Error(), "no login form found") {
+		t.Errorf("expected 'no login form found' error, got: %v", err)
+	}
+}
+
+func TestSAMLLogin_RedirectLoop(t *testing.T) {
+	// Server always redirects to itself.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, r.URL.String()+"x", http.StatusFound)
+	}))
+	defer srv.Close()
+
+	_, err := SAMLLogin(context.Background(), srv.URL, testCredProvider("u", "p"), false, false)
+	if err == nil {
+		t.Fatal("expected error for redirect loop, got nil")
+	}
+	if !strings.Contains(err.Error(), "exceeded") && !strings.Contains(err.Error(), "redirect") {
+		t.Errorf("expected redirect loop error, got: %v", err)
+	}
+}
+
+func TestSAMLLogin_VerboseNoSecrets(t *testing.T) {
+	srv := mockSAMLServer(t, "admin@example.com", "secret123")
+	defer srv.Close()
+
+	// Capture stderr to verify no secrets are logged.
+	// SAMLLogin writes to os.Stderr; we can't easily capture that in a unit test,
+	// so we verify the function succeeds in verbose mode without panicking.
+	// The real security test is the code review verifying no log call includes
+	// password, SAMLResponse body, or cookie values.
+	cookies, err := SAMLLogin(context.Background(), srv.URL, testCredProvider("admin@example.com", "secret123"), false, true)
+	if err != nil {
+		t.Fatalf("SAMLLogin (verbose) failed: %v", err)
+	}
+	if len(cookies) == 0 {
+		t.Error("expected cookies in verbose mode")
+	}
+}
+
+func TestSAMLLogin_ReauthOn401(t *testing.T) {
+	// Simulate a Transport that gets a 401 and calls ReauthFunc.
+	samlServer := mockSAMLServer(t, "admin@example.com", "secret123")
+	defer samlServer.Close()
+
+	reauthCalled := false
+	reauthFunc := func(ctx context.Context) (map[string]string, error) {
+		reauthCalled = true
+		return SAMLLogin(ctx, samlServer.URL, testCredProvider("admin@example.com", "secret123"), false, false)
+	}
+
+	// Create a mock SAP server that returns 401 once, then succeeds.
+	var attempt int32
+	sapServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		n := atomic.AddInt32(&attempt, 1)
+		if r.URL.Path == "/sap/bc/adt/core/discovery" && r.Method == http.MethodHead {
+			w.Header().Set("X-CSRF-Token", "test-token")
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+		if n == 1 {
+			w.WriteHeader(http.StatusUnauthorized)
+			fmt.Fprintf(w, "Session expired")
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprintf(w, "<ok/>")
+	}))
+	defer sapServer.Close()
+
+	cfg := NewConfig(sapServer.URL, "", "", WithReauthFunc(reauthFunc))
+	transport := NewTransport(cfg)
+
+	_, err := transport.Request(context.Background(), "/test", nil)
+	if err != nil {
+		t.Fatalf("Request failed: %v", err)
+	}
+	if !reauthCalled {
+		t.Error("ReauthFunc was not called on 401")
+	}
+}
+
+func TestSAMLLogin_ReauthConcurrent(t *testing.T) {
+	// Verify that concurrent 401s don't trigger multiple SAML dances.
+	// Use a real httptest server so fetchCSRFToken (called inside callReauthFunc) returns fast.
+	csrfServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("X-CSRF-Token", "concurrent-token")
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer csrfServer.Close()
+
+	var reauthCount int32
+	reauthFunc := func(ctx context.Context) (map[string]string, error) {
+		atomic.AddInt32(&reauthCount, 1)
+		time.Sleep(100 * time.Millisecond) // Simulate SAML dance latency
+		return map[string]string{"MYSAPSSO2": "fresh"}, nil
+	}
+
+	cfg := NewConfig(csrfServer.URL, "", "", WithReauthFunc(reauthFunc))
+	transport := NewTransport(cfg)
+
+	// Simulate concurrent callReauthFunc invocations.
+	var wg sync.WaitGroup
+	for i := 0; i < 5; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_ = transport.callReauthFunc(context.Background())
+		}()
+	}
+	wg.Wait()
+
+	count := atomic.LoadInt32(&reauthCount)
+	if count != 1 {
+		t.Errorf("expected exactly 1 re-auth call (stampede protection), got %d", count)
+	}
+}
+
+// --- extractFormData unit tests ---
+
+func TestExtractFormData_BasicForm(t *testing.T) {
+	body := []byte(`<html><body>
+		<form method="POST" action="/login">
+			<input type="hidden" name="token" value="abc123"/>
+			<input type="text" name="username" value=""/>
+			<input type="password" name="password" value=""/>
+			<input type="submit" name="submit" value="Login"/>
+		</form>
+	</body></html>`)
+
+	base, _ := url.Parse("https://idp.example.com/sso")
+	form, err := extractFormData(body, base)
+	if err != nil {
+		t.Fatalf("extractFormData failed: %v", err)
+	}
+
+	if form.Action != "https://idp.example.com/login" {
+		t.Errorf("expected action https://idp.example.com/login, got %s", form.Action)
+	}
+	if form.Method != "POST" {
+		t.Errorf("expected method POST, got %s", form.Method)
+	}
+	if form.Fields["token"] != "abc123" {
+		t.Errorf("expected token=abc123, got %q", form.Fields["token"])
+	}
+	if _, ok := form.Fields["username"]; !ok {
+		t.Error("expected username field")
+	}
+	if _, ok := form.Fields["password"]; !ok {
+		t.Error("expected password field")
+	}
+	// Submit button should NOT be included
+	if _, ok := form.Fields["submit"]; ok {
+		t.Error("submit button should be excluded from form fields")
+	}
+}
+
+func TestExtractFormData_SAMLResponse(t *testing.T) {
+	body := []byte(`<html><body>
+		<form method="POST" action="https://sap.example.com/sap/saml2/sp/acs">
+			<input type="hidden" name="SAMLResponse" value="PHNhbWxwOlJ..."/>
+			<input type="hidden" name="RelayState" value="token"/>
+		</form>
+		<script>document.forms[0].submit();</script>
+	</body></html>`)
+
+	form, err := extractFormData(body, nil)
+	if err != nil {
+		t.Fatalf("extractFormData failed: %v", err)
+	}
+
+	if form.Action != "https://sap.example.com/sap/saml2/sp/acs" {
+		t.Errorf("expected SAP ACS URL, got %s", form.Action)
+	}
+	if form.Fields["SAMLResponse"] != "PHNhbWxwOlJ..." {
+		t.Errorf("expected SAMLResponse field")
+	}
+	if form.Fields["RelayState"] != "token" {
+		t.Errorf("expected RelayState field")
+	}
+}
+
+func TestExtractFormData_NoForm(t *testing.T) {
+	body := []byte(`<html><body><p>No forms here</p></body></html>`)
+	_, err := extractFormData(body, nil)
+	if err == nil {
+		t.Fatal("expected error for HTML without forms")
+	}
+}
+
+func TestExtractFormData_RelativeAction(t *testing.T) {
+	body := []byte(`<form action="/relative/path"><input name="f" value="v"/></form>`)
+	base, _ := url.Parse("https://host.example.com/some/page")
+
+	form, err := extractFormData(body, base)
+	if err != nil {
+		t.Fatalf("extractFormData failed: %v", err)
+	}
+	if form.Action != "https://host.example.com/relative/path" {
+		t.Errorf("expected resolved URL, got %s", form.Action)
+	}
+}
+
+func TestZeroBytes(t *testing.T) {
+	data := []byte("secret password")
+	original := make([]byte, len(data))
+	copy(original, data)
+
+	zeroBytes(data)
+
+	for i, b := range data {
+		if b != 0 {
+			t.Errorf("byte %d not zeroed: got %d", i, b)
+		}
+	}
+
+	// Verify original was actually non-zero
+	if bytes.Equal(original, data) {
+		t.Error("original and zeroed should differ")
+	}
+}
+
+func TestExtractSAPCookiesFromJar(t *testing.T) {
+	// Use httptest server that sets cookies, then extract via jar.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.SetCookie(w, &http.Cookie{Name: "MYSAPSSO2", Value: "token", Path: "/"})
+		http.SetCookie(w, &http.Cookie{Name: "SAP_SESSIONID_X_001", Value: "sess", Path: "/sap/"})
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	// Create client with a cookie jar.
+	jar, _ := cookiejar.New(nil)
+	client := &http.Client{Jar: jar}
+	resp, err := client.Get(srv.URL)
+	if err != nil {
+		t.Fatalf("GET failed: %v", err)
+	}
+	io.Copy(io.Discard, resp.Body)
+	resp.Body.Close()
+
+	u, _ := url.Parse(srv.URL)
+	cookies := extractSAPCookiesFromJar(jar, u)
+
+	if cookies["MYSAPSSO2"] != "token" {
+		t.Errorf("expected MYSAPSSO2=token, got %q", cookies["MYSAPSSO2"])
+	}
+}

--- a/pkg/adt/saml_auth_test.go
+++ b/pkg/adt/saml_auth_test.go
@@ -427,6 +427,27 @@ func TestSAMLLogin_FormChainHostMismatch(t *testing.T) {
 	}
 }
 
+func TestSAMLLogin_RedirectHTTPDowngrade(t *testing.T) {
+	// HTTPS server redirects to HTTP — CheckRedirect should reject the downgrade.
+	httpSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Error("request should not reach HTTP server after downgrade rejection")
+	}))
+	defer httpSrv.Close()
+
+	httpsSrv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, httpSrv.URL+"/idp/login", http.StatusFound)
+	}))
+	defer httpsSrv.Close()
+
+	_, err := SAMLLogin(context.Background(), httpsSrv.URL, testCredProvider("u", "p"), true, false)
+	if err == nil {
+		t.Fatal("expected error for HTTPS→HTTP redirect downgrade, got nil")
+	}
+	if !strings.Contains(err.Error(), "downgrade") {
+		t.Errorf("expected downgrade error, got: %v", err)
+	}
+}
+
 // --- extractFormData unit tests ---
 
 func TestExtractFormData_BasicForm(t *testing.T) {


### PR DESCRIPTION
## Summary

Add SAML SSO authentication support for SAP S/4HANA Public Cloud systems where Basic Auth is disabled for business users.

**Three new capabilities:**

- **`--browser-auth` fix**: Existing browser-based auth now works with SAML/IAS SSO flows. Improved cookie URL filtering (`cookieURLsForSAP()` queries 4 URL paths), smarter poll timing (500ms intervals with elapsed tracking), and verbose SAML redirect logging.

- **`--saml-auth` (new)**: Programmatic SAML SSO without a browser. Performs the full SAP→IAS→SAP SAML dance via HTTP client. Supports SP-initiated (HTTP-POST binding) and IdP-initiated flows. Automatic 401 re-auth with stampede protection (mutex + cooldown). Ideal for CI/CD pipelines. Does not support MFA — use `--browser-auth` for MFA-protected systems.

- **`--credential-cmd` (new)**: External credential provider integration (git-credential-helper pattern). Executes an external command that returns `{"username": "...", "password": "..."}` JSON. Works with any credential manager (KeePass CLI, 1Password, HashiCorp Vault, etc.). Argv-based execution — no shell interpretation.

**Security hardening:**
- HTTPS→HTTP downgrade prevention at 5 enforcement points (redirects, form actions, SP-initiated flow)
- Host validation prevents credential/assertion exfiltration via crafted form actions
- Case-insensitive, port-normalized host comparison (`canonicalHost`)
- Credential zeroing (`[]byte`) after each use; `CredentialProvider` callback re-reads on each auth attempt
- No shell execution in `--credential-cmd` (argv-based `exec.Command`)
- Verbose mode never logs passwords, SAML assertions, or cookie values
- 10-hop redirect/form chain limit prevents infinite loops
- `cmd.Context()` propagation for proper Ctrl+C cancellation

**New dependency:** `golang.org/x/net` (for `html` package — robust HTML form parsing instead of regex)

## Files changed

| File | Change |
|------|--------|
| `pkg/adt/saml_auth.go` | New — 4-step SAML dance, form parser, host validation |
| `pkg/adt/saml_auth_test.go` | New — 16 test cases (full flow, errors, security guards) |
| `pkg/adt/credential_cmd.go` | New — argv-based credential command execution |
| `pkg/adt/credential_cmd_test.go` | New — 8 test cases (valid/invalid JSON, timeout, etc.) |
| `pkg/adt/browser_auth.go` | Modified — cookie URL filtering, poll timing, SAML logging |
| `pkg/adt/browser_auth_test.go` | Modified — expanded cookie/auth tests |
| `pkg/adt/browser_auth_integration_test.go` | New — chromedp integration tests (build tag) |
| `pkg/adt/http.go` | Modified — 401 re-auth handler, `ReauthFunc`, stampede protection |
| `pkg/adt/config.go` | Modified — `ReauthFunc` field + `WithReauthFunc` option |
| `cmd/vsp/main.go` | Modified — CLI flags, `processSAMLAuth()`, credential wiring |
| `go.mod` / `go.sum` | Modified — add `golang.org/x/net` |
| `internal/mcp/server.go` | Modified — version string update |

## Usage examples

```bash
# Browser-based SAML SSO (supports MFA)
vsp --browser-auth --url https://your-system.s4hana.cloud.sap -v

# Programmatic SAML SSO (no browser, no MFA)
vsp --saml-auth --saml-user user@company.com --saml-password '***' \
    --url https://your-system.s4hana.cloud.sap

# With environment variables
export SAP_SAML_USER=user@company.com
export SAP_SAML_PASSWORD='***'
vsp --saml-auth --url https://your-system.s4hana.cloud.sap

# With external credential provider
vsp --saml-auth --credential-cmd 'keepassxc-cli show -sa password MyDB.kdbx SAP' \
    --url https://your-system.s4hana.cloud.sap
```

## Test plan

- [x] `go test ./pkg/adt/...` — all tests pass (6.5s)
- [x] `go build ./cmd/vsp` — compiles clean
- [x] 3 rounds of security audit (credential lifecycle, host validation, shell injection, SAML assertion protection)
- [ ] Manual test against S/4HANA Public Cloud — pending system access