### PR TITLE
fix: enforce SAP_ALLOWED_PACKAGES on existing-object mutations

### DIFF
--- a/pkg/adt/client.go
+++ b/pkg/adt/client.go
@@ -117,9 +117,88 @@ func (c *Client) checkPackageSafety(pkg string) error {
 	return c.config.Safety.CheckPackage(pkg)
 }
 
+// checkObjectPackageSafety resolves the package for an existing object and
+// validates it against the configured package whitelist.
+func (c *Client) checkObjectPackageSafety(ctx context.Context, objectURL string) error {
+	if len(c.config.Safety.AllowedPackages) == 0 {
+		return nil
+	}
+
+	pkg, err := c.getObjectPackage(ctx, objectURL)
+	if err != nil {
+		return fmt.Errorf("resolving package for %s: %w", normalizeObjectURLForPackageCheck(objectURL), err)
+	}
+
+	return c.checkPackageSafety(pkg)
+}
+
 // checkTransportableEdit checks if editing objects that require transports is allowed.
 func (c *Client) checkTransportableEdit(transport, opName string) error {
 	return c.config.Safety.CheckTransportableEdit(transport, opName)
+}
+
+func (c *Client) getObjectPackage(ctx context.Context, objectURL string) (string, error) {
+	normalized := normalizeObjectURLForPackageCheck(objectURL)
+	objectName, err := objectNameFromURL(normalized)
+	if err != nil {
+		return "", err
+	}
+
+	results, err := c.SearchObject(ctx, objectName, 20)
+	if err != nil {
+		return "", err
+	}
+
+	canonicalURL := canonicalizeObjectURL(normalized)
+	for _, result := range results {
+		if result.PackageName == "" {
+			continue
+		}
+		if canonicalizeObjectURL(result.URI) == canonicalURL {
+			return result.PackageName, nil
+		}
+	}
+
+	return "", fmt.Errorf("package metadata not found")
+}
+
+func normalizeObjectURLForPackageCheck(objectURL string) string {
+	normalized := strings.TrimSuffix(objectURL, "/")
+
+	if idx := strings.Index(normalized, "/includes/"); idx >= 0 {
+		return normalized[:idx]
+	}
+	if strings.HasSuffix(normalized, "/source/main") {
+		return strings.TrimSuffix(normalized, "/source/main")
+	}
+
+	return normalized
+}
+
+func canonicalizeObjectURL(objectURL string) string {
+	normalized := normalizeObjectURLForPackageCheck(objectURL)
+	if decoded, err := url.PathUnescape(normalized); err == nil {
+		normalized = decoded
+	}
+	return strings.ToLower(strings.TrimSuffix(normalized, "/"))
+}
+
+func objectNameFromURL(objectURL string) (string, error) {
+	normalized := normalizeObjectURLForPackageCheck(objectURL)
+	parts := strings.Split(strings.Trim(normalized, "/"), "/")
+	if len(parts) == 0 {
+		return "", fmt.Errorf("invalid object URL")
+	}
+
+	name, err := url.PathUnescape(parts[len(parts)-1])
+	if err != nil {
+		return "", fmt.Errorf("decoding object name: %w", err)
+	}
+	if name == "" {
+		return "", fmt.Errorf("invalid object URL")
+	}
+
+	return strings.ToUpper(name), nil
 }
 
 // Safety returns the safety configuration for checking transport operations.
@@ -2283,4 +2362,3 @@ func (c *Client) GetAPIReleaseState(ctx context.Context, objectURI string) (*API
 
 	return &state, nil
 }
-

--- a/pkg/adt/client_test.go
+++ b/pkg/adt/client_test.go
@@ -45,6 +45,13 @@ func newTestResponse(body string) *http.Response {
 	}
 }
 
+func newSearchResponse(uri, objType, name, pkg string) *http.Response {
+	return newTestResponse(`<?xml version="1.0" encoding="UTF-8"?>
+<adtcore:objectReferences xmlns:adtcore="http://www.sap.com/adt/core">
+  <adtcore:objectReference adtcore:uri="` + uri + `" adtcore:type="` + objType + `" adtcore:name="` + name + `" adtcore:packageName="` + pkg + `"/>
+</adtcore:objectReferences>`)
+}
+
 func TestClient_SearchObject(t *testing.T) {
 	searchResponse := `<?xml version="1.0" encoding="UTF-8"?>
 <adtcore:objectReferences xmlns:adtcore="http://www.sap.com/adt/core">
@@ -73,6 +80,128 @@ func TestClient_SearchObject(t *testing.T) {
 
 	if results[0].Name != "ZTEST" {
 		t.Errorf("Name = %v, want ZTEST", results[0].Name)
+	}
+}
+
+func TestClient_CheckObjectPackageSafety_NormalizesObjectURLs(t *testing.T) {
+	tests := []struct {
+		name      string
+		objectURL string
+		searchURI string
+	}{
+		{
+			name:      "source main URL resolves to parent object",
+			objectURL: "/sap/bc/adt/programs/programs/ZTEST/source/main",
+			searchURI: "/sap/bc/adt/programs/programs/ztest",
+		},
+		{
+			name:      "class include URL resolves to parent class",
+			objectURL: "/sap/bc/adt/oo/classes/ZCL_TEST/includes/testclasses",
+			searchURI: "/sap/bc/adt/oo/classes/zcl_test",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mock := &mockTransportClient{
+				responses: map[string]*http.Response{
+					"search":    newSearchResponse(tt.searchURI, "PROG/P", "ZTEST", "$TMP"),
+					"discovery": newTestResponse("OK"),
+				},
+			}
+
+			cfg := NewConfig("https://sap.example.com:44300", "user", "pass", WithAllowedPackages("$TMP"))
+			transport := NewTransportWithClient(cfg, mock)
+			client := NewClientWithTransport(cfg, transport)
+
+			if err := client.checkObjectPackageSafety(context.Background(), tt.objectURL); err != nil {
+				t.Fatalf("checkObjectPackageSafety failed: %v", err)
+			}
+		})
+	}
+}
+
+func TestClient_UpdateSource_EnforcesAllowedPackages(t *testing.T) {
+	mock := &mockTransportClient{
+		responses: map[string]*http.Response{
+			"search":    newSearchResponse("/sap/bc/adt/programs/programs/ztest", "PROG/P", "ZTEST", "ZOTHER"),
+			"discovery": newTestResponse("OK"),
+		},
+	}
+
+	cfg := NewConfig("https://sap.example.com:44300", "user", "pass", WithAllowedPackages("$TMP"))
+	transport := NewTransportWithClient(cfg, mock)
+	client := NewClientWithTransport(cfg, transport)
+
+	err := client.UpdateSource(context.Background(), "/sap/bc/adt/programs/programs/ZTEST/source/main", "REPORT ztest.", "lock123", "")
+	if err == nil {
+		t.Fatal("UpdateSource should fail when object package is not allowed")
+	}
+	if !strings.Contains(err.Error(), "operations on package 'ZOTHER'") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestClient_DeleteObject_EnforcesAllowedPackages(t *testing.T) {
+	mock := &mockTransportClient{
+		responses: map[string]*http.Response{
+			"search":    newSearchResponse("/sap/bc/adt/programs/programs/ztest", "PROG/P", "ZTEST", "ZOTHER"),
+			"discovery": newTestResponse("OK"),
+		},
+	}
+
+	cfg := NewConfig("https://sap.example.com:44300", "user", "pass", WithAllowedPackages("$TMP"))
+	transport := NewTransportWithClient(cfg, mock)
+	client := NewClientWithTransport(cfg, transport)
+
+	err := client.DeleteObject(context.Background(), "/sap/bc/adt/programs/programs/ZTEST", "lock123", "")
+	if err == nil {
+		t.Fatal("DeleteObject should fail when object package is not allowed")
+	}
+	if !strings.Contains(err.Error(), "operations on package 'ZOTHER'") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestClient_CreateTestInclude_EnforcesAllowedPackages(t *testing.T) {
+	mock := &mockTransportClient{
+		responses: map[string]*http.Response{
+			"search":    newSearchResponse("/sap/bc/adt/oo/classes/zcl_test", "CLAS/OC", "ZCL_TEST", "ZOTHER"),
+			"discovery": newTestResponse("OK"),
+		},
+	}
+
+	cfg := NewConfig("https://sap.example.com:44300", "user", "pass", WithAllowedPackages("$TMP"))
+	transport := NewTransportWithClient(cfg, mock)
+	client := NewClientWithTransport(cfg, transport)
+
+	err := client.CreateTestInclude(context.Background(), "ZCL_TEST", "lock123", "")
+	if err == nil {
+		t.Fatal("CreateTestInclude should fail when parent class package is not allowed")
+	}
+	if !strings.Contains(err.Error(), "operations on package 'ZOTHER'") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestClient_WriteMessageClassTexts_EnforcesAllowedPackages(t *testing.T) {
+	mock := &mockTransportClient{
+		responses: map[string]*http.Response{
+			"search":    newSearchResponse("/sap/bc/adt/messageclass/ztest_mc", "MSAG", "ZTEST_MC", "ZOTHER"),
+			"discovery": newTestResponse("OK"),
+		},
+	}
+
+	cfg := NewConfig("https://sap.example.com:44300", "user", "pass", WithAllowedPackages("$TMP"))
+	transport := NewTransportWithClient(cfg, mock)
+	client := NewClientWithTransport(cfg, transport)
+
+	err := client.WriteMessageClassTexts(context.Background(), "ZTEST_MC", "EN", nil, "lock123", "")
+	if err == nil {
+		t.Fatal("WriteMessageClassTexts should fail when object package is not allowed")
+	}
+	if !strings.Contains(err.Error(), "operations on package 'ZOTHER'") {
+		t.Fatalf("unexpected error: %v", err)
 	}
 }
 

--- a/pkg/adt/crud.go
+++ b/pkg/adt/crud.go
@@ -117,6 +117,12 @@ func (c *Client) UpdateSource(ctx context.Context, objectSourceURL string, sourc
 	if err := c.checkSafety(OpUpdate, "UpdateSource"); err != nil {
 		return err
 	}
+	if err := c.checkObjectPackageSafety(ctx, objectSourceURL); err != nil {
+		return err
+	}
+	if err := c.checkTransportableEdit(transport, "UpdateSource"); err != nil {
+		return err
+	}
 
 	params := url.Values{}
 	params.Set("lockHandle", lockHandle)
@@ -602,6 +608,12 @@ func (c *Client) DeleteObject(ctx context.Context, objectURL string, lockHandle 
 	if err := c.checkSafety(OpDelete, "DeleteObject"); err != nil {
 		return err
 	}
+	if err := c.checkObjectPackageSafety(ctx, objectURL); err != nil {
+		return err
+	}
+	if err := c.checkTransportableEdit(transport, "DeleteObject"); err != nil {
+		return err
+	}
 
 	params := url.Values{}
 	params.Set("lockHandle", lockHandle)
@@ -712,6 +724,12 @@ func GetClassIncludeSourceURL(className string, includeType ClassIncludeType) st
 // Supports namespaced classes.
 func (c *Client) CreateTestInclude(ctx context.Context, className string, lockHandle string, transport string) error {
 	className = strings.ToUpper(className)
+	if err := c.checkObjectPackageSafety(ctx, GetObjectURL(ObjectTypeClass, className, "")); err != nil {
+		return err
+	}
+	if err := c.checkTransportableEdit(transport, "CreateTestInclude"); err != nil {
+		return err
+	}
 
 	body := `<?xml version="1.0" encoding="UTF-8"?>
 <class:abapClassInclude xmlns:class="http://www.sap.com/adt/oo/classes"
@@ -757,6 +775,12 @@ func (c *Client) GetClassInclude(ctx context.Context, className string, includeT
 // Requires a lock on the parent class.
 func (c *Client) UpdateClassInclude(ctx context.Context, className string, includeType ClassIncludeType, source string, lockHandle string, transport string) error {
 	sourceURL := GetClassIncludeSourceURL(className, includeType)
+	if err := c.checkObjectPackageSafety(ctx, sourceURL); err != nil {
+		return err
+	}
+	if err := c.checkTransportableEdit(transport, "UpdateClassInclude"); err != nil {
+		return err
+	}
 
 	params := url.Values{}
 	params.Set("lockHandle", lockHandle)

--- a/pkg/adt/crud.go
+++ b/pkg/adt/crud.go
@@ -113,14 +113,13 @@ func (c *Client) UnlockObject(ctx context.Context, objectURL string, lockHandle 
 // lockHandle is required (from LockObject)
 // transport is optional (for transportable objects)
 func (c *Client) UpdateSource(ctx context.Context, objectSourceURL string, source string, lockHandle string, transport string) error {
-	// Safety check
-	if err := c.checkSafety(OpUpdate, "UpdateSource"); err != nil {
-		return err
-	}
-	if err := c.checkObjectPackageSafety(ctx, objectSourceURL); err != nil {
-		return err
-	}
-	if err := c.checkTransportableEdit(transport, "UpdateSource"); err != nil {
+	// Unified mutation policy gate (op type + package + transport)
+	if err := c.checkMutation(ctx, MutationContext{
+		Op:        OpUpdate,
+		OpName:    "UpdateSource",
+		ObjectURL: objectSourceURL,
+		Transport: transport,
+	}); err != nil {
 		return err
 	}
 
@@ -318,11 +317,6 @@ func (c *Client) packageExists(ctx context.Context, packageName string) bool {
 // This prevents orphan ENQUEUE locks that SAP creates internally during CreateObject
 // before validating the request. These orphan locks can only be cleared via SM12.
 func (c *Client) CreateObject(ctx context.Context, opts CreateObjectOptions) error {
-	// Safety check
-	if err := c.checkSafety(OpCreate, "CreateObject"); err != nil {
-		return err
-	}
-
 	typeInfo, ok := objectTypes[opts.ObjectType]
 	if !ok {
 		return fmt.Errorf("unsupported object type: %s", opts.ObjectType)
@@ -331,13 +325,19 @@ func (c *Client) CreateObject(ctx context.Context, opts CreateObjectOptions) err
 	opts.Name = strings.ToUpper(opts.Name)
 	opts.PackageName = strings.ToUpper(opts.PackageName)
 
-	// Check package restrictions
 	// For package creation, check the package being created (opts.Name), not the parent (opts.PackageName)
 	packageToCheck := opts.PackageName
 	if opts.ObjectType == ObjectTypePackage {
 		packageToCheck = opts.Name
 	}
-	if err := c.checkPackageSafety(packageToCheck); err != nil {
+
+	// Unified mutation policy gate (op type + package + transport)
+	if err := c.checkMutation(ctx, MutationContext{
+		Op:        OpCreate,
+		OpName:    "CreateObject",
+		Package:   packageToCheck,
+		Transport: opts.Transport,
+	}); err != nil {
 		return err
 	}
 
@@ -604,14 +604,13 @@ func escapeXML(s string) string {
 // lockHandle is required (from LockObject)
 // transport is optional (for transportable objects)
 func (c *Client) DeleteObject(ctx context.Context, objectURL string, lockHandle string, transport string) error {
-	// Safety check
-	if err := c.checkSafety(OpDelete, "DeleteObject"); err != nil {
-		return err
-	}
-	if err := c.checkObjectPackageSafety(ctx, objectURL); err != nil {
-		return err
-	}
-	if err := c.checkTransportableEdit(transport, "DeleteObject"); err != nil {
+	// Unified mutation policy gate (op type + package + transport)
+	if err := c.checkMutation(ctx, MutationContext{
+		Op:        OpDelete,
+		OpName:    "DeleteObject",
+		ObjectURL: objectURL,
+		Transport: transport,
+	}); err != nil {
 		return err
 	}
 
@@ -724,10 +723,14 @@ func GetClassIncludeSourceURL(className string, includeType ClassIncludeType) st
 // Supports namespaced classes.
 func (c *Client) CreateTestInclude(ctx context.Context, className string, lockHandle string, transport string) error {
 	className = strings.ToUpper(className)
-	if err := c.checkObjectPackageSafety(ctx, GetObjectURL(ObjectTypeClass, className, "")); err != nil {
-		return err
-	}
-	if err := c.checkTransportableEdit(transport, "CreateTestInclude"); err != nil {
+
+	// Unified mutation policy gate (op type + parent class package + transport)
+	if err := c.checkMutation(ctx, MutationContext{
+		Op:        OpCreate,
+		OpName:    "CreateTestInclude",
+		ObjectURL: GetObjectURL(ObjectTypeClass, className, ""),
+		Transport: transport,
+	}); err != nil {
 		return err
 	}
 
@@ -775,10 +778,14 @@ func (c *Client) GetClassInclude(ctx context.Context, className string, includeT
 // Requires a lock on the parent class.
 func (c *Client) UpdateClassInclude(ctx context.Context, className string, includeType ClassIncludeType, source string, lockHandle string, transport string) error {
 	sourceURL := GetClassIncludeSourceURL(className, includeType)
-	if err := c.checkObjectPackageSafety(ctx, sourceURL); err != nil {
-		return err
-	}
-	if err := c.checkTransportableEdit(transport, "UpdateClassInclude"); err != nil {
+
+	// Unified mutation policy gate (op type + package + transport)
+	if err := c.checkMutation(ctx, MutationContext{
+		Op:        OpUpdate,
+		OpName:    "UpdateClassInclude",
+		ObjectURL: sourceURL,
+		Transport: transport,
+	}); err != nil {
 		return err
 	}
 

--- a/pkg/adt/i18n.go
+++ b/pkg/adt/i18n.go
@@ -127,6 +127,12 @@ func (c *Client) WriteMessageClassTexts(ctx context.Context, name, lang string, 
 
 	name = strings.ToUpper(name)
 	lang = strings.ToUpper(lang)
+	if err := c.checkObjectPackageSafety(ctx, fmt.Sprintf("/sap/bc/adt/messageclass/%s", url.PathEscape(strings.ToLower(name)))); err != nil {
+		return err
+	}
+	if err := c.checkTransportableEdit(transport, "WriteMessageClassTexts"); err != nil {
+		return err
+	}
 
 	// Build XML body
 	mc := MessageClass{
@@ -169,6 +175,12 @@ func (c *Client) WriteDataElementLabels(ctx context.Context, name, lang string, 
 
 	name = strings.ToUpper(name)
 	lang = strings.ToUpper(lang)
+	if err := c.checkObjectPackageSafety(ctx, fmt.Sprintf("/sap/bc/adt/ddic/dataelements/%s", url.PathEscape(name))); err != nil {
+		return err
+	}
+	if err := c.checkTransportableEdit(transport, "WriteDataElementLabels"); err != nil {
+		return err
+	}
 
 	body, err := xml.Marshal(labels)
 	if err != nil {

--- a/pkg/adt/i18n.go
+++ b/pkg/adt/i18n.go
@@ -121,16 +121,16 @@ func (c *Client) GetMessageClassTexts(ctx context.Context, name, lang string) ([
 // WriteMessageClassTexts updates message class texts in a specific language.
 // Requires a lock handle from LockObject and optionally a transport request number.
 func (c *Client) WriteMessageClassTexts(ctx context.Context, name, lang string, texts []MessageClassMessage, lockHandle, transport string) error {
-	if err := c.checkSafety(OpUpdate, "WriteMessageClassTexts"); err != nil {
-		return err
-	}
-
 	name = strings.ToUpper(name)
 	lang = strings.ToUpper(lang)
-	if err := c.checkObjectPackageSafety(ctx, fmt.Sprintf("/sap/bc/adt/messageclass/%s", url.PathEscape(strings.ToLower(name)))); err != nil {
-		return err
-	}
-	if err := c.checkTransportableEdit(transport, "WriteMessageClassTexts"); err != nil {
+
+	// Unified mutation policy gate (op type + package + transport)
+	if err := c.checkMutation(ctx, MutationContext{
+		Op:        OpUpdate,
+		OpName:    "WriteMessageClassTexts",
+		ObjectURL: fmt.Sprintf("/sap/bc/adt/messageclass/%s", url.PathEscape(strings.ToLower(name))),
+		Transport: transport,
+	}); err != nil {
 		return err
 	}
 
@@ -169,16 +169,16 @@ func (c *Client) WriteMessageClassTexts(ctx context.Context, name, lang string, 
 // WriteDataElementLabels updates data element labels in a specific language.
 // Requires a lock handle from LockObject and optionally a transport request number.
 func (c *Client) WriteDataElementLabels(ctx context.Context, name, lang string, labels *DataElementLabels, lockHandle, transport string) error {
-	if err := c.checkSafety(OpUpdate, "WriteDataElementLabels"); err != nil {
-		return err
-	}
-
 	name = strings.ToUpper(name)
 	lang = strings.ToUpper(lang)
-	if err := c.checkObjectPackageSafety(ctx, fmt.Sprintf("/sap/bc/adt/ddic/dataelements/%s", url.PathEscape(name))); err != nil {
-		return err
-	}
-	if err := c.checkTransportableEdit(transport, "WriteDataElementLabels"); err != nil {
+
+	// Unified mutation policy gate (op type + package + transport)
+	if err := c.checkMutation(ctx, MutationContext{
+		Op:        OpUpdate,
+		OpName:    "WriteDataElementLabels",
+		ObjectURL: fmt.Sprintf("/sap/bc/adt/ddic/dataelements/%s", url.PathEscape(name)),
+		Transport: transport,
+	}); err != nil {
 		return err
 	}
 

--- a/pkg/adt/mutation_gate.go
+++ b/pkg/adt/mutation_gate.go
@@ -1,0 +1,125 @@
+package adt
+
+import (
+	"context"
+	"fmt"
+)
+
+// MutationSurface identifies the object surface a mutation targets. Different
+// surfaces require different metadata resolution strategies (ADT SearchObject,
+// UI5 BSP metadata, etc.). Use SurfaceADT for standard ABAP objects.
+type MutationSurface int
+
+const (
+	// SurfaceADT is the default ADT object surface (classes, programs,
+	// interfaces, data elements, message classes, etc.). Package resolution
+	// for existing objects uses SearchObject.
+	SurfaceADT MutationSurface = iota
+
+	// SurfaceUI5 is the UI5/BSP filestore surface. Package resolution for
+	// existing UI5 apps is not yet implemented — mutations on this surface
+	// are blocked when AllowedPackages is configured until app→package
+	// resolution lands.
+	SurfaceUI5
+)
+
+// MutationContext describes a single mutation operation for policy evaluation.
+// Callers should build a MutationContext at the top of every mutating public
+// method and pass it to checkMutation before performing any side effects.
+//
+// There are two ways to provide the target package:
+//   - For **existing** objects: set ObjectURL and leave Package empty. The
+//     gate resolves the package from the object metadata.
+//   - For **create** operations: set Package explicitly (and optionally
+//     ObjectURL, but it will not be resolved).
+type MutationContext struct {
+	// Op is the operation type used for safety whitelist/blacklist checks
+	// (OpCreate, OpUpdate, OpDelete, OpActivate, OpWorkflow, ...).
+	Op OperationType
+
+	// OpName is a human-readable name of the operation, used in error
+	// messages ("EditSource", "DeleteObject", ...).
+	OpName string
+
+	// ObjectURL is the ADT URL of an existing object being mutated. When
+	// AllowedPackages is configured and Package is empty, the gate resolves
+	// the object's package via this URL.
+	ObjectURL string
+
+	// Package is an explicit target package, used for create operations
+	// where the package is a caller-supplied parameter.
+	Package string
+
+	// Transport is the transport request number supplied by the caller
+	// (empty for local objects).
+	Transport string
+
+	// Surface selects the package-resolution strategy. Defaults to SurfaceADT.
+	Surface MutationSurface
+}
+
+// checkMutation runs all policy checks for a mutation operation in a single
+// place. It performs (in order):
+//
+//  1. Operation-type safety check (read-only, allowed/disallowed ops)
+//  2. Package ownership check (resolves from ObjectURL for existing objects,
+//     or uses explicit Package for creates)
+//  3. Transportable-edit check (when a transport is supplied)
+//
+// This is the single source of truth for mutation policy. Individual mutators
+// should call this at the top of their implementation instead of wiring the
+// sub-checks by hand — that avoids the class of bug where one sub-check is
+// forgotten and a whole mutation path silently bypasses policy.
+func (c *Client) checkMutation(ctx context.Context, m MutationContext) error {
+	// 1. Operation type check
+	if err := c.checkSafety(m.Op, m.OpName); err != nil {
+		return err
+	}
+
+	// 2. Package ownership check
+	if err := c.checkMutationPackage(ctx, m); err != nil {
+		return err
+	}
+
+	// 3. Transportable-edit check
+	if err := c.checkTransportableEdit(m.Transport, m.OpName); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// checkMutationPackage validates the target package for a mutation. If no
+// package whitelist is configured, the check is a no-op.
+func (c *Client) checkMutationPackage(ctx context.Context, m MutationContext) error {
+	if len(c.config.Safety.AllowedPackages) == 0 {
+		return nil
+	}
+
+	// If the caller supplied an explicit package (create path), check it
+	// directly.
+	if m.Package != "" {
+		return c.checkPackageSafety(m.Package)
+	}
+
+	// Otherwise resolve the package from the existing object.
+	if m.ObjectURL == "" {
+		return fmt.Errorf("mutation gate: %s requires either ObjectURL or Package when AllowedPackages is configured", m.OpName)
+	}
+
+	switch m.Surface {
+	case SurfaceADT:
+		return c.checkObjectPackageSafety(ctx, m.ObjectURL)
+
+	case SurfaceUI5:
+		// UI5 app→package resolution is not yet implemented. Fail closed
+		// when a package whitelist is configured so that UI5 mutations do
+		// not silently bypass policy.
+		return fmt.Errorf(
+			"operation '%s' on UI5 surface is blocked: UI5 app→package resolution not yet implemented, cannot verify package against SAP_ALLOWED_PACKAGES (tracked as follow-up)",
+			m.OpName)
+
+	default:
+		return fmt.Errorf("mutation gate: unknown surface %d for %s", m.Surface, m.OpName)
+	}
+}

--- a/pkg/adt/mutation_gate_test.go
+++ b/pkg/adt/mutation_gate_test.go
@@ -1,0 +1,172 @@
+package adt
+
+import (
+	"context"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+func TestCheckMutation_NoPolicy_Passes(t *testing.T) {
+	cfg := NewConfig("https://sap.example.com:44300", "user", "pass")
+	client := NewClientWithTransport(cfg, NewTransportWithClient(cfg, &mockTransportClient{
+		responses: map[string]*http.Response{"discovery": newTestResponse("OK")},
+	}))
+
+	err := client.checkMutation(context.Background(), MutationContext{
+		Op:        OpUpdate,
+		OpName:    "TestOp",
+		ObjectURL: "/sap/bc/adt/programs/programs/ZTEST",
+	})
+	if err != nil {
+		t.Fatalf("expected no error when no policy configured, got: %v", err)
+	}
+}
+
+func TestCheckMutation_OpType_Blocked(t *testing.T) {
+	cfg := NewConfig("https://sap.example.com:44300", "user", "pass", WithReadOnly())
+	client := NewClientWithTransport(cfg, NewTransportWithClient(cfg, &mockTransportClient{
+		responses: map[string]*http.Response{"discovery": newTestResponse("OK")},
+	}))
+
+	err := client.checkMutation(context.Background(), MutationContext{
+		Op:     OpUpdate,
+		OpName: "TestOp",
+	})
+	if err == nil {
+		t.Fatal("expected read-only mode to block OpUpdate")
+	}
+}
+
+func TestCheckMutation_ExplicitPackage_NotInWhitelist(t *testing.T) {
+	cfg := NewConfig("https://sap.example.com:44300", "user", "pass", WithAllowedPackages("$TMP"))
+	client := NewClientWithTransport(cfg, NewTransportWithClient(cfg, &mockTransportClient{
+		responses: map[string]*http.Response{"discovery": newTestResponse("OK")},
+	}))
+
+	err := client.checkMutation(context.Background(), MutationContext{
+		Op:      OpCreate,
+		OpName:  "CreateObject",
+		Package: "ZOTHER",
+	})
+	if err == nil {
+		t.Fatal("expected explicit package outside whitelist to be blocked")
+	}
+	if !strings.Contains(err.Error(), "ZOTHER") {
+		t.Fatalf("expected error to mention blocked package, got: %v", err)
+	}
+}
+
+func TestCheckMutation_ObjectURL_ResolvesADTPackage(t *testing.T) {
+	mock := &mockTransportClient{
+		responses: map[string]*http.Response{
+			"search":    newSearchResponse("/sap/bc/adt/programs/programs/ztest", "PROG/P", "ZTEST", "ZOTHER"),
+			"discovery": newTestResponse("OK"),
+		},
+	}
+	cfg := NewConfig("https://sap.example.com:44300", "user", "pass", WithAllowedPackages("$TMP"))
+	client := NewClientWithTransport(cfg, NewTransportWithClient(cfg, mock))
+
+	err := client.checkMutation(context.Background(), MutationContext{
+		Op:        OpUpdate,
+		OpName:    "UpdateSource",
+		ObjectURL: "/sap/bc/adt/programs/programs/ZTEST/source/main",
+	})
+	if err == nil {
+		t.Fatal("expected object URL resolution to block non-whitelisted package")
+	}
+	if !strings.Contains(err.Error(), "ZOTHER") {
+		t.Fatalf("expected error to mention resolved package, got: %v", err)
+	}
+}
+
+func TestCheckMutation_UI5Surface_BlockedWhenPolicyActive(t *testing.T) {
+	cfg := NewConfig("https://sap.example.com:44300", "user", "pass", WithAllowedPackages("$TMP"))
+	client := NewClientWithTransport(cfg, NewTransportWithClient(cfg, &mockTransportClient{
+		responses: map[string]*http.Response{"discovery": newTestResponse("OK")},
+	}))
+
+	err := client.checkMutation(context.Background(), MutationContext{
+		Op:        OpUpdate,
+		OpName:    "UI5UploadFile",
+		ObjectURL: "MYAPP",
+		Surface:   SurfaceUI5,
+	})
+	if err == nil {
+		t.Fatal("expected UI5 surface to be blocked until app→package resolution lands")
+	}
+	if !strings.Contains(err.Error(), "UI5") {
+		t.Fatalf("expected error to mention UI5, got: %v", err)
+	}
+}
+
+func TestCheckMutation_UI5Surface_AllowedWhenNoPolicy(t *testing.T) {
+	cfg := NewConfig("https://sap.example.com:44300", "user", "pass")
+	client := NewClientWithTransport(cfg, NewTransportWithClient(cfg, &mockTransportClient{
+		responses: map[string]*http.Response{"discovery": newTestResponse("OK")},
+	}))
+
+	err := client.checkMutation(context.Background(), MutationContext{
+		Op:        OpUpdate,
+		OpName:    "UI5UploadFile",
+		ObjectURL: "MYAPP",
+		Surface:   SurfaceUI5,
+	})
+	if err != nil {
+		t.Fatalf("expected UI5 surface to pass when no package policy, got: %v", err)
+	}
+}
+
+func TestCheckMutation_MissingObjectURLAndPackage_FailsClosed(t *testing.T) {
+	cfg := NewConfig("https://sap.example.com:44300", "user", "pass", WithAllowedPackages("$TMP"))
+	client := NewClientWithTransport(cfg, NewTransportWithClient(cfg, &mockTransportClient{
+		responses: map[string]*http.Response{"discovery": newTestResponse("OK")},
+	}))
+
+	err := client.checkMutation(context.Background(), MutationContext{
+		Op:     OpUpdate,
+		OpName: "MysteryOp",
+	})
+	if err == nil {
+		t.Fatal("expected gate to fail closed when neither ObjectURL nor Package is provided under policy")
+	}
+	if !strings.Contains(err.Error(), "MysteryOp") {
+		t.Fatalf("expected error to mention op name, got: %v", err)
+	}
+}
+
+func TestClient_UI5UploadFile_BlockedUnderAllowedPackages(t *testing.T) {
+	cfg := NewConfig("https://sap.example.com:44300", "user", "pass", WithAllowedPackages("$TMP"))
+	client := NewClientWithTransport(cfg, NewTransportWithClient(cfg, &mockTransportClient{
+		responses: map[string]*http.Response{"discovery": newTestResponse("OK")},
+	}))
+
+	err := client.UI5UploadFile(context.Background(), "MYAPP", "/index.html", []byte("x"), "text/html")
+	if err == nil {
+		t.Fatal("expected UI5UploadFile to be blocked under AllowedPackages policy")
+	}
+}
+
+func TestClient_UI5DeleteFile_BlockedUnderAllowedPackages(t *testing.T) {
+	cfg := NewConfig("https://sap.example.com:44300", "user", "pass", WithAllowedPackages("$TMP"))
+	client := NewClientWithTransport(cfg, NewTransportWithClient(cfg, &mockTransportClient{
+		responses: map[string]*http.Response{"discovery": newTestResponse("OK")},
+	}))
+
+	err := client.UI5DeleteFile(context.Background(), "MYAPP", "/index.html")
+	if err == nil {
+		t.Fatal("expected UI5DeleteFile to be blocked under AllowedPackages policy")
+	}
+}
+
+func TestClient_UI5DeleteApp_BlockedUnderAllowedPackages(t *testing.T) {
+	cfg := NewConfig("https://sap.example.com:44300", "user", "pass", WithAllowedPackages("$TMP"))
+	client := NewClientWithTransport(cfg, NewTransportWithClient(cfg, &mockTransportClient{
+		responses: map[string]*http.Response{"discovery": newTestResponse("OK")},
+	}))
+
+	err := client.UI5DeleteApp(context.Background(), "MYAPP", "")
+	if err == nil {
+		t.Fatal("expected UI5DeleteApp to be blocked under AllowedPackages policy")
+	}
+}

--- a/pkg/adt/ui5.go
+++ b/pkg/adt/ui5.go
@@ -271,11 +271,18 @@ func (c *Client) UI5GetFileContent(ctx context.Context, appName, filePath string
 
 // UI5UploadFile uploads a single file to a UI5/Fiori BSP application.
 func (c *Client) UI5UploadFile(ctx context.Context, appName, filePath string, content []byte, contentType string) error {
-	if err := c.checkSafety(OpUpdate, "UI5UploadFile"); err != nil {
+	appName = strings.ToUpper(appName)
+
+	// Unified mutation policy gate. UI5 surface blocks when AllowedPackages
+	// is configured until app→package resolution is implemented.
+	if err := c.checkMutation(ctx, MutationContext{
+		Op:        OpUpdate,
+		OpName:    "UI5UploadFile",
+		ObjectURL: appName,
+		Surface:   SurfaceUI5,
+	}); err != nil {
 		return err
 	}
-
-	appName = strings.ToUpper(appName)
 	// Remove leading slash if present for path construction
 	if strings.HasPrefix(filePath, "/") {
 		filePath = filePath[1:]
@@ -303,11 +310,18 @@ func (c *Client) UI5UploadFile(ctx context.Context, appName, filePath string, co
 
 // UI5DeleteFile deletes a file from a UI5/Fiori BSP application.
 func (c *Client) UI5DeleteFile(ctx context.Context, appName, filePath string) error {
-	if err := c.checkSafety(OpDelete, "UI5DeleteFile"); err != nil {
+	appName = strings.ToUpper(appName)
+
+	// Unified mutation policy gate. UI5 surface blocks when AllowedPackages
+	// is configured until app→package resolution is implemented.
+	if err := c.checkMutation(ctx, MutationContext{
+		Op:        OpDelete,
+		OpName:    "UI5DeleteFile",
+		ObjectURL: appName,
+		Surface:   SurfaceUI5,
+	}); err != nil {
 		return err
 	}
-
-	appName = strings.ToUpper(appName)
 	// Remove leading slash if present for path construction
 	if strings.HasPrefix(filePath, "/") {
 		filePath = filePath[1:]
@@ -329,15 +343,18 @@ func (c *Client) UI5DeleteFile(ctx context.Context, appName, filePath string) er
 
 // UI5CreateApp creates a new UI5/Fiori BSP application.
 func (c *Client) UI5CreateApp(ctx context.Context, appName, description, packageName, transport string) error {
-	if err := c.checkSafety(OpCreate, "UI5CreateApp"); err != nil {
-		return err
-	}
-
-	if err := c.checkPackageSafety(packageName); err != nil {
-		return err
-	}
-
 	appName = strings.ToUpper(appName)
+
+	// Unified mutation policy gate. Create path provides an explicit package
+	// so no UI5 app→package resolution is required.
+	if err := c.checkMutation(ctx, MutationContext{
+		Op:        OpCreate,
+		OpName:    "UI5CreateApp",
+		Package:   packageName,
+		Transport: transport,
+	}); err != nil {
+		return err
+	}
 
 	// Build XML payload for app creation
 	xmlPayload := fmt.Sprintf(`<?xml version="1.0" encoding="UTF-8"?>
@@ -368,11 +385,19 @@ func (c *Client) UI5CreateApp(ctx context.Context, appName, description, package
 
 // UI5DeleteApp deletes a UI5/Fiori BSP application.
 func (c *Client) UI5DeleteApp(ctx context.Context, appName, transport string) error {
-	if err := c.checkSafety(OpDelete, "UI5DeleteApp"); err != nil {
+	appName = strings.ToUpper(appName)
+
+	// Unified mutation policy gate. UI5 surface blocks when AllowedPackages
+	// is configured until app→package resolution is implemented.
+	if err := c.checkMutation(ctx, MutationContext{
+		Op:        OpDelete,
+		OpName:    "UI5DeleteApp",
+		ObjectURL: appName,
+		Surface:   SurfaceUI5,
+		Transport: transport,
+	}); err != nil {
 		return err
 	}
-
-	appName = strings.ToUpper(appName)
 	deletePath := fmt.Sprintf("%s/%s", ui5FilestoreBase, url.PathEscape(appName))
 
 	params := url.Values{}

--- a/pkg/adt/workflows.go
+++ b/pkg/adt/workflows.go
@@ -32,6 +32,11 @@ func (c *Client) WriteProgram(ctx context.Context, programName string, source st
 	objectURL := fmt.Sprintf("/sap/bc/adt/programs/programs/%s", url.PathEscape(programName))
 	sourceURL := objectURL + "/source/main"
 
+	// Check package safety for existing object
+	if err := c.checkObjectPackageSafety(ctx, objectURL); err != nil {
+		return nil, err
+	}
+
 	result := &WriteProgramResult{
 		ProgramName: programName,
 		ObjectURL:   objectURL,
@@ -121,6 +126,11 @@ func (c *Client) WriteClass(ctx context.Context, className string, source string
 	className = strings.ToUpper(className)
 	objectURL := fmt.Sprintf("/sap/bc/adt/oo/classes/%s", url.PathEscape(className))
 	sourceURL := objectURL + "/source/main"
+
+	// Check package safety for existing object
+	if err := c.checkObjectPackageSafety(ctx, objectURL); err != nil {
+		return nil, err
+	}
 
 	result := &WriteClassResult{
 		ClassName: className,

--- a/pkg/adt/workflows.go
+++ b/pkg/adt/workflows.go
@@ -23,17 +23,17 @@ type WriteProgramResult struct {
 // WriteProgram performs Lock -> SyntaxCheck -> UpdateSource -> Unlock -> Activate workflow.
 // This is a convenience method for updating existing programs.
 func (c *Client) WriteProgram(ctx context.Context, programName string, source string, transport string) (*WriteProgramResult, error) {
-	// Safety check for workflow operations
-	if err := c.checkSafety(OpWorkflow, "WriteProgram"); err != nil {
-		return nil, err
-	}
-
 	programName = strings.ToUpper(programName)
 	objectURL := fmt.Sprintf("/sap/bc/adt/programs/programs/%s", url.PathEscape(programName))
 	sourceURL := objectURL + "/source/main"
 
-	// Check package safety for existing object
-	if err := c.checkObjectPackageSafety(ctx, objectURL); err != nil {
+	// Unified mutation policy gate (op type + package + transport)
+	if err := c.checkMutation(ctx, MutationContext{
+		Op:        OpWorkflow,
+		OpName:    "WriteProgram",
+		ObjectURL: objectURL,
+		Transport: transport,
+	}); err != nil {
 		return nil, err
 	}
 
@@ -118,17 +118,17 @@ type WriteClassResult struct {
 
 // WriteClass performs Lock -> SyntaxCheck -> UpdateSource -> Unlock -> Activate workflow for classes.
 func (c *Client) WriteClass(ctx context.Context, className string, source string, transport string) (*WriteClassResult, error) {
-	// Safety check for workflow operations
-	if err := c.checkSafety(OpWorkflow, "WriteClass"); err != nil {
-		return nil, err
-	}
-
 	className = strings.ToUpper(className)
 	objectURL := fmt.Sprintf("/sap/bc/adt/oo/classes/%s", url.PathEscape(className))
 	sourceURL := objectURL + "/source/main"
 
-	// Check package safety for existing object
-	if err := c.checkObjectPackageSafety(ctx, objectURL); err != nil {
+	// Unified mutation policy gate (op type + package + transport)
+	if err := c.checkMutation(ctx, MutationContext{
+		Op:        OpWorkflow,
+		OpName:    "WriteClass",
+		ObjectURL: objectURL,
+		Transport: transport,
+	}); err != nil {
 		return nil, err
 	}
 
@@ -213,16 +213,16 @@ type CreateProgramResult struct {
 // CreateAndActivateProgram creates a new program with source code and activates it.
 // Workflow: CreateObject -> Lock -> UpdateSource -> Unlock -> Activate
 func (c *Client) CreateAndActivateProgram(ctx context.Context, programName string, description string, packageName string, source string, transport string) (*CreateProgramResult, error) {
-	// Safety check for workflow operations
-	if err := c.checkSafety(OpWorkflow, "CreateAndActivateProgram"); err != nil {
-		return nil, err
-	}
-
 	programName = strings.ToUpper(programName)
 	packageName = strings.ToUpper(packageName)
 
-	// Check package restrictions
-	if err := c.checkPackageSafety(packageName); err != nil {
+	// Unified mutation policy gate (op type + package + transport)
+	if err := c.checkMutation(ctx, MutationContext{
+		Op:        OpWorkflow,
+		OpName:    "CreateAndActivateProgram",
+		Package:   packageName,
+		Transport: transport,
+	}); err != nil {
 		return nil, err
 	}
 
@@ -306,16 +306,16 @@ type CreateClassWithTestsResult struct {
 // CreateClassWithTests creates a new class with unit tests and runs them.
 // Workflow: CreateObject -> Lock -> UpdateSource -> CreateTestInclude -> UpdateClassInclude -> Unlock -> Activate -> RunUnitTests
 func (c *Client) CreateClassWithTests(ctx context.Context, className string, description string, packageName string, classSource string, testSource string, transport string) (*CreateClassWithTestsResult, error) {
-	// Safety check for workflow operations
-	if err := c.checkSafety(OpWorkflow, "CreateClassWithTests"); err != nil {
-		return nil, err
-	}
-
 	className = strings.ToUpper(className)
 	packageName = strings.ToUpper(packageName)
 
-	// Check package restrictions
-	if err := c.checkPackageSafety(packageName); err != nil {
+	// Unified mutation policy gate (op type + package + transport)
+	if err := c.checkMutation(ctx, MutationContext{
+		Op:        OpWorkflow,
+		OpName:    "CreateClassWithTests",
+		Package:   packageName,
+		Transport: transport,
+	}); err != nil {
 		return nil, err
 	}
 

--- a/pkg/adt/workflows_edit.go
+++ b/pkg/adt/workflows_edit.go
@@ -154,6 +154,11 @@ func (c *Client) EditSourceWithOptions(ctx context.Context, objectURL, oldString
 		opts = &EditSourceOptions{SyntaxCheck: true}
 	}
 
+	// Check package safety for existing object
+	if err := c.checkObjectPackageSafety(ctx, objectURL); err != nil {
+		return nil, err
+	}
+
 	// Check if transportable edits are allowed when transport is specified
 	if err := c.checkTransportableEdit(opts.Transport, "EditSource"); err != nil {
 		return nil, err

--- a/pkg/adt/workflows_edit.go
+++ b/pkg/adt/workflows_edit.go
@@ -144,23 +144,18 @@ func (c *Client) EditSource(ctx context.Context, objectURL, oldString, newString
 //     "METHOD foo.\n  rv_result = 42.\n  ENDMETHOD.",
 //     &EditSourceOptions{Method: "FOO"})
 func (c *Client) EditSourceWithOptions(ctx context.Context, objectURL, oldString, newString string, opts *EditSourceOptions) (*EditSourceResult, error) {
-	// Safety check
-	if err := c.checkSafety(OpUpdate, "EditSource"); err != nil {
-		return nil, err
-	}
-
 	// Default options
 	if opts == nil {
 		opts = &EditSourceOptions{SyntaxCheck: true}
 	}
 
-	// Check package safety for existing object
-	if err := c.checkObjectPackageSafety(ctx, objectURL); err != nil {
-		return nil, err
-	}
-
-	// Check if transportable edits are allowed when transport is specified
-	if err := c.checkTransportableEdit(opts.Transport, "EditSource"); err != nil {
+	// Unified mutation policy gate (op type + package + transport)
+	if err := c.checkMutation(ctx, MutationContext{
+		Op:        OpUpdate,
+		OpName:    "EditSource",
+		ObjectURL: objectURL,
+		Transport: opts.Transport,
+	}); err != nil {
 		return nil, err
 	}
 	// SyntaxCheck defaults to true if not explicitly set (zero value is false, so we need to handle this)

--- a/pkg/adt/workflows_fileio.go
+++ b/pkg/adt/workflows_fileio.go
@@ -37,12 +37,23 @@ func (c *Client) RenameObject(ctx context.Context, objType CreatableObjectType, 
 		ObjectType: string(objType),
 	}
 
-	// 1. Get old object source
+	// Check package safety for the old object being renamed
 	oldURL, err := c.buildObjectURL(objType, oldName)
 	if err != nil {
 		return nil, err
 	}
+	if err := c.checkObjectPackageSafety(ctx, oldURL); err != nil {
+		return nil, err
+	}
 
+	// Check package safety for the target package
+	if packageName != "" {
+		if err := c.checkPackageSafety(packageName); err != nil {
+			return nil, err
+		}
+	}
+
+	// 1. Get old object source
 	resp, err := c.transport.Request(ctx, oldURL+"/source/main", &RequestOptions{
 		Method: "GET",
 		Accept: "text/plain",

--- a/pkg/adt/workflows_fileio.go
+++ b/pkg/adt/workflows_fileio.go
@@ -26,29 +26,35 @@ type RenameObjectResult struct {
 //
 // This is a destructive operation - use with caution!
 func (c *Client) RenameObject(ctx context.Context, objType CreatableObjectType, oldName, newName, packageName, transport string) (*RenameObjectResult, error) {
-	// Safety check
-	if err := c.checkSafety(OpDelete, "RenameObject"); err != nil {
-		return nil, err
-	}
-
 	result := &RenameObjectResult{
 		OldName:    oldName,
 		NewName:    newName,
 		ObjectType: string(objType),
 	}
 
-	// Check package safety for the old object being renamed
 	oldURL, err := c.buildObjectURL(objType, oldName)
 	if err != nil {
 		return nil, err
 	}
-	if err := c.checkObjectPackageSafety(ctx, oldURL); err != nil {
+
+	// Unified mutation policy gate for the old object being deleted.
+	if err := c.checkMutation(ctx, MutationContext{
+		Op:        OpDelete,
+		OpName:    "RenameObject",
+		ObjectURL: oldURL,
+		Transport: transport,
+	}); err != nil {
 		return nil, err
 	}
 
-	// Check package safety for the target package
+	// If a target package is supplied, gate the create side as well.
 	if packageName != "" {
-		if err := c.checkPackageSafety(packageName); err != nil {
+		if err := c.checkMutation(ctx, MutationContext{
+			Op:        OpCreate,
+			OpName:    "RenameObject",
+			Package:   packageName,
+			Transport: transport,
+		}); err != nil {
 			return nil, err
 		}
 	}

--- a/pkg/adt/workflows_source.go
+++ b/pkg/adt/workflows_source.go
@@ -187,11 +187,6 @@ func (c *Client) WriteSource(ctx context.Context, objectType, name, source strin
 		fmt.Fprintf(os.Stderr, "[DEBUG] WriteSource: BaseURL=%s, objectType=%s, name=%s\n", c.config.BaseURL, objectType, name)
 	}
 
-	// Safety check for workflow operations
-	if err := c.checkSafety(OpWorkflow, "WriteSource"); err != nil {
-		return nil, err
-	}
-
 	if opts == nil {
 		opts = &WriteSourceOptions{Mode: WriteModeUpsert}
 	}
@@ -199,8 +194,17 @@ func (c *Client) WriteSource(ctx context.Context, objectType, name, source strin
 		opts.Mode = WriteModeUpsert
 	}
 
-	// Check if transportable edits are allowed when transport is specified
-	if err := c.checkTransportableEdit(opts.Transport, "WriteSource"); err != nil {
+	// Top-level mutation gate. The precise package check runs in the
+	// delegated create/update path (CreateAndActivate* / WriteProgram /
+	// WriteClass) because the target package is known there; here we
+	// enforce op-type and transportable-edit policy up front so the caller
+	// gets a clear early rejection.
+	if err := c.checkMutation(ctx, MutationContext{
+		Op:        OpWorkflow,
+		OpName:    "WriteSource",
+		Package:   opts.Package, // empty for update path, present for create
+		Transport: opts.Transport,
+	}); err != nil {
 		return nil, err
 	}
 

--- a/reports/2026-04-12-001-overnight-package-safety-fix.md
+++ b/reports/2026-04-12-001-overnight-package-safety-fix.md
@@ -84,32 +84,115 @@ errors) and the low-level CRUD layer (backstop). This is intentional
 redundancy — it makes intent obvious at the call sites and prevents future
 workflow additions from silently bypassing the guard.
 
-## Remaining Gap — Tracked Follow-up
+## Phase 2 — Unified Mutation Gate (commit `c3a5341`)
 
-UI5/BSP mutation paths (`UI5UploadFile`, `UI5DeleteFile`, `UI5DeleteApp`) are
-**not yet guarded**. These use a different URL scheme
-(`/sap/bc/adt/filestore/ui5-bsp/objects/...`) and need a separate
-app-to-package resolution helper before they can share the same check.
+After Phase 1 landed, Alice asked for a single unified gate instead of
+scattered per-function checks:
 
-Recommended approach (from Codex's audit):
+> "давайте сделайте всё через один auth/filter gate - потому что у нас
+> гейты есть по CRUD, по TR (по CR!) по пакетам"
+
+Phase 2 consolidates all three policy dimensions behind one entry point.
+
+### Design
+
+New file `pkg/adt/mutation_gate.go`:
+
+```go
+type MutationContext struct {
+    Op        OperationType     // safety op (R/U/C/D/A/W/...)
+    OpName    string            // human name for error messages
+    ObjectURL string            // for existing-object path resolution
+    Package   string            // for create path (explicit package)
+    Transport string            // transport request number
+    Surface   MutationSurface   // ADT or UI5 (different resolution)
+}
+
+func (c *Client) checkMutation(ctx, m) error {
+    // 1. Operation type check
+    // 2. Package ownership check
+    //    - explicit Package > resolve via ObjectURL > fail closed
+    // 3. Transportable-edit check
+}
+```
+
+Precedence: explicit `Package` wins for create ops; otherwise the gate
+resolves the package from `ObjectURL` via `SearchObject`; if neither is
+available under an active whitelist, **fail closed** with a clear error
+naming the op.
+
+### Migrated mutators (15 functions)
+
+All mutation paths in `pkg/adt/` now use the unified gate:
+
+- `workflows_edit.go`: `EditSourceWithOptions`
+- `workflows.go`: `WriteProgram`, `WriteClass`, `CreateAndActivateProgram`,
+  `CreateClassWithTests`
+- `workflows_source.go`: `WriteSource` (top-level gate; delegates still gate)
+- `workflows_fileio.go`: `RenameObject` (dual gate: delete old + create target)
+- `crud.go`: `UpdateSource`, `DeleteObject`, `CreateObject`,
+  `CreateTestInclude`, `UpdateClassInclude`
+- `i18n.go`: `WriteMessageClassTexts`, `WriteDataElementLabels`
+- `ui5.go`: `UI5CreateApp`, `UI5UploadFile`, `UI5DeleteFile`, `UI5DeleteApp`
+
+### Behavior change — UI5 fail-closed
+
+The UI5 surface previously bypassed package policy silently. In Phase 2
+this is closed:
+
+- `UI5CreateApp` works as before (explicit `Package` parameter)
+- `UI5UploadFile`, `UI5DeleteFile`, `UI5DeleteApp` now **fail closed**
+  when `SAP_ALLOWED_PACKAGES` is set — they return a clear error
+  pointing to the follow-up (UI5 app→package resolution)
+- When no package policy is configured, UI5 mutations work as before
+
+Users combining `AllowedPackages` with UI5 writes will see:
+
+> operation 'UI5UploadFile' on UI5 surface is blocked: UI5 app→package
+> resolution not yet implemented, cannot verify package against
+> SAP_ALLOWED_PACKAGES (tracked as follow-up)
+
+### Tests
+
+New file `pkg/adt/mutation_gate_test.go` with 10 tests:
+
+- `TestCheckMutation_NoPolicy_Passes`
+- `TestCheckMutation_OpType_Blocked`
+- `TestCheckMutation_ExplicitPackage_NotInWhitelist`
+- `TestCheckMutation_ObjectURL_ResolvesADTPackage`
+- `TestCheckMutation_UI5Surface_BlockedWhenPolicyActive`
+- `TestCheckMutation_UI5Surface_AllowedWhenNoPolicy`
+- `TestCheckMutation_MissingObjectURLAndPackage_FailsClosed`
+- `TestClient_UI5UploadFile_BlockedUnderAllowedPackages`
+- `TestClient_UI5DeleteFile_BlockedUnderAllowedPackages`
+- `TestClient_UI5DeleteApp_BlockedUnderAllowedPackages`
+
+Full suite still green.
+
+## Remaining Follow-up
+
+UI5 app→package resolution remains the one outstanding item, but the gap
+is no longer a silent bypass — it's a clear fail-closed error until the
+resolver is implemented. Recommended approach (from Codex's audit):
+
 1. Add `UI5ResolveAppPackage(appName)` using BSP metadata
-2. Apply package enforcement on all UI5 mutation paths
+2. Let `SurfaceUI5` use that resolver instead of fail-closed
 3. Ship as a follow-up PR
-
-This gap is not a regression — those paths were never guarded. It's an
-existing edge case that warrants its own focused fix.
 
 ## Timeline
 
 - **23:00** — User report received from Philip Dolker via Alice
-- **23:05** — Code audit by Claude and Codex independently; both identified
-  the same gap in the workflow layer
-- **23:15** — Alice approved fix implementation; Claude took implementation,
-  Codex switched to review/foreman mode
-- **23:35** — Fix implemented across 7 files, tests pass
-- **23:45** — Codex review approved, no blockers
-- **23:50** — Committed (08e3d78), pushed, PR #101 created
-- **23:55** — Graceful handover, session wrap-up
+- **23:05** — Independent audits by Claude and Codex; both identified the
+  same gap in the workflow layer
+- **23:15** — Alice approved fix implementation
+- **23:35** — Phase 1 fix implemented across 7 files, tests pass
+- **23:45** — Codex review approved Phase 1, no blockers
+- **23:50** — Phase 1 committed (`08e3d78`), pushed, PR #101 created
+- **23:55** — Graceful handover
+- **next day** — Alice requested unified gate ("один auth/filter gate")
+- **next day** — Phase 2 implemented: `checkMutation`, 15 mutators
+  migrated, UI5 fail-closed, 10 new tests; Codex reviewed and approved
+- **next day** — Phase 2 committed (`c3a5341`), pushed
 
 ## Philip Reply Draft (not yet sent)
 

--- a/reports/2026-04-12-001-overnight-package-safety-fix.md
+++ b/reports/2026-04-12-001-overnight-package-safety-fix.md
@@ -1,0 +1,147 @@
+# Overnight Work Report: SAP_ALLOWED_PACKAGES Enforcement Fix
+
+**Date:** 2026-04-12
+**Authors:** Claude (implementation), Codex (audit + review), Alice (direction)
+**PR:** https://github.com/oisee/vibing-steampunk/pull/101
+**Commit:** 08e3d78
+**Branch:** pr-93-fix
+
+---
+
+## Summary
+
+User Philip Dolker reported that `SAP_ALLOWED_PACKAGES` did not restrict object
+modifications to the configured package whitelist — vsp was letting him edit
+objects in any package regardless of the setting.
+
+Investigation confirmed this was a real enforcement bug, not a configuration
+issue. The fix is committed and pushed in PR #101, with Codex's review approval.
+
+## Problem
+
+`SAP_ALLOWED_PACKAGES` was correctly parsed from the environment and wired into
+`SafetyConfig.AllowedPackages`, but the check was only enforced on a small
+subset of operations:
+
+- `CreateObject` (crud.go)
+- `CreateAndActivateProgram`, `CreateClassWithTests` (workflows.go)
+- `UI5CreateApp` (ui5.go)
+
+The main mutation paths that AI agents actually use to modify existing objects
+bypassed the package check entirely. An agent could call `EditSource`,
+`WriteSource`, `WriteProgram`, or `WriteClass` on any object in any package and
+the `AllowedPackages` restriction would have no effect.
+
+## Root Cause
+
+The safety check was applied at create-time (where the package is an explicit
+parameter) but never at edit-time (where the package must be resolved from the
+existing object's metadata).
+
+## Fix
+
+Added `checkObjectPackageSafety(ctx, objectURL)` calls to all existing-object
+mutation paths. This helper already existed in `client.go` — it resolves the
+object's package via `SearchObject` and validates it against the whitelist,
+with URL normalization for `/source/main` and `/includes/...` suffixes.
+
+### Functions hardened
+
+| Function | File | Check added |
+|---|---|---|
+| `EditSourceWithOptions` | `workflows_edit.go` | `checkObjectPackageSafety` |
+| `WriteProgram` | `workflows.go` | `checkObjectPackageSafety` |
+| `WriteClass` | `workflows.go` | `checkObjectPackageSafety` |
+| `RenameObject` | `workflows_fileio.go` | `checkObjectPackageSafety` (old) + `checkPackageSafety` (target) |
+| `UpdateSource` | `crud.go` | `checkObjectPackageSafety` + `checkTransportableEdit` |
+| `DeleteObject` | `crud.go` | `checkObjectPackageSafety` + `checkTransportableEdit` |
+| `CreateTestInclude` | `crud.go` | `checkObjectPackageSafety` + `checkTransportableEdit` |
+| `UpdateClassInclude` | `crud.go` | `checkObjectPackageSafety` + `checkTransportableEdit` |
+| `WriteMessageClassTexts` | `i18n.go` | `checkObjectPackageSafety` + `checkTransportableEdit` |
+| `WriteDataElementLabels` | `i18n.go` | `checkObjectPackageSafety` + `checkTransportableEdit` |
+
+Note: `WriteSource` didn't need a direct check — its update path delegates to
+`WriteProgram`/`WriteClass` which are now guarded, and its create path
+delegates to `CreateAndActivateProgram`/`CreateClassWithTests` which already
+had checks.
+
+### Tests
+
+New tests in `client_test.go`:
+- `TestClient_CheckObjectPackageSafety_NormalizesObjectURLs` — verifies
+  `/source/main` and `/includes/...` URL normalization
+- `TestClient_UpdateSource_EnforcesAllowedPackages`
+- `TestClient_DeleteObject_EnforcesAllowedPackages`
+- `TestClient_CreateTestInclude_EnforcesAllowedPackages`
+- `TestClient_WriteMessageClassTexts_EnforcesAllowedPackages`
+
+Full test suite passes: `go test ./...` clean, zero regressions.
+
+## Defense in Depth
+
+The fix applies checks at both the workflow layer (early rejection with clear
+errors) and the low-level CRUD layer (backstop). This is intentional
+redundancy — it makes intent obvious at the call sites and prevents future
+workflow additions from silently bypassing the guard.
+
+## Remaining Gap — Tracked Follow-up
+
+UI5/BSP mutation paths (`UI5UploadFile`, `UI5DeleteFile`, `UI5DeleteApp`) are
+**not yet guarded**. These use a different URL scheme
+(`/sap/bc/adt/filestore/ui5-bsp/objects/...`) and need a separate
+app-to-package resolution helper before they can share the same check.
+
+Recommended approach (from Codex's audit):
+1. Add `UI5ResolveAppPackage(appName)` using BSP metadata
+2. Apply package enforcement on all UI5 mutation paths
+3. Ship as a follow-up PR
+
+This gap is not a regression — those paths were never guarded. It's an
+existing edge case that warrants its own focused fix.
+
+## Timeline
+
+- **23:00** — User report received from Philip Dolker via Alice
+- **23:05** — Code audit by Claude and Codex independently; both identified
+  the same gap in the workflow layer
+- **23:15** — Alice approved fix implementation; Claude took implementation,
+  Codex switched to review/foreman mode
+- **23:35** — Fix implemented across 7 files, tests pass
+- **23:45** — Codex review approved, no blockers
+- **23:50** — Committed (08e3d78), pushed, PR #101 created
+- **23:55** — Graceful handover, session wrap-up
+
+## Philip Reply Draft (not yet sent)
+
+> Hi Philip,
+>
+> Thank you for reporting this — and congrats-thanks for the 200+ stars!
+>
+> You found a real bug. Your configuration was correct, but
+> `SAP_ALLOWED_PACKAGES` was only being enforced on object creation paths
+> (like `CreateObject`). The main mutation paths for existing objects —
+> `EditSource`, `WriteSource`, `WriteProgram`, `WriteClass`, and others —
+> were not checking the package restriction at all. So vsp would let an
+> agent modify any object regardless of the configured package whitelist.
+>
+> This is now fixed. The package ownership check is enforced on all
+> standard ADT object mutation paths (edit, write, update, delete, rename).
+>
+> One additional note: if `$CONDUCT_RAPTEST` is a transportable package
+> (not `$TMP`), you may also need to set `SAP_ALLOW_TRANSPORTABLE_EDITS=true`
+> in your env block to allow writes to objects in that package. Without it,
+> vsp blocks edits to objects in non-local packages as an extra safety layer.
+>
+> The fix will be in the next release. A small remaining area (UI5/BSP app
+> mutations) will be completed separately, but that shouldn't affect typical
+> ABAP development scenarios.
+>
+> Thanks again for the detailed report — it helped us find and close a real
+> enforcement gap.
+
+## Pending Actions
+
+- [ ] Merge PR #101 to main
+- [ ] Rebuild release binaries (if hotfix desired)
+- [ ] Send reply to Philip
+- [ ] Open follow-up issue for UI5 BSP app-to-package resolution


### PR DESCRIPTION
## Summary

- `SAP_ALLOWED_PACKAGES` was only enforced on object **creation** paths, not on existing-object mutations
- Added `checkObjectPackageSafety` to all write paths: `EditSource`, `WriteProgram`, `WriteClass`, `WriteSource` (update path), `RenameObject`, `UpdateSource`, `DeleteObject`, `CreateTestInclude`, `UpdateClassInclude`, `WriteMessageClassTexts`, `WriteDataElementLabels`
- UI5 BSP mutation paths (`UI5UploadFile`, `UI5DeleteFile`, `UI5DeleteApp`) remain as follow-up — needs app-to-package resolution

Reported by Philip Dolker.

## Test plan

- [x] All existing tests pass (`go test ./...`)
- [x] Existing `checkObjectPackageSafety` normalization tests pass
- [x] Existing `UpdateSource`/`DeleteObject`/`CreateTestInclude`/`WriteMessageClassTexts` enforcement tests pass
- [ ] Integration test: configure `SAP_ALLOWED_PACKAGES=$TMP` and verify `EditSource` on a non-$TMP object is blocked
- [ ] Follow-up: UI5 BSP app-to-package resolution for upload/delete enforcement

🤖 Generated with [Claude Code](https://claude.com/claude-code)