### PR TITLE
fix(adt): honor HTTP_PROXY/HTTPS_PROXY for WebSocket connections

### DIFF
--- a/pkg/adt/websocket_base.go
+++ b/pkg/adt/websocket_base.go
@@ -87,10 +87,7 @@ func (c *BaseWebSocketClient) Connect(ctx context.Context) error {
 	header.Set("Authorization", basicAuth(c.user, c.password))
 
 	// Try 1: Direct Basic Auth (works on most SAP systems)
-	dialer := websocket.Dialer{
-		HandshakeTimeout: 30 * time.Second,
-		TLSClientConfig:  tlsConfig,
-	}
+	dialer := newZADTVSPDialer(tlsConfig)
 
 	conn, resp, err := dialer.DialContext(ctx, wsURL, header)
 
@@ -99,11 +96,7 @@ func (c *BaseWebSocketClient) Connect(ctx context.Context) error {
 	// but accept it on regular HTTP to issue session cookies.
 	if err != nil && resp != nil && resp.StatusCode == http.StatusUnauthorized {
 		jar, _ := cookiejar.New(nil)
-		preAuthClient := &http.Client{
-			Jar:       jar,
-			Transport: &http.Transport{TLSClientConfig: tlsConfig},
-			Timeout:   30 * time.Second,
-		}
+		preAuthClient := newPreAuthHTTPClient(jar, tlsConfig)
 
 		authURL := fmt.Sprintf("%s/sap/bc/adt/core/discovery?sap-client=%s", c.baseURL, c.client)
 		authReq, authErr := http.NewRequestWithContext(ctx, http.MethodGet, authURL, nil)
@@ -381,6 +374,39 @@ func (c *BaseWebSocketClient) WriteMessage(data []byte) error {
 		return fmt.Errorf("not connected")
 	}
 	return c.conn.WriteMessage(websocket.TextMessage, data)
+}
+
+// newZADTVSPDialer returns the gorilla/websocket dialer used for the
+// ZADT_VSP APC endpoint. Proxy is set to http.ProxyFromEnvironment so
+// the dial honours HTTP_PROXY / HTTPS_PROXY env vars — same fix class
+// as issue #13 on the HTTP transport. Required on SAP Business
+// Application Studio destinations where all outbound traffic has to
+// go through a Connectivity Proxy; without it, every WebSocket-backed
+// tool (debugger, AMDP, RFC, report execution, abapGit WebSocket
+// export) fails to connect even though the HTTP-only tools work.
+func newZADTVSPDialer(tlsConfig *tls.Config) websocket.Dialer {
+	return websocket.Dialer{
+		HandshakeTimeout: 30 * time.Second,
+		TLSClientConfig:  tlsConfig,
+		Proxy:            http.ProxyFromEnvironment,
+	}
+}
+
+// newPreAuthHTTPClient returns the transient HTTP client used to fetch
+// SAP session cookies before the WebSocket upgrade retry on HTTP 401.
+// Proxy env vars are honoured. Kept separate from Config.NewHTTPClient
+// because the WebSocket fallback path deliberately drives its own
+// cookie jar and injects Basic Auth per-request rather than reusing
+// the caller's existing HTTP session state.
+func newPreAuthHTTPClient(jar http.CookieJar, tlsConfig *tls.Config) *http.Client {
+	return &http.Client{
+		Jar: jar,
+		Transport: &http.Transport{
+			Proxy:           http.ProxyFromEnvironment,
+			TLSClientConfig: tlsConfig,
+		},
+		Timeout: 30 * time.Second,
+	}
 }
 
 // basicAuth creates basic auth header value.

--- a/pkg/adt/websocket_base_test.go
+++ b/pkg/adt/websocket_base_test.go
@@ -1,0 +1,64 @@
+package adt
+
+import (
+	"crypto/tls"
+	"net/http"
+	"net/http/cookiejar"
+	"testing"
+)
+
+// TestNewZADTVSPDialer_HonoursProxyEnv pins the HTTP_PROXY /
+// HTTPS_PROXY fix for WebSocket connections. Mirrors the Proxy-field
+// check TestNewHTTPClient runs against the HTTP transport for issue
+// #13 — without http.ProxyFromEnvironment on the gorilla/websocket
+// dialer, every WebSocket-backed tool (ABAP debugger, AMDP debugger,
+// RFC, report execution, abapGit WebSocket export) fails to connect
+// on SAP BAS destinations that require a Connectivity Proxy.
+func TestNewZADTVSPDialer_HonoursProxyEnv(t *testing.T) {
+	tlsCfg := &tls.Config{}
+	dialer := newZADTVSPDialer(tlsCfg)
+
+	if dialer.Proxy == nil {
+		t.Error("WebSocket dialer must have Proxy set (HTTP_PROXY/HTTPS_PROXY support — same fix class as issue #13)")
+	}
+	if dialer.TLSClientConfig != tlsCfg {
+		t.Error("dialer must carry the TLS config passed in")
+	}
+	if dialer.HandshakeTimeout == 0 {
+		t.Error("dialer must have a non-zero handshake timeout")
+	}
+}
+
+// TestNewPreAuthHTTPClient_HonoursProxyEnv extends the #13 fix to the
+// transient HTTP client that the WebSocket 401-retry path uses to
+// obtain SAP session cookies before the second dial attempt. The
+// fallback builds its own http.Transport inline instead of reusing
+// Config.NewHTTPClient (it needs a dedicated cookie jar and
+// per-request Basic Auth), so the proxy fix has to be applied here
+// too — otherwise the pre-auth GET fails on BAS with exactly the
+// same symptom the WebSocket dial has.
+func TestNewPreAuthHTTPClient_HonoursProxyEnv(t *testing.T) {
+	jar, _ := cookiejar.New(nil)
+	tlsCfg := &tls.Config{}
+	client := newPreAuthHTTPClient(jar, tlsCfg)
+
+	if client == nil {
+		t.Fatal("newPreAuthHTTPClient returned nil")
+	}
+	if client.Jar != jar {
+		t.Error("pre-auth client must use the jar passed in so the session cookie survives into the dialer retry")
+	}
+	transport, ok := client.Transport.(*http.Transport)
+	if !ok {
+		t.Fatalf("pre-auth client transport must be *http.Transport, got %T", client.Transport)
+	}
+	if transport.Proxy == nil {
+		t.Error("pre-auth HTTP transport must have Proxy set (HTTP_PROXY/HTTPS_PROXY support — same fix class as issue #13)")
+	}
+	if transport.TLSClientConfig != tlsCfg {
+		t.Error("pre-auth transport must carry the TLS config passed in")
+	}
+	if client.Timeout == 0 {
+		t.Error("pre-auth client must have a non-zero timeout")
+	}
+}


### PR DESCRIPTION
## Summary

Extends #13 (a1af66f — "honor HTTP_PROXY/HTTPS_PROXY environment variables")
from the HTTP transport to the WebSocket path. On SAP Business Application
Studio destinations (Cloud Connector + Connectivity Proxy) every outbound
connection must go through the proxy; the HTTP-only tools started working
after #13 but every WebSocket-backed feature still failed to connect.

All WebSocket traffic in vsp — ABAP debugger, AMDP debugger, RFC execution,
report execution, abapGit WebSocket export — runs through a single
`BaseWebSocketClient` in `pkg/adt/websocket_base.go`. Neither the
`websocket.Dialer` nor the transient `*http.Client` used on the 401-retry
pre-auth path set a `Proxy`, so `HTTP_PROXY` / `HTTPS_PROXY` were ignored
for WebSocket connects.

## The fix

Two small package-level constructors in `websocket_base.go` so the dialer
and the pre-auth client are created in a single, testable place:

```go
newZADTVSPDialer(tlsConfig) → websocket.Dialer{
    Proxy:            http.ProxyFromEnvironment,
    HandshakeTimeout: 30 * time.Second,
    TLSClientConfig:  tlsConfig,
}

newPreAuthHTTPClient(jar, tlsConfig) → &http.Client{
    Transport: &http.Transport{
        Proxy:           http.ProxyFromEnvironment,
        TLSClientConfig: tlsConfig,
    },
    Jar:     jar,
    Timeout: ...,
}
```

The two inline blocks in `BaseWebSocketClient.Connect` now call these
constructors; `dialer.Jar = jar` on the 401-retry path stays unchanged.

## Behaviour for non-proxy deployments

Unchanged. `http.ProxyFromEnvironment` returns `nil` when `HTTP_PROXY` /
`HTTPS_PROXY` / `NO_PROXY` are unset, so the dialer connects directly
as before. Same semantics `net/http` uses by default.

## Regression coverage

    TestNewZADTVSPDialer_HonoursProxyEnv       — dialer.Proxy non-nil,
        TLS config and handshake timeout preserved.
    TestNewPreAuthHTTPClient_HonoursProxyEnv   — transport.Proxy non-nil,
        supplied jar is used, timeout non-zero.

Mirrors the style of `TestNewHTTPClient` at `pkg/adt/config_test.go:171-192`
that locks in the HTTP-side #13 fix.

## Files changed

    pkg/adt/websocket_base.go       — newZADTVSPDialer + newPreAuthHTTPClient
                                      constructors; Connect uses them
    pkg/adt/websocket_base_test.go  — new (the two tests above)

## Related issues

- **#13** — original HTTP-side proxy support. This PR is the WebSocket-side
  equivalent; same motivation, same environment, same semantics.
