### PR TITLE
fix(install): propagate Description, detect pre-existing package, stop silent success

### DIFF
--- a/cmd/vsp/devops.go
+++ b/cmd/vsp/devops.go
@@ -3158,14 +3158,23 @@ func runInstallZadtVsp(cmd *cobra.Command, args []string) error {
 		fmt.Fprintf(os.Stderr, "  [%d/%d] %s ... ", i+1, len(objects), obj.Name)
 
 		opts := &adt.WriteSourceOptions{
-			Package: packageName,
-			Mode:    adt.WriteModeUpsert,
+			Package:     packageName,
+			Description: obj.Description,
+			Mode:        adt.WriteModeUpsert,
 		}
-		_, err := client.WriteSource(ctx, obj.Type, obj.Name, obj.Source, opts)
-		if err != nil {
+		res, err := client.WriteSource(ctx, obj.Type, obj.Name, obj.Source, opts)
+		switch {
+		case err != nil:
 			fmt.Fprintf(os.Stderr, "FAILED: %v\n", err)
 			failed++
-		} else {
+		case res == nil || !res.Success:
+			msg := "unknown failure"
+			if res != nil && res.Message != "" {
+				msg = res.Message
+			}
+			fmt.Fprintf(os.Stderr, "FAILED: %s\n", msg)
+			failed++
+		default:
 			fmt.Fprintf(os.Stderr, "OK\n")
 			deployed++
 		}

--- a/cmd/vsp/devops.go
+++ b/cmd/vsp/devops.go
@@ -3058,11 +3058,18 @@ func runInstallZadtVsp(cmd *cobra.Command, args []string) error {
 	// Phase 1: Check prerequisites
 	fmt.Fprintf(os.Stderr, "Checking prerequisites...\n")
 
-	// Check if package exists
-	packageExists := false
-	pkg, err := client.GetPackage(ctx, packageName)
-	if err == nil && pkg.URI != "" {
-		packageExists = true
+	// Check if package exists.
+	// GetPackage reads the nodestructure API and cannot distinguish
+	// "package does not exist" from "package exists but has no children",
+	// so we use the direct PackageExists probe here. If the probe itself
+	// errors (5xx, network), we fall through to the create path and let
+	// SAP's own error surface there.
+	packageExists, err := client.PackageExists(ctx, packageName)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "  Package %s existence check failed: %v — will attempt create\n", packageName, err)
+		packageExists = false
+	}
+	if packageExists {
 		fmt.Fprintf(os.Stderr, "  Package %s exists\n", packageName)
 	} else {
 		fmt.Fprintf(os.Stderr, "  Package %s will be created\n", packageName)
@@ -3310,10 +3317,16 @@ func runInstallAbapGit(cmd *cobra.Command, args []string) error {
 
 	ctx := context.Background()
 
-	// Ensure package exists
+	// Ensure package exists. PackageExists probes /packages/{name} directly;
+	// a GetPackage-based check cannot distinguish "absent" from "present but
+	// empty" because nodestructure returns an empty tree in both cases.
 	fmt.Fprintf(os.Stderr, "Checking package %s...\n", packageName)
-	pkg, pkgErr := client.GetPackage(ctx, packageName)
-	if pkgErr != nil || pkg.URI == "" {
+	exists, pkgErr := client.PackageExists(ctx, packageName)
+	if pkgErr != nil {
+		fmt.Fprintf(os.Stderr, "  Package existence check failed: %v — will attempt create\n", pkgErr)
+		exists = false
+	}
+	if !exists {
 		fmt.Fprintf(os.Stderr, "Creating package %s...\n", packageName)
 		err = client.CreateObject(ctx, adt.CreateObjectOptions{
 			ObjectType:  adt.ObjectTypePackage,

--- a/internal/mcp/handlers_install.go
+++ b/internal/mcp/handlers_install.go
@@ -427,14 +427,23 @@ func (s *Server) handleInstallZADTVSP(ctx context.Context, request mcp.CallToolR
 
 		// Use WriteSource to create/update
 		opts := &adt.WriteSourceOptions{
-			Package: packageName,
-			Mode:    adt.WriteModeUpsert,
+			Package:     packageName,
+			Description: obj.Description,
+			Mode:        adt.WriteModeUpsert,
 		}
-		_, err := s.adtClient.WriteSource(ctx, obj.Type, obj.Name, obj.Source, opts)
-		if err != nil {
+		res, err := s.adtClient.WriteSource(ctx, obj.Type, obj.Name, obj.Source, opts)
+		switch {
+		case err != nil:
 			fmt.Fprintf(&sb, "✗ Failed: %v\n", err)
 			failed = append(failed, obj.Name+": "+err.Error())
-		} else {
+		case res == nil || !res.Success:
+			msg := "unknown failure"
+			if res != nil && res.Message != "" {
+				msg = res.Message
+			}
+			fmt.Fprintf(&sb, "✗ Failed: %s\n", msg)
+			failed = append(failed, obj.Name+": "+msg)
+		default:
 			sb.WriteString("✓ Deployed\n")
 			deployed = append(deployed, obj.Name)
 		}

--- a/pkg/adt/client.go
+++ b/pkg/adt/client.go
@@ -3,6 +3,7 @@ package adt
 import (
 	"context"
 	"encoding/xml"
+	"errors"
 	"fmt"
 	"html"
 	"net/http"
@@ -810,6 +811,33 @@ func (c *Client) GetMessageClass(ctx context.Context, msgClassName string) (*Mes
 }
 
 // --- Package Operations ---
+
+// PackageExists returns true if SAP has a package with the given name.
+// It probes /sap/bc/adt/packages/{name} directly: 200 → exists, 404 → not,
+// any other outcome (5xx, network, auth) is returned as an error so the
+// caller does not silently classify a transient failure as "missing".
+//
+// Unlike GetPackage, which reads the nodestructure API and cannot distinguish
+// "package does not exist" from "package exists but has no children" (both
+// return an empty tree), this is a definitive existence check.
+func (c *Client) PackageExists(ctx context.Context, packageName string) (bool, error) {
+	if packageName == "" {
+		return false, fmt.Errorf("empty package name")
+	}
+	objectURL := fmt.Sprintf("/sap/bc/adt/packages/%s", url.PathEscape(strings.ToUpper(packageName)))
+	_, err := c.transport.Request(ctx, objectURL, &RequestOptions{
+		Method: http.MethodGet,
+		Accept: "application/*",
+	})
+	if err == nil {
+		return true, nil
+	}
+	var apiErr *APIError
+	if errors.As(err, &apiErr) && apiErr.StatusCode == http.StatusNotFound {
+		return false, nil
+	}
+	return false, err
+}
 
 // GetPackage retrieves the contents of a package using the nodestructure API.
 func (c *Client) GetPackage(ctx context.Context, packageName string) (*PackageContent, error) {


### PR DESCRIPTION
## Summary

Two independent defects in `vsp install zadt-vsp` (and its MCP-handler
twin, `InstallZadtVsp`). Surfaced running the installer end-to-end
against a fresh S/4HANA DEV client with `VSP_HTTP_TRACE=1` — the tool
reported `DEPLOYMENT COMPLETE, Deployed: 9` twice in a row while the
trace showed no object ever reached SAP. A follow-up rerun against an
already-installed system then escalated: the same code tried to LOCK +
DELETE the pre-existing `$ZADT_VSP` package and was only saved by SAP
refusing the delete because the package still contained objects
(`PAK/051`).

1. **Propagate `Description` + surface `!result.Success`** — per-object
   deploy silently reported OK when the object was never written.
2. **Detect pre-existing package via direct probe** — rerun tried to
   create a package that already exists, fell into the partial-create
   reconcile path, and attempted a destructive cleanup on foreign state.

A third, deeper defect — `reconcileFailedCreate` treating a 400
`ExceptionResourceAlreadyExists` as partial persistence and running
LOCK + DELETE on pre-existing state — is out of scope here and tracked
as a data-safety follow-up. The install flows no longer reach it
after fix #2, but the reconciler is still latently dangerous for any
other `CreateObject` caller that can race with pre-existing state.

## 1. Propagate `Description`; treat `!result.Success` as failure

Chained defect between the install driver and `WriteSource`:

- `cmd/vsp/devops.go:3160` and `internal/mcp/handlers_install.go:429`
  both build `WriteSourceOptions` **without** `Description`, even though
  every `embedded.ObjectInfo` already carries one.
- In `pkg/adt/workflows_source.go:300-303`, `writeSourceCreate` short-
  circuits with `result.Message = "Description is required for creating
  new objects"` **and returns `nil` as the error** — it stuffs the
  failure into the result struct.
- Both loops ignore the returned `*WriteSourceResult` (`_, err := …`) and
  only branch on `err`. With `err` always `nil`, every object printed
  `OK` / `✓ Deployed` and the summary reported full success.

Observable symptom in the HTTP trace: per object a single
`GET /source/main → 404` (the existence probe) and then the next
object's probe. No POST, no PUT, no activation — and nine green ticks.

Fix:

- Pass `obj.Description` into `opts`.
- Inspect the returned result. If `err != nil` **or** `res == nil` **or**
  `!res.Success`, mark the object as FAILED and print `res.Message`.

The broader "return `(result, nil)` on failure" pattern in
`writeSourceCreate` / `writeSourceUpdate` is a bug class, not a single
bug, and is left for a follow-up; this change at least makes the
install loops fail loudly when they trip it.

## 2. Detect pre-existing package via direct probe

`GetPackage` reads the nodestructure API
(`POST /repository/nodestructure?parent_name=$ZADT_VSP&parent_type=DEVC/K`),
and its parser in `pkg/adt/client.go` never populates
`PackageContent.URI`. Both install flows gated their "create package"
step on `pkg.URI != ""`:

    cmd/vsp/devops.go:3063   — zadt-vsp install
    cmd/vsp/devops.go:3315   — abapgit install

Because `URI` is never set, the gate always failed open. On first run
the package did not exist and the subsequent `CreateObject` succeeded
so nothing looked wrong. On second run:

    POST /packages  → 400  ExceptionResourceAlreadyExists
    GET  /packages/$ZADT_VSP  → 200      (reconcile existence probe)
    POST /packages/$ZADT_VSP?_action=LOCK   → 200
    DELETE /packages/$ZADT_VSP              → 400  PAK/051
        "Paket $ZADT_VSP enthält noch Entwicklungsobjekte oder andere Pakete"

The reconciler in `pkg/adt/crud.go:reconcileFailedCreate` interpreted
the 200 on the existence probe as "SAP partially persisted our create"
and ran the compensating cleanup — on a package full of the user's
prior objects. Only `PAK/051` prevented data loss.

Why nodestructure cannot fix this: for both "package does not exist"
and "package exists but has no children" it returns the same empty
tree. There is no way to tell the two apart from its response.

Fix — add a public `Client.PackageExists` probe that hits
`/sap/bc/adt/packages/{name}` directly:

| HTTP | meaning |
|---|---|
| 200 | exists |
| 404 | does not exist |
| else | transient / auth / 5xx — returned as error, caller decides |

Both install flows switch to `PackageExists`. On a probe error we fall
through to the create path and let SAP's own error surface there,
preserving existing behaviour for transient failures.

After this change the rerun cleanly reports `Package $ZADT_VSP exists`
and skips `CreateObject` entirely; the dangerous reconcile branch
is not reached.

## Files changed

    cmd/vsp/devops.go                 — Description propagated; res.Success
                                        checked; PackageExists used in both
                                        zadt-vsp and abapgit install flows
    internal/mcp/handlers_install.go  — same Description + res.Success fix
                                        for the MCP InstallZadtVsp tool
    pkg/adt/client.go                 — new public Client.PackageExists

## Related issues

None filed yet — both defects were caught during live install
verification on a fresh DEV client.

## Non-goals / follow-ups

- **Data-safety: reconcileFailedCreate guard on ExceptionResourceAlreadyExists.**
  `pkg/adt/crud.go:392` currently treats any `CreateObject` failure
  whose existence probe returns 200 as partial persistence, including
  the 400 `ExceptionResourceAlreadyExists` case where the object was
  there *before* our request. LOCK + DELETE on pre-existing state is
  categorically wrong and only failed safe here because SAP refused to
  delete a non-empty package. To track separately; requires sniffing
  the exception `type` from the original error body and short-circuiting
  cleanup when it is `ExceptionResourceAlreadyExists`.

- **Bug class: `writeSourceCreate` / `writeSourceUpdate` return
  `(result, nil)` on failure.** Every failure path in these functions
  stuffs the reason into `result.Message` and returns a nil error. Any
  caller that uses the Go-idiomatic `_, err := …` pattern silently sees
  success. The install loops are one known victim; a sweep for the
  pattern and a conversion to proper error returns is the real fix.
