### PR TITLE
fix(adt): deploy session ordering + correct MODIFICATION_SUPPORT handling

### DIFF
--- a/pkg/adt/config.go
+++ b/pkg/adt/config.go
@@ -244,17 +244,37 @@ func (c *Config) NewHTTPClient() *http.Client {
 		Timeout:   c.Timeout,
 	}
 
-	// Preserve Authorization header across redirects.
-	// Go's default strips it per RFC 7235 §4.2, but SAP BTP/Cloud
-	// authentication flows require it to survive redirects.
-	// Without this, BTP users get 401 even though curl works (issue #90).
+	// Preserve ADT-critical headers across redirects.
+	//
+	// Go's default strips Authorization / WWW-Authenticate / Cookie / Cookie2
+	// on cross-origin redirects per RFC 7235 §4.2 — SAP BTP/Cloud SAML flows
+	// need Authorization back, otherwise the IdP dance drops it and the user
+	// gets 401 even though curl works (issue #90).
+	//
+	// Custom headers like X-CSRF-Token and X-sap-adt-sessiontype are *not*
+	// in Go's sensitive-headers list, so Go technically forwards them by
+	// default. We re-set them explicitly anyway for two reasons:
+	//   - defensive: guards against any Go version or middleware tweak that
+	//     decides to strip custom headers on its own;
+	//   - intent: makes it obvious in the code that these two headers are
+	//     load-bearing for the lock→write→unlock ADT sequence. If either
+	//     goes missing across a redirect, the second hop hits SAP with a
+	//     fresh (stateless) session-type or a missing CSRF token, and the
+	//     lock handle / mutation is rejected.
 	client.CheckRedirect = func(req *http.Request, via []*http.Request) error {
 		if len(via) >= 10 {
 			return fmt.Errorf("too many redirects")
 		}
 		if len(via) > 0 {
-			if auth := via[0].Header.Get("Authorization"); auth != "" {
+			first := via[0]
+			if auth := first.Header.Get("Authorization"); auth != "" {
 				req.Header.Set("Authorization", auth)
+			}
+			if csrf := first.Header.Get("X-CSRF-Token"); csrf != "" {
+				req.Header.Set("X-CSRF-Token", csrf)
+			}
+			if st := first.Header.Get("X-sap-adt-sessiontype"); st != "" {
+				req.Header.Set("X-sap-adt-sessiontype", st)
 			}
 		}
 		return nil

--- a/pkg/adt/config_test.go
+++ b/pkg/adt/config_test.go
@@ -202,3 +202,81 @@ func TestSessionTypes(t *testing.T) {
 		t.Errorf("SessionKeep = %v, want keep", SessionKeep)
 	}
 }
+
+// TestNewHTTPClient_CheckRedirectPreservesADTHeaders verifies that the
+// HTTP client's CheckRedirect callback re-sets headers that are
+// load-bearing for the ADT lock→write→unlock sequence across redirects:
+//   - Authorization: Go strips this by default on cross-origin redirects
+//     (sensitive header per RFC 7235). Without restoration, SAML flows get
+//     401 even when curl works (issue #90).
+//   - X-CSRF-Token: mutation requests are rejected as CSRF-violating if
+//     this disappears mid-sequence.
+//   - X-sap-adt-sessiontype: the lock handle is bound to a stateful
+//     session; if a redirect hop lands stateless, the subsequent PUT
+//     can't find the lock and gets HTTP 423.
+//
+// Go's default forwards custom headers on same-origin redirects, but this
+// test pins the behaviour explicitly so future refactors can't silently
+// drop them.
+func TestNewHTTPClient_CheckRedirectPreservesADTHeaders(t *testing.T) {
+	cfg := NewConfig("https://sap.example.com:44300", "user", "pass")
+	client := cfg.NewHTTPClient()
+
+	if client.CheckRedirect == nil {
+		t.Fatal("CheckRedirect must be set")
+	}
+
+	// Build the "via" chain: the original request that carries the ADT
+	// headers we expect to be re-set on the redirect target.
+	orig, err := http.NewRequest(http.MethodPost,
+		"https://sap.example.com:44300/sap/bc/adt/oo/classes/ZFOO?_action=LOCK", nil)
+	if err != nil {
+		t.Fatalf("NewRequest(orig): %v", err)
+	}
+	orig.Header.Set("Authorization", "Basic dXNlcjpwYXNz")
+	orig.Header.Set("X-CSRF-Token", "ABC123==")
+	orig.Header.Set("X-sap-adt-sessiontype", "stateful")
+
+	// The redirect target that Go would follow — initially without any
+	// of the ADT headers (simulating Go having stripped them cross-origin).
+	next, err := http.NewRequest(http.MethodPost,
+		"https://sap.example.com:44300/sap/bc/adt/follow", nil)
+	if err != nil {
+		t.Fatalf("NewRequest(next): %v", err)
+	}
+
+	if err := client.CheckRedirect(next, []*http.Request{orig}); err != nil {
+		t.Fatalf("CheckRedirect returned error: %v", err)
+	}
+
+	if got := next.Header.Get("Authorization"); got != "Basic dXNlcjpwYXNz" {
+		t.Errorf("Authorization = %q, want preserved from initial request (issue #90)", got)
+	}
+	if got := next.Header.Get("X-CSRF-Token"); got != "ABC123==" {
+		t.Errorf("X-CSRF-Token = %q, want preserved — mutation requests need it to survive redirect hops", got)
+	}
+	if got := next.Header.Get("X-sap-adt-sessiontype"); got != "stateful" {
+		t.Errorf("X-sap-adt-sessiontype = %q, want preserved — lock handles are bound to a stateful session (issue #88)", got)
+	}
+}
+
+// TestNewHTTPClient_CheckRedirectHonoursLimit guards the 10-redirect cap
+// that CheckRedirect enforces to prevent infinite loops.
+func TestNewHTTPClient_CheckRedirectHonoursLimit(t *testing.T) {
+	cfg := NewConfig("https://sap.example.com:44300", "user", "pass")
+	client := cfg.NewHTTPClient()
+
+	if client.CheckRedirect == nil {
+		t.Fatal("CheckRedirect must be set")
+	}
+
+	next, _ := http.NewRequest(http.MethodGet, "https://sap.example.com:44300/", nil)
+	via := make([]*http.Request, 10)
+	for i := range via {
+		via[i], _ = http.NewRequest(http.MethodGet, "https://sap.example.com:44300/", nil)
+	}
+
+	if err := client.CheckRedirect(next, via); err == nil {
+		t.Error("CheckRedirect must return an error on the 10th redirect")
+	}
+}

--- a/pkg/adt/crud.go
+++ b/pkg/adt/crud.go
@@ -57,23 +57,27 @@ func (c *Client) LockObject(ctx context.Context, objectURL string, accessMode st
 		return nil, err
 	}
 
-	// BTP / ABAP Cloud systems sometimes return a successful lock with
-	// MODIFICATION_SUPPORT="NoModification" — the lock acquired but the
-	// object is read-only via ADT (typical for SAP-delivered objects in
-	// hyperfocused mode, or systems where the user lacks the edit role).
-	// Without this guard the caller proceeds to PUT/POST and gets a
-	// confusing 423 InvalidLockHandle several seconds later. Surface it
-	// upfront so the user sees a clear, actionable error (issue #91).
-	if accessMode == "MODIFY" && strings.EqualFold(result.ModificationSupport, "NoModification") {
-		return nil, fmt.Errorf(
-			"object %s is not modifiable via ADT on this system "+
-				"(SAP returned modificationSupport=%q during LOCK). "+
-				"Common causes: read-only system class, missing developer/edit role, "+
-				"BTP ABAP Environment object outside the customer namespace, "+
-				"or hyperfocused mode locking the object as read-only",
-			objectURL, result.ModificationSupport)
-	}
-
+	// MODIFICATION_SUPPORT carries SAP-side policy metadata about how the
+	// object's changes are tracked, not whether the caller may modify it.
+	// IF_ADT_LOCK_RESULT in SAP's standard ADT defines four values:
+	//
+	//   "ModifcationAssistant"  (CO_MOD_SUPPORT_MODASS)         — SAP/partner
+	//       object with Modification Assistant; changes are tracked.
+	//   "ModificationsLoggedOnly" (CO_MOD_SUPPORT_LOGGED_ONLY) — SAP/partner
+	//       object; changes are only logged (no Modification Assistant).
+	//   "NoModification" (CO_MOD_SUPPORT_NOT_NEEDED) — customer-namespace
+	//       object; tracking is not needed. This is the normal response
+	//       for Z*/Y* objects that customers edit freely.
+	//   "" (CO_MOD_SUPPORT_NOT_SPECIFIED) — not specified.
+	//
+	// A valid LOCK_HANDLE plus any of these values means the caller got the
+	// lock. The previous guard that rejected "NoModification" at LOCK time
+	// (issue #91 attempt) was a misreading of the string — the constant is
+	// *NOT_NEEDED*, not *NOT_PERMITTED*. Genuine read-only rejections
+	// surface at other layers (HTTP 403 on the LOCK itself, or 423 on the
+	// subsequent write if session affinity is broken); the correct place
+	// to handle those is where they originate. Here we just return the
+	// parsed result verbatim.
 	return result, nil
 }
 

--- a/pkg/adt/crud_reconcile_test.go
+++ b/pkg/adt/crud_reconcile_test.go
@@ -550,15 +550,41 @@ func TestCreateTestInclude_UsesStatefulSession(t *testing.T) {
 	}
 }
 
-// TestLockObject_RejectsNoModification covers the BTP / ABAP Cloud
-// case from issue #91: a successful LOCK can return
-// MODIFICATION_SUPPORT=NoModification to signal that the object is
-// read-only via ADT for this user/system. Before the fix the caller
-// proceeded to PUT and got a confusing 423 InvalidLockHandle several
-// seconds later. The expected behaviour is to fail at the LOCK call
-// with a clear, actionable error message.
-func TestLockObject_RejectsNoModification(t *testing.T) {
-	const noModLockXML = `<?xml version="1.0" encoding="UTF-8"?>
+// TestLockObject_PassesThroughModificationSupport pins the correct
+// semantics of the MODIFICATION_SUPPORT field on the ADT lock response.
+//
+// The SAP standard interface IF_ADT_LOCK_RESULT defines four values:
+//
+//   - "ModifcationAssistant"    (CO_MOD_SUPPORT_MODASS)       — SAP/partner
+//     object, Modification Assistant on.
+//   - "ModificationsLoggedOnly" (CO_MOD_SUPPORT_LOGGED_ONLY)  — SAP/partner
+//     object, no Modification Assistant (changes only logged).
+//   - "NoModification"          (CO_MOD_SUPPORT_NOT_NEEDED)   — customer
+//     namespace object; modification tracking is NOT NEEDED. This is the
+//     usual response when a developer edits their own Z*/Y* code.
+//   - ""                        (CO_MOD_SUPPORT_NOT_SPECIFIED) — not set.
+//
+// The string "NoModification" therefore means "no tracking needed", not
+// "no edit allowed". An earlier commit (22517d4) hard-failed on this value
+// as if it meant read-only, which broke every normal customer-code edit
+// on destinations that populate the field (e.g. SAP Business Application
+// Studio via Cloud Connector + Principal Propagation). This test locks
+// the corrected behaviour: LockObject returns the parsed result verbatim
+// for any value of MODIFICATION_SUPPORT, and callers treat it as
+// advisory metadata only.
+func TestLockObject_PassesThroughModificationSupport(t *testing.T) {
+	cases := []struct {
+		name    string
+		support string
+	}{
+		{"customer-namespace-not-needed", "NoModification"},
+		{"sap-modification-assistant", "ModifcationAssistant"},
+		{"sap-logged-only", "ModificationsLoggedOnly"},
+		{"not-specified", ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			lockXML := `<?xml version="1.0" encoding="UTF-8"?>
 <asx:abap xmlns:asx="http://www.sap.com/abapxml" version="1.0">
   <asx:values>
     <DATA>
@@ -568,40 +594,45 @@ func TestLockObject_RejectsNoModification(t *testing.T) {
       <CORRTEXT></CORRTEXT>
       <IS_LOCAL></IS_LOCAL>
       <IS_LINK_UP></IS_LINK_UP>
-      <MODIFICATION_SUPPORT>NoModification</MODIFICATION_SUPPORT>
+      <MODIFICATION_SUPPORT>` + tc.support + `</MODIFICATION_SUPPORT>
     </DATA>
   </asx:values>
 </asx:abap>`
-	mock := &methodPathMock{
-		routes: []routedResponse{
-			resp("", "discovery", 200, "ok"),
-			resp(http.MethodPost, "/oo/classes/ZREADONLY", 200, noModLockXML),
-		},
-	}
-	cfg := NewConfig("https://sap.example.com:44300", "user", "pass")
-	transport := NewTransportWithClient(cfg, mock)
-	client := NewClientWithTransport(cfg, transport)
+			mock := &methodPathMock{
+				routes: []routedResponse{
+					resp("", "discovery", 200, "ok"),
+					resp(http.MethodPost, "/oo/classes/ZOBJ", 200, lockXML),
+				},
+			}
+			cfg := NewConfig("https://sap.example.com:44300", "user", "pass")
+			transport := NewTransportWithClient(cfg, mock)
+			client := NewClientWithTransport(cfg, transport)
 
-	_, err := client.LockObject(
-		context.Background(),
-		"/sap/bc/adt/oo/classes/ZREADONLY",
-		"MODIFY",
-	)
-	if err == nil {
-		t.Fatal("LockObject should have returned an error for NoModification, got nil")
-	}
-	if !strings.Contains(err.Error(), "not modifiable") {
-		t.Errorf("error = %q, want to contain \"not modifiable\"", err.Error())
-	}
-	if !strings.Contains(err.Error(), "NoModification") {
-		t.Errorf("error = %q, want to surface the raw modificationSupport value", err.Error())
+			result, err := client.LockObject(
+				context.Background(),
+				"/sap/bc/adt/oo/classes/ZOBJ",
+				"MODIFY",
+			)
+			if err != nil {
+				t.Fatalf("LockObject(MODIFY) must not fail on MODIFICATION_SUPPORT=%q, got error: %v", tc.support, err)
+			}
+			if result == nil {
+				t.Fatal("LockObject returned nil result")
+			}
+			if result.LockHandle != "HANDLE-X" {
+				t.Errorf("LockHandle = %q, want HANDLE-X", result.LockHandle)
+			}
+			if result.ModificationSupport != tc.support {
+				t.Errorf("ModificationSupport = %q, want %q (must be passed through verbatim)", result.ModificationSupport, tc.support)
+			}
+		})
 	}
 }
 
-// TestLockObject_AllowsNoModificationOnReadLock proves the guard is
-// scoped to MODIFY locks — read-only locks (accessMode != MODIFY)
-// must still succeed even if the system flags the object as not
-// modifiable, because there is no write to fail downstream.
+// TestLockObject_AllowsNoModificationOnReadLock exercises the READ access
+// mode path, which skips the OpLock safety check. Kept as a companion to
+// TestLockObject_PassesThroughModificationSupport so the READ branch
+// keeps explicit coverage for the same metadata-only behaviour.
 func TestLockObject_AllowsNoModificationOnReadLock(t *testing.T) {
 	const noModLockXML = `<?xml version="1.0" encoding="UTF-8"?>
 <asx:abap xmlns:asx="http://www.sap.com/abapxml" version="1.0">
@@ -639,3 +670,4 @@ func TestLockObject_AllowsNoModificationOnReadLock(t *testing.T) {
 		t.Errorf("LockHandle = %q, want HANDLE-X", result.LockHandle)
 	}
 }
+

--- a/pkg/adt/http.go
+++ b/pkg/adt/http.go
@@ -8,10 +8,75 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"os"
 	"strings"
 	"sync"
 	"time"
 )
+
+// httpTraceEnabled reports whether the VSP_HTTP_TRACE env var requests raw
+// HTTP request/response dumps to stderr. Diagnostic-only — never leaves the
+// binary switched on by default, and Authorization / Cookie values are
+// redacted so the dump is safe to paste.
+func httpTraceEnabled() bool {
+	v := os.Getenv("VSP_HTTP_TRACE")
+	return v == "1" || strings.EqualFold(v, "true")
+}
+
+const httpTraceBodyLimit = 4096
+
+func traceHTTPRequest(req *http.Request, body []byte) {
+	if !httpTraceEnabled() {
+		return
+	}
+	fmt.Fprintf(os.Stderr, "\n>>> HTTP %s %s\n", req.Method, req.URL.String())
+	for k, vs := range req.Header {
+		for _, v := range vs {
+			if strings.EqualFold(k, "Authorization") || strings.EqualFold(k, "Cookie") {
+				v = "[REDACTED]"
+			}
+			fmt.Fprintf(os.Stderr, ">>> %s: %s\n", k, v)
+		}
+	}
+	if len(body) > 0 {
+		trunc := body
+		if len(trunc) > httpTraceBodyLimit {
+			trunc = trunc[:httpTraceBodyLimit]
+		}
+		fmt.Fprintf(os.Stderr, ">>> body (%d bytes):\n%s\n", len(body), string(trunc))
+		if len(body) > httpTraceBodyLimit {
+			fmt.Fprintf(os.Stderr, ">>> ... (truncated)\n")
+		}
+	}
+}
+
+func traceHTTPResponse(resp *http.Response, body []byte) {
+	if !httpTraceEnabled() || resp == nil {
+		return
+	}
+	fmt.Fprintf(os.Stderr, "<<< HTTP %d %s\n", resp.StatusCode, resp.Status)
+	for k, vs := range resp.Header {
+		for _, v := range vs {
+			if strings.EqualFold(k, "Set-Cookie") {
+				if i := strings.Index(v, "="); i > 0 {
+					v = v[:i] + "=[REDACTED]"
+				}
+			}
+			fmt.Fprintf(os.Stderr, "<<< %s: %s\n", k, v)
+		}
+	}
+	if len(body) > 0 {
+		trunc := body
+		if len(trunc) > httpTraceBodyLimit {
+			trunc = trunc[:httpTraceBodyLimit]
+		}
+		fmt.Fprintf(os.Stderr, "<<< body (%d bytes):\n%s\n", len(body), string(trunc))
+		if len(body) > httpTraceBodyLimit {
+			fmt.Fprintf(os.Stderr, "<<< ... (truncated)\n")
+		}
+	}
+	fmt.Fprintln(os.Stderr)
+}
 
 // HTTPDoer is an interface for executing HTTP requests.
 // This abstraction allows for easy testing with mock implementations.
@@ -140,6 +205,7 @@ func (t *Transport) Request(ctx context.Context, path string, opts *RequestOptio
 	}
 
 	// Execute request
+	traceHTTPRequest(req, opts.Body)
 	resp, err := t.httpClient.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("executing request: %w", err)
@@ -151,6 +217,7 @@ func (t *Transport) Request(ctx context.Context, path string, opts *RequestOptio
 	if err != nil {
 		return nil, fmt.Errorf("reading response body: %w", err)
 	}
+	traceHTTPResponse(resp, body)
 
 	// Handle CSRF token refresh on 403
 	if resp.StatusCode == http.StatusForbidden && isModifyingMethod(opts.Method) {
@@ -255,6 +322,7 @@ func (t *Transport) retryRequest(ctx context.Context, path string, opts *Request
 		req.Header.Set("X-sap-adt-sessiontype", "stateful")
 	}
 
+	traceHTTPRequest(req, opts.Body)
 	resp, err := t.httpClient.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("executing retry request: %w", err)
@@ -265,6 +333,7 @@ func (t *Transport) retryRequest(ctx context.Context, path string, opts *Request
 	if err != nil {
 		return nil, fmt.Errorf("reading response body: %w", err)
 	}
+	traceHTTPResponse(resp, body)
 
 	if resp.StatusCode >= 400 {
 		return nil, &APIError{
@@ -308,6 +377,7 @@ func (t *Transport) fetchCSRFToken(ctx context.Context) error {
 		req.Header.Set("X-sap-adt-sessiontype", "stateful")
 	}
 
+	traceHTTPRequest(req, nil)
 	resp, err := t.httpClient.Do(req)
 	if err != nil {
 		return fmt.Errorf("executing request: %w", err)
@@ -316,6 +386,7 @@ func (t *Transport) fetchCSRFToken(ctx context.Context) error {
 
 	// Drain body to allow connection reuse
 	_, _ = io.Copy(io.Discard, resp.Body)
+	traceHTTPResponse(resp, nil)
 
 	// Note: HEAD may return 400 but still provides CSRF token in headers
 	// But 401/403 indicates auth failure and won't have a valid token

--- a/pkg/adt/http.go
+++ b/pkg/adt/http.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/http/cookiejar"
 	"net/url"
 	"os"
 	"strings"
@@ -90,6 +91,14 @@ type Transport struct {
 	config     *Config
 	httpClient HTTPDoer
 
+	// jar, if non-nil, points to the cookie jar of the underlying
+	// *http.Client. Used by clearSAPSessionCookies to drop stale
+	// sap-contextid / SAP_SESSIONID entries on session-expiry recovery;
+	// the cached CSRF token and in-memory sessionID alone are not enough
+	// — SAP keeps replying ICMENOSESSION until the dead contextid cookie
+	// stops leaking back into outgoing requests.
+	jar http.CookieJar
+
 	// CSRF token management
 	csrfToken string
 	csrfMu    sync.RWMutex
@@ -110,19 +119,25 @@ type Transport struct {
 
 // NewTransport creates a new Transport with the given configuration.
 func NewTransport(cfg *Config) *Transport {
+	hc := cfg.NewHTTPClient()
 	return &Transport{
 		config:     cfg,
-		httpClient: cfg.NewHTTPClient(),
+		httpClient: hc,
+		jar:        hc.Jar,
 	}
 }
 
 // NewTransportWithClient creates a new Transport with a custom HTTP client.
 // This is useful for testing with mock HTTP clients.
 func NewTransportWithClient(cfg *Config, client HTTPDoer) *Transport {
-	return &Transport{
+	t := &Transport{
 		config:     cfg,
 		httpClient: client,
 	}
+	if hc, ok := client.(*http.Client); ok {
+		t.jar = hc.Jar
+	}
+	return t
 }
 
 // RequestOptions contains options for an HTTP request.
@@ -250,9 +265,14 @@ func (t *Transport) Request(ctx context.Context, path string, opts *RequestOptio
 
 		// Handle session timeout - refresh session and retry once
 		if apiErr.IsSessionExpired() {
-			// Clear cached CSRF token and session ID
+			// Clear cached CSRF token, session ID, AND the stale sap-contextid /
+			// SAP_SESSIONID cookies. Without dropping the jar entries SAP keeps
+			// routing the retry to the same dead context and replies
+			// ICMENOSESSION in a loop (including on the HEAD /core/discovery
+			// fetch that's supposed to open a fresh session).
 			t.setCSRFToken("")
 			t.setSessionID("")
+			t.clearSAPSessionCookies()
 			// Fetch new CSRF token (this establishes a new session)
 			if err := t.fetchCSRFToken(ctx); err != nil {
 				return nil, fmt.Errorf("refreshing session after timeout: %w", err)
@@ -488,6 +508,45 @@ func (t *Transport) extractSessionID(resp *http.Response) string {
 		}
 	}
 	return ""
+}
+
+// clearSAPSessionCookies replaces the cookie jar with a fresh one to
+// drop every stale sap-contextid / SAP_SESSIONID entry the server set
+// during the now-expired stateful context.
+//
+// Long-running MCP-server processes hit this after the first
+// Lock→Write→Unlock→Activate cycle: the stateless Activate call ends
+// the stateful context on SAP's side, but the jar keeps the contextid
+// from the earlier stateful responses. Every subsequent request then
+// re-sends the dead identifier and SAP replies HTTP 400 ICMENOSESSION
+// — including on the HEAD /core/discovery refetch that the
+// IsSessionExpired recovery path relies on. Short-lived CLI
+// subcommands don't see the bug because each spawns a fresh process.
+//
+// Earlier attempts to delete targeted cookies via SetCookies with
+// MaxAge=-1 failed in practice because Go's http.CookieJar keys each
+// entry by (name, domain, path) and does not expose the stored path
+// through its public interface: SAP's ICM sets sap-contextid with
+// paths like /sap/, /sap/bc/, or /sap/bc/adt/, and an expire cookie
+// for Path="/" leaves those entries untouched. Replacing the jar
+// entirely removes every path variant in a single step.
+//
+// User-provided cookies (config.Cookies, e.g. SAML/SSO session
+// cookies from browser-auth) are attached per request via addCookies()
+// on each outbound Request, so the jar swap does not lose them — only
+// cookies that the server had dynamically deposited during the dead
+// session are dropped, which is exactly the desired behaviour.
+func (t *Transport) clearSAPSessionCookies() {
+	hc, ok := t.httpClient.(*http.Client)
+	if !ok {
+		return
+	}
+	fresh, err := cookiejar.New(nil)
+	if err != nil {
+		return
+	}
+	hc.Jar = fresh
+	t.jar = fresh
 }
 
 // CSRF token accessors with mutex protection

--- a/pkg/adt/http_test.go
+++ b/pkg/adt/http_test.go
@@ -625,3 +625,92 @@ func TestTransport_Request_BothAuthMethods(t *testing.T) {
 		t.Error("Cookie should also be present when both auth methods are set")
 	}
 }
+
+// TestClearSAPSessionCookies_ReplacesJar pins the ICMENOSESSION
+// recovery path observed in long-running MCP servers: after the first
+// Lock → Write → Unlock → Activate sequence SAP closes the stateful
+// context on its side, but sap-contextid cookies the server issued
+// during that sequence stay in Go's cookie jar — sometimes on multiple
+// paths (/, /sap/, /sap/bc/, /sap/bc/adt/). Every subsequent request
+// re-sends a matching dead identifier and SAP answers HTTP 400
+// ICMENOSESSION, including on the HEAD /core/discovery call that was
+// supposed to open a fresh session.
+//
+// Go's http.CookieJar interface does not expose the stored Path, so a
+// targeted SetCookies-with-MaxAge=-1 expire leaves cookies on unknown
+// paths untouched. The recovery therefore swaps the jar for a fresh
+// one. User-supplied cookies in config.Cookies are attached per
+// request via addCookies() and survive unchanged; only dynamically
+// server-deposited entries are lost, which is the intended behaviour.
+func TestClearSAPSessionCookies_ReplacesJar(t *testing.T) {
+	cfg := NewConfig("https://sap.example.com:44300", "u", "p")
+	transport := NewTransport(cfg)
+
+	baseURL, err := url.Parse(cfg.BaseURL)
+	if err != nil {
+		t.Fatalf("parse base URL: %v", err)
+	}
+
+	// Seed the jar with a spread of the cookies SAP is known to plant
+	// during a stateful sequence, including entries on deeper paths
+	// that a targeted-delete approach cannot reach.
+	seed := func(u *url.URL, cs []*http.Cookie) { transport.jar.SetCookies(u, cs) }
+	root := *baseURL
+	root.Path = "/"
+	seed(&root, []*http.Cookie{{Name: "sap-contextid", Value: "ROOT", Path: "/"}})
+	sap := *baseURL
+	sap.Path = "/sap/"
+	seed(&sap, []*http.Cookie{{Name: "sap-contextid", Value: "SAP", Path: "/sap/"}})
+	adt := *baseURL
+	adt.Path = "/sap/bc/adt/"
+	seed(&adt, []*http.Cookie{
+		{Name: "sap-contextid", Value: "ADT", Path: "/sap/bc/adt/"},
+		{Name: "SAP_SESSIONID_ABC_001", Value: "SESS", Path: "/sap/bc/adt/"},
+	})
+
+	originalJar := transport.jar
+
+	transport.clearSAPSessionCookies()
+
+	if transport.jar == originalJar {
+		t.Fatal("expected a new jar instance; jar reference unchanged")
+	}
+
+	// No path deeper than the ADT root should carry any SAP session
+	// cookie after the swap.
+	for _, p := range []string{"/", "/sap/", "/sap/bc/", "/sap/bc/adt/"} {
+		u := *baseURL
+		u.Path = p
+		for _, c := range transport.jar.Cookies(&u) {
+			if c.Name == "sap-contextid" || strings.HasPrefix(c.Name, "SAP_SESSIONID") {
+				t.Errorf("stale cookie %q survived jar swap on path %q: %v", c.Name, p, c)
+			}
+		}
+	}
+
+	// The underlying *http.Client must also point at the new jar — if
+	// only our cached reference changed, outgoing requests would keep
+	// reading from the old (stale-cookie) jar.
+	hc, ok := transport.httpClient.(*http.Client)
+	if !ok {
+		t.Fatal("expected NewTransport to produce an *http.Client")
+	}
+	if hc.Jar != transport.jar {
+		t.Error("*http.Client.Jar must be swapped alongside Transport.jar — otherwise outbound requests keep reading the stale jar")
+	}
+}
+
+// TestClearSAPSessionCookies_NonHTTPClientIsSafe guards the test-only
+// path: NewTransportWithClient fed a mock HTTPDoer leaves the jar nil,
+// and clearSAPSessionCookies must stay a no-op instead of panicking.
+func TestClearSAPSessionCookies_NonHTTPClientIsSafe(t *testing.T) {
+	cfg := NewConfig("https://sap.example.com:44300", "u", "p")
+	transport := NewTransportWithClient(cfg, &mockHTTPClient{})
+	if transport.jar != nil {
+		t.Fatal("expected jar to be nil when HTTPDoer is not *http.Client")
+	}
+	transport.clearSAPSessionCookies() // must not panic
+	if transport.jar != nil {
+		t.Error("mocked transport must remain jar-less after clear (no swap to perform)")
+	}
+}

--- a/pkg/adt/workflows_deploy.go
+++ b/pkg/adt/workflows_deploy.go
@@ -77,29 +77,9 @@ func (c *Client) CreateFromFile(ctx context.Context, filePath, packageName, tran
 		return nil, err
 	}
 
-	// 5. Lock object
-	lockResult, err := c.LockObject(ctx, objectURL, "MODIFY")
-	if err != nil {
-		return &DeployResult{
-			FilePath:   filePath,
-			ObjectURL:  objectURL,
-			ObjectName: info.ObjectName,
-			ObjectType: string(info.ObjectType),
-			Success:    false,
-			Errors:     []string{fmt.Sprintf("lock failed: %v", err)},
-			Message:    fmt.Sprintf("Object created but failed to lock: %v", err),
-		}, nil
-	}
-
-	// Ensure unlock on any error
-	unlocked := false
-	defer func() {
-		if !unlocked {
-			_ = c.UnlockObject(ctx, objectURL, lockResult.LockHandle)
-		}
-	}()
-
-	// 6. Syntax check (optional pre-check)
+	// 5. Syntax check BEFORE lock — SyntaxCheck runs stateless and would
+	// break stateful session affinity if placed between Lock and UpdateSource,
+	// causing ICMENOSESSION / CSRF errors.
 	syntaxErrors, err := c.SyntaxCheck(ctx, objectURL, source)
 	if err != nil {
 		return &DeployResult{
@@ -129,6 +109,29 @@ func (c *Client) CreateFromFile(ctx context.Context, filePath, packageName, tran
 			Message:      fmt.Sprintf("Object created but has %d syntax errors", len(syntaxErrors)),
 		}, nil
 	}
+
+	// 6. Lock object — from here on, ALL requests must be stateful to
+	// maintain session affinity for the lock handle (issue #88).
+	lockResult, err := c.LockObject(ctx, objectURL, "MODIFY")
+	if err != nil {
+		return &DeployResult{
+			FilePath:   filePath,
+			ObjectURL:  objectURL,
+			ObjectName: info.ObjectName,
+			ObjectType: string(info.ObjectType),
+			Success:    false,
+			Errors:     []string{fmt.Sprintf("lock failed: %v", err)},
+			Message:    fmt.Sprintf("Object created but failed to lock: %v", err),
+		}, nil
+	}
+
+	// Ensure unlock on any error
+	unlocked := false
+	defer func() {
+		if !unlocked {
+			_ = c.UnlockObject(ctx, objectURL, lockResult.LockHandle)
+		}
+	}()
 
 	// 7. Write source (need source URL, not object URL)
 	sourceURL, err := c.buildSourceURL(info.ObjectType, info.ObjectName)
@@ -224,29 +227,9 @@ func (c *Client) UpdateFromFile(ctx context.Context, filePath, transport string)
 		return nil, err
 	}
 
-	// 4. Lock object
-	lockResult, err := c.LockObject(ctx, objectURL, "MODIFY")
-	if err != nil {
-		return &DeployResult{
-			FilePath:   filePath,
-			ObjectURL:  objectURL,
-			ObjectName: info.ObjectName,
-			ObjectType: string(info.ObjectType),
-			Success:    false,
-			Errors:     []string{fmt.Sprintf("lock failed: %v", err)},
-			Message:    fmt.Sprintf("Failed to lock object: %v", err),
-		}, nil
-	}
-
-	// Ensure unlock on any error
-	unlocked := false
-	defer func() {
-		if !unlocked {
-			_ = c.UnlockObject(ctx, objectURL, lockResult.LockHandle)
-		}
-	}()
-
-	// 5. Syntax check (skip for class includes - will check after update)
+	// 4. Syntax check BEFORE lock (skip for class includes - will check after update).
+	// SyntaxCheck runs stateless and would break stateful session affinity if
+	// placed between Lock and UpdateSource, causing ICMENOSESSION / CSRF errors.
 	if !isClassInclude {
 		syntaxErrors, err := c.SyntaxCheck(ctx, objectURL, source)
 		if err != nil {
@@ -278,6 +261,29 @@ func (c *Client) UpdateFromFile(ctx context.Context, filePath, transport string)
 			}, nil
 		}
 	}
+
+	// 5. Lock object — from here on, ALL requests must be stateful to
+	// maintain session affinity for the lock handle (issue #88).
+	lockResult, err := c.LockObject(ctx, objectURL, "MODIFY")
+	if err != nil {
+		return &DeployResult{
+			FilePath:   filePath,
+			ObjectURL:  objectURL,
+			ObjectName: info.ObjectName,
+			ObjectType: string(info.ObjectType),
+			Success:    false,
+			Errors:     []string{fmt.Sprintf("lock failed: %v", err)},
+			Message:    fmt.Sprintf("Failed to lock object: %v", err),
+		}, nil
+	}
+
+	// Ensure unlock on any error
+	unlocked := false
+	defer func() {
+		if !unlocked {
+			_ = c.UnlockObject(ctx, objectURL, lockResult.LockHandle)
+		}
+	}()
 
 	// 6. Write source
 	if isClassInclude {


### PR DESCRIPTION
## Summary

Four independent but related fixes to the ADT layer. All surfaced while
verifying `vsp deploy` on SAP Business Application Studio destinations
(Cloud Connector + Principal Propagation). Live-tested against an on-prem
S/4HANA (DEV 2021 FPS05) for CLAS and INTF, both `$TMP` and transportable
customer packages. Full `pkg/adt` suite stays green.

1. **SyntaxCheck before Lock** in `CreateFromFile` / `UpdateFromFile`.
2. **Drop the `MODIFICATION_SUPPORT="NoModification"` hard-fail** at LOCK.
3. **Preserve `X-CSRF-Token` and `X-sap-adt-sessiontype`** on redirects.
4. **Replace the cookie jar on `ICMENOSESSION` recovery.**

Plus one opt-in diagnostic: `VSP_HTTP_TRACE=1` dumps raw HTTP requests
and responses to stderr with Authorization / Cookie values redacted. It
made the root-cause analysis of (2) and (4) possible.

## 1. SyntaxCheck before Lock

`SyntaxCheck` carried the default stateless session-type; running it
*after* `LockObject` interleaves a stateless hop between the stateful
lock and write. SAP's ICM retires the stateful context on that hop
(`Sap-Err-Id: ICMENOSESSION` on the PUT), and the ensuing CSRF refresh
fails because the session that held the token is already gone.

Moving `SyntaxCheck` before `LockObject` keeps `Lock → UpdateSource →
Unlock → Activate` as a single uninterrupted stateful block. The
per-request `Stateful: true` flags from 22517d4 are necessary but not
sufficient on their own — call ordering matters too.

## 2. `MODIFICATION_SUPPORT="NoModification"` is not "read-only"

Commit 22517d4 hard-failed `LockObject` when the response carried
`MODIFICATION_SUPPORT=NoModification`, reading it as "object is
read-only via ADT". That is a misreading of the SAP-standard interface
`IF_ADT_LOCK_RESULT`, which defines four values:

| XML value                 | Constant                       | Documented meaning |
|---|---|---|
| `ModifcationAssistant` *(sic)* | `CO_MOD_SUPPORT_MODASS`      | SAP/partner object, Modification Assistant on |
| `ModificationsLoggedOnly` | `CO_MOD_SUPPORT_LOGGED_ONLY`     | SAP/partner object, changes only logged |
| `NoModification`          | **`CO_MOD_SUPPORT_NOT_NEEDED`** | **"Modification support is not needed because object is not in SAP/partner namespace in a customer system."** |
| `` (empty)                | `CO_MOD_SUPPORT_NOT_SPECIFIED`   | not specified |

The constant is **`NOT_NEEDED`**, not `NOT_PERMITTED`. Customer Z\*/Y\*
objects routinely return this value and the subsequent PUT succeeds —
confirmed live with `VSP_HTTP_TRACE=1`:

    <LOCK_HANDLE>…</LOCK_HANDLE>
    <CORRNR>WSDK920768</CORRNR> <CORRUSER>X60000469</CORRUSER>
    <MODIFICATION_SUPPORT>NoModification</MODIFICATION_SUPPORT>
    → PUT …/source/main: HTTP 200, Etag returned; Activate: activationExecuted="true"

`CORRNR` / `CORRUSER` populated on the LOCK response means SAP accepted
the lock. The field is tracking metadata, not an authorisation verdict.

The "confusing HTTP 423 a few seconds later" the guard was meant to
pre-empt is fully explained by the session-affinity work in 27f4d7c +
the class-include completion in 22517d4 itself. The guard only ever
fires as a false positive on destinations whose SAP system populates
the flag — blocking legitimate customer edits.

`LockObject` now returns the parsed result verbatim for any value.
Tests move from the asymmetric `_RejectsNoModification` pair to a
table-driven `_PassesThroughModificationSupport`, plus the retained
read-lock variant.

## 3. `CheckRedirect` preserves ADT headers

Go's `http.Client` strips Authorization / WWW-Authenticate / Cookie on
cross-origin redirects (RFC 7235). The existing `CheckRedirect`
restores `Authorization` for #90. `X-CSRF-Token` and
`X-sap-adt-sessiontype` are not on Go's sensitive-header list and are
therefore forwarded by default — but if either silently vanishes
across a redirect (proxy, future library change, middleware), the
second hop lands stateless with a missing CSRF token and the in-flight
lock is invalidated. Re-set both explicitly from `via[0]`, mirroring
the existing `Authorization` logic. Documented as defensive in the
source comment.

## 4. Replace the cookie jar on `ICMENOSESSION` recovery

Long-running processes (MCP server) hit HTTP 400 ICMENOSESSION on
every request after the first successful
Lock → Write → Unlock → Activate cycle. Captured trace:

    POST …/activation?method=activate              → 200  (stateless; ends context)
    POST …/repository/nodestructure                → 400 ICMENOSESSION
        + 6× Set-Cookie: sap-contextid=…
    HEAD …/core/discovery                          → 400 ICMENOSESSION
        + 6× Set-Cookie: sap-contextid=…
    …                                               (stuck)

Root cause: the stateless `Activate` closes SAP's stateful context
server-side, but `sap-contextid` cookies from the stateful phase stay
in Go's cookie jar — sometimes on multiple paths (`/`, `/sap/`,
`/sap/bc/`, `/sap/bc/adt/`). Every retry re-sends a matching dead
identifier, including the HEAD `/core/discovery` refetch that
`IsSessionExpired` recovery relies on. Short-lived CLI subcommands
escape because each spawns a fresh jar.

A first iteration of this fix expired cookies with
`SetCookies(baseURL, {MaxAge: -1, Path: "/"})`. It did not work in
practice: `http.CookieJar` keys entries by `(name, domain, path)` and
does not expose the stored path — an expire for `Path="/"` leaves
entries on deeper paths untouched, and that is exactly where SAP
stores the contextid.

Final fix replaces the entire cookie jar with a fresh one before the
CSRF refetch. User-provided cookies (`config.Cookies`, populated by
browser-auth / SAML / cookie-file flows) are attached per request via
`addCookies()` and survive untouched; only dynamically
server-deposited entries from the dead session are dropped —
the desired outcome. `Transport` gains a cached `jar http.CookieJar`
reference from the underlying `*http.Client`; a type-assertion on
`HTTPDoer` leaves the field nil for test mocks and the helper no-ops
there.

## Files changed

    pkg/adt/workflows_deploy.go     — SyntaxCheck before Lock
    pkg/adt/crud.go                 — drop NoModification guard, add interface doc comment
    pkg/adt/crud_reconcile_test.go  — _PassesThroughModificationSupport (table-driven)
    pkg/adt/config.go               — CheckRedirect preserves X-CSRF-Token +
                                      X-sap-adt-sessiontype
    pkg/adt/config_test.go          — _CheckRedirectPreservesADTHeaders
                                      _CheckRedirectHonoursLimit
    pkg/adt/http.go                 — VSP_HTTP_TRACE env gate + trace helpers hooked
                                      into Request / retryRequest / fetchCSRFToken;
                                      Transport.jar field; clearSAPSessionCookies
                                      (jar-replace) helper; ICMENOSESSION recovery
                                      call site
    pkg/adt/http_test.go            — _ClearSAPSessionCookies_ReplacesJar
                                      _ClearSAPSessionCookies_NonHTTPClientIsSafe

## Related issues

- **#88 / #92 / #98** — session affinity. Fully closed by the combination
  of 27f4d7c + 22517d4's class-include completion + the ordering fix in
  this PR's commit 1.
- **#91** — this PR reverses the NoModification interpretation. A real
  read-only case on BTP, if it exists, will now surface with SAP's
  authoritative error at the write step rather than spuriously at LOCK.

