### PR TITLE
fix: detect HANA database from S4CORE component in GetSystemInfo

### DIFF
--- a/pkg/adt/client.go
+++ b/pkg/adt/client.go
@@ -1000,10 +1000,20 @@ func (c *Client) GetSystemInfo(ctx context.Context) (*SystemInfo, error) {
 	}
 
 	// Try to detect HANA from CVERS (optional)
-	hanaResult, err := c.RunQuery(ctx, "SELECT RELEASE FROM CVERS WHERE COMPONENT LIKE '%HDB%' OR COMPONENT LIKE '%HANA%'", 1)
+	hanaResult, err := c.RunQuery(ctx,
+		"SELECT RELEASE FROM CVERS WHERE COMPONENT LIKE '%HDB%' OR COMPONENT LIKE '%HANA%'", 1)
 	if err == nil && len(hanaResult.Rows) > 0 {
 		info.DatabaseSystem = "HDB"
 		info.DatabaseRelease = getString(hanaResult.Rows[0], "RELEASE")
+	} else {
+		// Step 2: S4CORE in CVERS — pure S/4HANA.
+		// S/4HANA implies HANA database. However its version cannot be inferred from the software component.
+		// Therefore DatabaseRelease is left blank
+		s4Result, err := c.RunQuery(ctx,
+			"SELECT COMPONENT FROM CVERS WHERE COMPONENT = 'S4CORE'", 1)
+		if err == nil && len(s4Result.Rows) > 0 {
+			info.DatabaseSystem = "HDB"
+		}
 	}
 
 	// If we couldn't get SystemID from T000, use fallback


### PR DESCRIPTION
 **Detect HANA database from S4CORE component**

`GetSystemInfo` currently relies on explicit HANA software components in the `CVERS` table. While this works for ECC on HANA, S/4HANA environments (like version 2022/757) often lack these specific components, causing the database to be reported incorrectly.

 **Changes:**
 - Added a fallback check for the `S4CORE` component.
 - Since S/4HANA strictly implies a HANA database, this allows the system to correctly identify `DatabaseSystem` as `HDB`.
 - **Note:** The specific HANA database version cannot be determined via `S4CORE`, so `DatabaseRelease` is left blank in this scenario.

 **A path for a possible rework**

 Other approaches for system info retrieval (e.g., Marianfoo's ARC-1) may be worth analyzing for more comprehensive metadata in future patches.