### PR TITLE
fix(adt): skip redundant mutation gate after lock to keep stateful session alive

### DIFF
--- a/pkg/adt/mutation_gate.go
+++ b/pkg/adt/mutation_gate.go
@@ -5,6 +5,46 @@ import (
 	"fmt"
 )
 
+// mutationGateSkipKey is the context-key used to mark that the unified
+// mutation policy gate has already been evaluated by an outer workflow.
+// Inner mutators (UpdateSource, UpdateClassInclude, DeleteObject,
+// CreateTestInclude) consult this flag and skip their own redundant gate
+// invocation when set.
+//
+// This prevents a session-affinity bug: the inner gate's package-resolution
+// path (getObjectPackage → SearchObject) issues a STATELESS HTTP hop. When
+// that hop is interleaved between a stateful LockObject and the stateful
+// PUT/DELETE/POST, SAP's ICM retires the stateful session server-side
+// (Sap-Err-Id: ICMENOSESSION), invalidating the lock handle and producing
+// HTTP 423 ExceptionResourceInvalidLockHandle on the write.
+//
+// This is the same bug class as commit 8cb45a5 (SyntaxCheck before Lock),
+// just at a different call site. The outer workflow already ran the gate
+// before LockObject; running it again after the lock buys nothing and
+// breaks the session.
+type mutationGateSkipKeyT struct{}
+
+var mutationGateSkipKey = mutationGateSkipKeyT{}
+
+// withMutationGateAlreadyRan returns a derived context that signals the
+// unified mutation gate has already been evaluated for this operation.
+// Inner mutators called through this context will skip their redundant
+// gate to keep the stateful session intact between Lock and Write.
+//
+// Callers must only set this flag AFTER successfully running checkMutation
+// themselves with a context that covers the same op-type, package, and
+// transport as the inner mutator would have checked.
+func withMutationGateAlreadyRan(ctx context.Context) context.Context {
+	return context.WithValue(ctx, mutationGateSkipKey, true)
+}
+
+// mutationGateAlreadyRan reports whether the context was marked by an
+// outer workflow as having already run the unified mutation gate.
+func mutationGateAlreadyRan(ctx context.Context) bool {
+	v, _ := ctx.Value(mutationGateSkipKey).(bool)
+	return v
+}
+
 // MutationSurface identifies the object surface a mutation targets. Different
 // surfaces require different metadata resolution strategies (ADT SearchObject,
 // UI5 BSP metadata, etc.). Use SurfaceADT for standard ABAP objects.
@@ -70,7 +110,17 @@ type MutationContext struct {
 // should call this at the top of their implementation instead of wiring the
 // sub-checks by hand — that avoids the class of bug where one sub-check is
 // forgotten and a whole mutation path silently bypasses policy.
+//
+// When the context was marked by an outer workflow via
+// withMutationGateAlreadyRan, this function returns immediately. The outer
+// workflow is responsible for having run an equivalent (or stricter) gate
+// before delegating to the inner mutator. See mutationGateSkipKey for the
+// session-affinity rationale.
 func (c *Client) checkMutation(ctx context.Context, m MutationContext) error {
+	if mutationGateAlreadyRan(ctx) {
+		return nil
+	}
+
 	// 1. Operation type check
 	if err := c.checkSafety(m.Op, m.OpName); err != nil {
 		return err

--- a/pkg/adt/mutation_gate_skip_test.go
+++ b/pkg/adt/mutation_gate_skip_test.go
@@ -1,0 +1,167 @@
+package adt
+
+import (
+	"context"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+// TestMutationGateSkip_EditSourceNoSearchBetweenLockAndPut is the
+// regression guard for the sister bug of commit 8cb45a5 (SyntaxCheck
+// before Lock).
+//
+// The original symptom: when AllowedPackages was configured, EditSource
+// produced an HTTP 423 ExceptionResourceInvalidLockHandle on the PUT
+// because the inner UpdateSource gate ran getObjectPackage →
+// SearchObject (a STATELESS hop) between the stateful Lock and the
+// stateful PUT. SAP's ICM retired the stateful session on the stateless
+// hop (Sap-Err-Id: ICMENOSESSION), and the lock handle bound to that
+// dead session was then rejected by the PUT.
+//
+// The fix marks the context with mutationGateSkipKey after the outer
+// EditSourceWithOptions gate completes; the inner UpdateSource sees
+// the flag and skips its own getObjectPackage call. This test pins
+// the absence of any informationsystem/search request between LOCK
+// and PUT in the call sequence.
+func TestMutationGateSkip_EditSourceNoSearchBetweenLockAndPut(t *testing.T) {
+	const sourceBody = "REPORT ztest.\nWRITE / 'hello'.\n"
+	const newSourceBody = "REPORT ztest.\nWRITE / 'world'.\n"
+
+	mock := &methodPathMock{
+		routes: []routedResponse{
+			resp("", "discovery", 200, "ok"),
+			// Outer gate's package resolution — happens BEFORE Lock.
+			resp("", "informationsystem/search", 200, searchZTESTInTmpXML),
+			// GET source/main → return current source.
+			resp(http.MethodGet, "/programs/programs/ZTEST/source/main", 200, sourceBody),
+			// SyntaxCheck (POST checkruns) → return clean.
+			resp(http.MethodPost, "checkruns", 200, ""),
+			// Lock acquisition (POST with _action=LOCK).
+			resp(http.MethodPost, "/programs/programs/ZTEST", 200, lockResponseXML),
+			// PUT source/main → succeed.
+			resp(http.MethodPut, "/programs/programs/ZTEST/source/main", 200, ""),
+			// Activate.
+			resp(http.MethodPost, "/activation", 200, ""),
+		},
+	}
+	cfg := NewConfig("https://sap.example.com:44300", "user", "pass",
+		WithAllowedPackages("$TMP"),
+	)
+	transport := NewTransportWithClient(cfg, mock)
+	client := NewClientWithTransport(cfg, transport)
+
+	result, err := client.EditSourceWithOptions(
+		context.Background(),
+		"/sap/bc/adt/programs/programs/ZTEST",
+		"WRITE / 'hello'.",
+		"WRITE / 'world'.",
+		&EditSourceOptions{SyntaxCheck: false},
+	)
+	if err != nil {
+		t.Fatalf("EditSourceWithOptions failed: %v", err)
+	}
+	_ = result
+	_ = newSourceBody
+
+	// Walk the recorded calls, find the Lock POST and the source PUT,
+	// and assert no informationsystem/search appears between them.
+	lockIdx, putIdx := -1, -1
+	for i, c := range mock.calls {
+		if c.method == http.MethodPost && strings.HasSuffix(c.path, "/programs/programs/ZTEST") {
+			// LockObject POSTs to the bare object URL with _action=LOCK
+			// in the query string. The mock records the path, not the
+			// query, so this is the right match.
+			lockIdx = i
+		}
+		if c.method == http.MethodPut && strings.HasSuffix(c.path, "/programs/programs/ZTEST/source/main") {
+			putIdx = i
+			break
+		}
+	}
+	if lockIdx == -1 {
+		t.Fatalf("no Lock POST observed; calls: %+v", mock.calls)
+	}
+	if putIdx == -1 {
+		t.Fatalf("no source PUT observed; calls: %+v", mock.calls)
+	}
+	if lockIdx >= putIdx {
+		t.Fatalf("lock should precede put; lockIdx=%d putIdx=%d calls=%+v",
+			lockIdx, putIdx, mock.calls)
+	}
+
+	for i := lockIdx + 1; i < putIdx; i++ {
+		if strings.Contains(mock.calls[i].path, "informationsystem/search") {
+			t.Errorf(
+				"informationsystem/search hop appeared between Lock and PUT (index %d): %s — "+
+					"this is the session-affinity regression: the stateless search "+
+					"retires SAP's stateful session and invalidates the lock handle "+
+					"(sister bug of commit 8cb45a5)",
+				i, mock.calls[i].path,
+			)
+		}
+	}
+}
+
+// TestMutationGateSkip_FlagSkipsInnerCheck unit-tests the
+// withMutationGateAlreadyRan / mutationGateAlreadyRan plumbing in
+// isolation: even with a deliberately invalid MutationContext that
+// would normally fail closed under AllowedPackages (no ObjectURL
+// AND no Package), checkMutation must short-circuit and return nil
+// when the context has been marked.
+func TestMutationGateSkip_FlagSkipsInnerCheck(t *testing.T) {
+	cfg := NewConfig("https://sap.example.com:44300", "user", "pass",
+		WithAllowedPackages("$TMP"),
+	)
+	client := NewClientWithTransport(cfg, NewTransportWithClient(cfg, &mockTransportClient{
+		responses: map[string]*http.Response{"discovery": newTestResponse("OK")},
+	}))
+
+	// Without the flag this MutationContext fails closed (line 107 of
+	// mutation_gate.go: "requires either ObjectURL or Package when
+	// AllowedPackages is configured").
+	unmarkedErr := client.checkMutation(context.Background(), MutationContext{
+		Op:     OpUpdate,
+		OpName: "TestOp",
+	})
+	if unmarkedErr == nil {
+		t.Fatal("baseline: expected failure when neither ObjectURL nor Package is set under AllowedPackages")
+	}
+
+	// With the flag set, the inner gate must short-circuit.
+	markedCtx := withMutationGateAlreadyRan(context.Background())
+	if !mutationGateAlreadyRan(markedCtx) {
+		t.Fatal("mutationGateAlreadyRan should report true for a marked context")
+	}
+	markedErr := client.checkMutation(markedCtx, MutationContext{
+		Op:     OpUpdate,
+		OpName: "TestOp",
+	})
+	if markedErr != nil {
+		t.Fatalf("marked context should bypass the inner gate, got error: %v", markedErr)
+	}
+}
+
+// TestMutationGateSkip_FlagDoesNotLeakAcrossContexts verifies that the
+// skip flag is scoped to a single context derivation chain — a sibling
+// context derived from the same parent must NOT inherit the flag, so
+// unrelated callers in the same goroutine cannot accidentally bypass
+// the gate.
+func TestMutationGateSkip_FlagDoesNotLeakAcrossContexts(t *testing.T) {
+	parent := context.Background()
+	marked := withMutationGateAlreadyRan(parent)
+
+	if mutationGateAlreadyRan(parent) {
+		t.Error("parent context should not be retroactively marked")
+	}
+	if !mutationGateAlreadyRan(marked) {
+		t.Error("derived context should be marked")
+	}
+
+	// A sibling derived from the parent (not the marked context) must
+	// be clean.
+	sibling := context.WithValue(parent, struct{ k string }{k: "x"}, 1)
+	if mutationGateAlreadyRan(sibling) {
+		t.Error("sibling context derived from parent must not be marked")
+	}
+}

--- a/pkg/adt/workflows.go
+++ b/pkg/adt/workflows.go
@@ -27,7 +27,10 @@ func (c *Client) WriteProgram(ctx context.Context, programName string, source st
 	objectURL := fmt.Sprintf("/sap/bc/adt/programs/programs/%s", url.PathEscape(programName))
 	sourceURL := objectURL + "/source/main"
 
-	// Unified mutation policy gate (op type + package + transport)
+	// Unified mutation policy gate (op type + package + transport).
+	// Marking the context skips the inner gate in UpdateSource so the
+	// stateful Lock → PUT block is not interrupted by a stateless
+	// SearchObject hop (see mutationGateSkipKey for full rationale).
 	if err := c.checkMutation(ctx, MutationContext{
 		Op:        OpWorkflow,
 		OpName:    "WriteProgram",
@@ -36,6 +39,7 @@ func (c *Client) WriteProgram(ctx context.Context, programName string, source st
 	}); err != nil {
 		return nil, err
 	}
+	ctx = withMutationGateAlreadyRan(ctx)
 
 	result := &WriteProgramResult{
 		ProgramName: programName,
@@ -122,7 +126,9 @@ func (c *Client) WriteClass(ctx context.Context, className string, source string
 	objectURL := fmt.Sprintf("/sap/bc/adt/oo/classes/%s", url.PathEscape(className))
 	sourceURL := objectURL + "/source/main"
 
-	// Unified mutation policy gate (op type + package + transport)
+	// Unified mutation policy gate (op type + package + transport).
+	// Mark the context to skip the inner gate in UpdateSource — see
+	// mutationGateSkipKey for the session-affinity rationale.
 	if err := c.checkMutation(ctx, MutationContext{
 		Op:        OpWorkflow,
 		OpName:    "WriteClass",
@@ -131,6 +137,7 @@ func (c *Client) WriteClass(ctx context.Context, className string, source string
 	}); err != nil {
 		return nil, err
 	}
+	ctx = withMutationGateAlreadyRan(ctx)
 
 	result := &WriteClassResult{
 		ClassName: className,
@@ -216,7 +223,10 @@ func (c *Client) CreateAndActivateProgram(ctx context.Context, programName strin
 	programName = strings.ToUpper(programName)
 	packageName = strings.ToUpper(packageName)
 
-	// Unified mutation policy gate (op type + package + transport)
+	// Unified mutation policy gate (op type + package + transport).
+	// Mark the context to skip the inner gate in CreateObject and
+	// UpdateSource — see mutationGateSkipKey for the session-affinity
+	// rationale.
 	if err := c.checkMutation(ctx, MutationContext{
 		Op:        OpWorkflow,
 		OpName:    "CreateAndActivateProgram",
@@ -225,6 +235,7 @@ func (c *Client) CreateAndActivateProgram(ctx context.Context, programName strin
 	}); err != nil {
 		return nil, err
 	}
+	ctx = withMutationGateAlreadyRan(ctx)
 
 	objectURL := fmt.Sprintf("/sap/bc/adt/programs/programs/%s", url.PathEscape(programName))
 	sourceURL := objectURL + "/source/main"
@@ -309,7 +320,10 @@ func (c *Client) CreateClassWithTests(ctx context.Context, className string, des
 	className = strings.ToUpper(className)
 	packageName = strings.ToUpper(packageName)
 
-	// Unified mutation policy gate (op type + package + transport)
+	// Unified mutation policy gate (op type + package + transport).
+	// Mark the context to skip the inner gate in CreateObject,
+	// UpdateSource, CreateTestInclude and UpdateClassInclude — see
+	// mutationGateSkipKey for the session-affinity rationale.
 	if err := c.checkMutation(ctx, MutationContext{
 		Op:        OpWorkflow,
 		OpName:    "CreateClassWithTests",
@@ -318,6 +332,7 @@ func (c *Client) CreateClassWithTests(ctx context.Context, className string, des
 	}); err != nil {
 		return nil, err
 	}
+	ctx = withMutationGateAlreadyRan(ctx)
 
 	objectURL := fmt.Sprintf("/sap/bc/adt/oo/classes/%s", url.PathEscape(className))
 	sourceURL := objectURL + "/source/main"

--- a/pkg/adt/workflows_deploy.go
+++ b/pkg/adt/workflows_deploy.go
@@ -33,10 +33,20 @@ type DeployResult struct {
 // Example:
 //   result, err := client.CreateFromFile(ctx, "/path/to/zcl_test.clas.abap", "$TMP", "")
 func (c *Client) CreateFromFile(ctx context.Context, filePath, packageName, transport string) (*DeployResult, error) {
-	// Safety check
-	if err := c.checkSafety(OpCreate, "CreateFromFile"); err != nil {
+	// Unified mutation policy gate (op type + package + transport).
+	// Run with the explicit Package the caller supplied, then mark the
+	// context so the inner CreateObject + UpdateSource skip their
+	// redundant gates — preventing the SearchObject hop between Lock and
+	// PUT (mutationGateSkipKey).
+	if err := c.checkMutation(ctx, MutationContext{
+		Op:        OpCreate,
+		OpName:    "CreateFromFile",
+		Package:   strings.ToUpper(packageName),
+		Transport: transport,
+	}); err != nil {
 		return nil, err
 	}
+	ctx = withMutationGateAlreadyRan(ctx)
 
 	// 1. Parse file to detect type and name
 	info, err := ParseABAPFile(filePath)
@@ -195,11 +205,6 @@ func (c *Client) CreateFromFile(ctx context.Context, filePath, packageName, tran
 // Example:
 //   result, err := client.UpdateFromFile(ctx, "/path/to/zcl_test.clas.abap", "")
 func (c *Client) UpdateFromFile(ctx context.Context, filePath, transport string) (*DeployResult, error) {
-	// Safety check
-	if err := c.checkSafety(OpUpdate, "UpdateFromFile"); err != nil {
-		return nil, err
-	}
-
 	// 1. Parse file to detect type and name
 	info, err := ParseABAPFile(filePath)
 	if err != nil {
@@ -223,6 +228,21 @@ func (c *Client) UpdateFromFile(ctx context.Context, filePath, transport string)
 	if err != nil {
 		return nil, err
 	}
+
+	// Unified mutation policy gate (op type + package + transport).
+	// Resolve and check the package up front, then mark the context so
+	// the inner UpdateSource / UpdateClassInclude / CreateTestInclude
+	// skip their redundant gates — preventing the SearchObject hop
+	// between Lock and PUT (mutationGateSkipKey).
+	if err := c.checkMutation(ctx, MutationContext{
+		Op:        OpUpdate,
+		OpName:    "UpdateFromFile",
+		ObjectURL: objectURL,
+		Transport: transport,
+	}); err != nil {
+		return nil, err
+	}
+	ctx = withMutationGateAlreadyRan(ctx)
 
 	// 4. Lock object
 	lockResult, err := c.LockObject(ctx, objectURL, "MODIFY")

--- a/pkg/adt/workflows_edit.go
+++ b/pkg/adt/workflows_edit.go
@@ -149,7 +149,13 @@ func (c *Client) EditSourceWithOptions(ctx context.Context, objectURL, oldString
 		opts = &EditSourceOptions{SyntaxCheck: true}
 	}
 
-	// Unified mutation policy gate (op type + package + transport)
+	// Unified mutation policy gate (op type + package + transport).
+	// We resolve the package here, BEFORE LockObject, so the inner
+	// UpdateSource / UpdateClassInclude do not repeat the resolution
+	// between the stateful Lock and the stateful PUT. Repeating it would
+	// inject a stateless SearchObject hop that retires SAP's stateful ICM
+	// session and invalidates the lock handle (HTTP 423). Same bug class
+	// as commit 8cb45a5 (SyntaxCheck before Lock), different call site.
 	if err := c.checkMutation(ctx, MutationContext{
 		Op:        OpUpdate,
 		OpName:    "EditSource",
@@ -158,6 +164,7 @@ func (c *Client) EditSourceWithOptions(ctx context.Context, objectURL, oldString
 	}); err != nil {
 		return nil, err
 	}
+	ctx = withMutationGateAlreadyRan(ctx)
 	// SyntaxCheck defaults to true if not explicitly set (zero value is false, so we need to handle this)
 	// Note: caller should explicitly set SyntaxCheck=false if they don't want it
 

--- a/pkg/adt/workflows_execute.go
+++ b/pkg/adt/workflows_execute.go
@@ -68,10 +68,19 @@ type ExecuteABAPOptions struct {
 //
 // Security: This is gated by OpWorkflow safety check.
 func (c *Client) ExecuteABAP(ctx context.Context, code string, opts *ExecuteABAPOptions) (*ExecuteABAPResult, error) {
-	// Safety check for workflow operations
-	if err := c.checkSafety(OpWorkflow, "ExecuteABAP"); err != nil {
+	// Unified mutation policy gate — temp programs always live in $TMP.
+	// Mark the context so the inner CreateObject + UpdateSource +
+	// DeleteObject (cleanup) skip their redundant gates and do not inject
+	// a stateless SearchObject hop between Lock and PUT/DELETE
+	// (mutationGateSkipKey).
+	if err := c.checkMutation(ctx, MutationContext{
+		Op:      OpWorkflow,
+		OpName:  "ExecuteABAP",
+		Package: "$TMP",
+	}); err != nil {
 		return nil, err
 	}
+	ctx = withMutationGateAlreadyRan(ctx)
 
 	if opts == nil {
 		opts = &ExecuteABAPOptions{}

--- a/pkg/adt/workflows_fileio.go
+++ b/pkg/adt/workflows_fileio.go
@@ -59,6 +59,12 @@ func (c *Client) RenameObject(ctx context.Context, objType CreatableObjectType, 
 		}
 	}
 
+	// Both gates have run; mark the context so inner CreateObject /
+	// UpdateSource / DeleteObject skip their redundant gates and do not
+	// inject a stateless SearchObject hop between Lock and PUT/DELETE
+	// (mutationGateSkipKey).
+	ctx = withMutationGateAlreadyRan(ctx)
+
 	// 1. Get old object source
 	resp, err := c.transport.Request(ctx, oldURL+"/source/main", &RequestOptions{
 		Method: "GET",

--- a/pkg/adt/workflows_source.go
+++ b/pkg/adt/workflows_source.go
@@ -366,6 +366,21 @@ func (c *Client) writeSourceCreate(ctx context.Context, objectType, name, source
 		objectURL := fmt.Sprintf("/sap/bc/adt/oo/interfaces/%s", url.PathEscape(name))
 		result.ObjectURL = objectURL
 
+		// Run the unified gate up front (with the explicit Package the caller
+		// supplied) and mark the context so the inner CreateObject and
+		// UpdateSource skip their redundant gates — preventing the
+		// SearchObject hop between Lock and PUT (mutationGateSkipKey).
+		if err := c.checkMutation(ctx, MutationContext{
+			Op:        OpCreate,
+			OpName:    "WriteSource(INTF,create)",
+			Package:   opts.Package,
+			Transport: opts.Transport,
+		}); err != nil {
+			result.Message = fmt.Sprintf("Failed mutation gate: %v", err)
+			return result, nil
+		}
+		ctx := withMutationGateAlreadyRan(ctx)
+
 		// Create object
 		err := c.CreateObject(ctx, CreateObjectOptions{
 			ObjectType:  ObjectTypeInterface,
@@ -461,6 +476,20 @@ func (c *Client) writeSourceCreate(ctx context.Context, objectType, name, source
 		}
 		result.ObjectURL = objectURL
 		sourceURL := objectURL + "/source/main"
+
+		// Run the unified gate up front and mark the context so the inner
+		// CreateObject + UpdateSource skip their redundant gates
+		// (mutationGateSkipKey).
+		if err := c.checkMutation(ctx, MutationContext{
+			Op:        OpCreate,
+			OpName:    fmt.Sprintf("WriteSource(%s,create)", objectType),
+			Package:   opts.Package,
+			Transport: opts.Transport,
+		}); err != nil {
+			result.Message = fmt.Sprintf("Failed mutation gate: %v", err)
+			return result, nil
+		}
+		ctx := withMutationGateAlreadyRan(ctx)
 
 		// Create object first
 		// For BDEF, include source in creation (ADT API requirement)
@@ -763,6 +792,22 @@ func (c *Client) writeSourceUpdate(ctx context.Context, objectType, name, source
 		sourceURL := objectURL + "/source/main"
 		result.ObjectURL = objectURL
 
+		// Resolve and check the package up front, then mark the context so
+		// the inner UpdateSource skips its redundant gate. Doing the
+		// SearchObject hop AFTER Lock would retire SAP's stateful session
+		// (ICMENOSESSION) and invalidate the lock handle. See
+		// mutationGateSkipKey for the full rationale.
+		if err := c.checkMutation(ctx, MutationContext{
+			Op:        OpUpdate,
+			OpName:    "WriteSource(INTF)",
+			ObjectURL: objectURL,
+			Transport: opts.Transport,
+		}); err != nil {
+			result.Message = fmt.Sprintf("Failed mutation gate: %v", err)
+			return result, nil
+		}
+		ctx := withMutationGateAlreadyRan(ctx)
+
 		// Syntax check
 		syntaxErrors, err := c.SyntaxCheck(ctx, objectURL, source)
 		if err != nil {
@@ -837,6 +882,20 @@ func (c *Client) writeSourceUpdate(ctx context.Context, objectType, name, source
 		}
 		result.ObjectURL = objectURL
 		sourceURL := objectURL + "/source/main"
+
+		// Resolve and check the package up front, then mark the context so
+		// the inner UpdateSource skips its redundant gate. See
+		// mutationGateSkipKey for rationale.
+		if err := c.checkMutation(ctx, MutationContext{
+			Op:        OpUpdate,
+			OpName:    fmt.Sprintf("WriteSource(%s)", objectType),
+			ObjectURL: objectURL,
+			Transport: opts.Transport,
+		}); err != nil {
+			result.Message = fmt.Sprintf("Failed mutation gate: %v", err)
+			return result, nil
+		}
+		ctx := withMutationGateAlreadyRan(ctx)
 
 		// Syntax check
 		syntaxErrors, err := c.SyntaxCheck(ctx, objectURL, source)
@@ -919,6 +978,20 @@ func (c *Client) writeClassMethodUpdate(ctx context.Context, className, methodNa
 	methodName = strings.ToUpper(methodName)
 	objectURL := fmt.Sprintf("/sap/bc/adt/oo/classes/%s", url.PathEscape(strings.ToLower(className)))
 	result.ObjectURL = objectURL
+
+	// Resolve and check the package up front, then mark the context so
+	// the inner UpdateSource skips its redundant gate. See
+	// mutationGateSkipKey for rationale.
+	if err := c.checkMutation(ctx, MutationContext{
+		Op:        OpUpdate,
+		OpName:    "WriteClassMethod",
+		ObjectURL: objectURL,
+		Transport: transport,
+	}); err != nil {
+		result.Message = fmt.Sprintf("Failed mutation gate: %v", err)
+		return result, nil
+	}
+	ctx = withMutationGateAlreadyRan(ctx)
 
 	// Get method boundaries
 	methods, err := c.GetClassMethods(ctx, className)


### PR DESCRIPTION
## Summary

Sister bug to commit 8cb45a5 (SyntaxCheck before Lock). When
`SAP_ALLOWED_PACKAGES` is configured, the inner mutation gate inside
`UpdateSource` / `UpdateClassInclude` / `DeleteObject` /
`CreateTestInclude` resolves the package via `getObjectPackage` —
which issues a STATELESS `informationsystem/search` hop. When that
hop is interleaved between a stateful `LockObject` and the stateful
write, SAP's ICM retires the stateful session and the lock handle is
invalidated on the write with HTTP 423
`ExceptionResourceInvalidLockHandle`.

Captured live against an on-prem S/4HANA via SAP Cloud Connector +
Principal Propagation. The trace below is from the working session
that finally produced the diagnosis. Full `go test ./...` is green.

## What & why

`pkg/adt/workflows_edit.go:153` correctly runs `checkMutation` once
before `LockObject` (line 363). The bug is on the inside: after the
lock is acquired, `EditSourceWithOptions` calls `UpdateSource`
(`pkg/adt/crud.go:138`) or `UpdateClassInclude` (`crud.go:1027`),
**and both of those call `checkMutation` AGAIN**. Under
`AllowedPackages`, the second invocation has to resolve the package
from `ObjectURL`, which fans out to `SearchObject` — and that hop
rides the transport's stateless default.

Reproduced on `EditSourceWithOptions` via live HTTP trace:

    line 1167  >>> POST /sap/bc/adt/oo/classes/zcl_my_class?_action=LOCK
                   X-Sap-Adt-Sessiontype: stateful
    line 1172  <<< 200 OK  LOCK_HANDLE 7C738FAC8D510A3F028F654D03EB9FC6B87EF4A3

    line 1192  >>> GET  /sap/bc/adt/repository/informationsystem/search
                       ?operation=quickSearch&query=ZCL_MY_CLASS
                   X-Sap-Adt-Sessiontype: stateless    ← kills stateful session
    line 1196  <<< 200 OK   (returns packageName=Z_MY_PACKAGE)

    line 1216  >>> PUT  /sap/bc/adt/oo/classes/zcl_my_class/source/main
                       ?lockHandle=7C738FAC8D510A3F028F654D03EB9FC6B87EF4A3
                   X-Sap-Adt-Sessiontype: stateful
                   X-Csrf-Token: dL_42DiJqxXMs6xF3dq_0A==
               <<< 400 Session Timed Out
                   Sap-Err-Id: ICMENOSESSION
                   Set-Cookie: sap-contextid=…  (×8 zombie cookies)

    line 1402  >>> PUT  …/source/main           (retry after CSRF refetch)
                   X-Sap-Adt-Sessiontype: stateful
                   X-Csrf-Token: 3hnk0iwUrYnH4QF-wHluTw==   ← fresh token
               <<< 423 Locked
                   ExceptionResourceInvalidLockHandle
                   "Ressource CLASS ZCL_MY_CLASS ist nicht gesperrt
                    (ungültiges Sperr-Handle: 7C738FAC8D510A3F028F654D03EB9FC6B87EF4A3)"

The lock handle is bound to the stateful session that the search hop
killed. Refetching CSRF gets a new token but the lock handle is gone,
and the retry hits 423.

## Fix

Unexported context-key `mutationGateSkipKey` plus two helpers in
`pkg/adt/mutation_gate.go`:

    func withMutationGateAlreadyRan(ctx context.Context) context.Context
    func mutationGateAlreadyRan(ctx context.Context) bool

`checkMutation` short-circuits immediately when the context is marked.
Outer workflows that have already run the gate before `LockObject`
mark the context and the inner mutators skip their redundant gate.

This keeps the precise package check intact (it still runs once, at
the outer entry point) while removing the second resolution from
between `Lock` and `Write`. The Stateful flags from 22517d4 remain
necessary; ordering matters too, and any stateless hop in the middle
breaks the session.

`Activate` is intentionally not touched — it runs only `checkSafety`
(no `getObjectPackage`), so it never injects a SearchObject hop.
`WriteMessageClassTexts` / `WriteDataElementLabels` / UI5 mutators
are leaf APIs reachable only from external lock-acquiring callers
(MCP tool handlers); deciding when to skip is a caller concern.

## Workflows updated to mark the context

- `EditSourceWithOptions`        — the smoking gun from the trace
- `WriteProgram`, `WriteClass`   — same Lock→UpdateSource pattern
- `CreateAndActivateProgram`     — Create→Lock→UpdateSource pattern
- `CreateClassWithTests`         — Create→Lock→UpdateSource→CreateTestInclude→UpdateClassInclude
- `CreateFromFile`               — added an upfront unified gate (was only `checkSafety`)
- `UpdateFromFile`               — added an upfront unified gate (was only `checkSafety`)
- `RenameObject`                 — already gates twice; mark after both
- `ExecuteABAP`                  — added an upfront unified gate ($TMP); avoids the bug for the temp-program Lock→PUT path under any AllowedPackages whitelist that excludes $TMP it now fails up front instead of mid-write
- `writeSourceUpdate` (INTF, DDLS/BDEF/SRVD branches) — direct Lock→UpdateSource
- `writeSourceCreate` (INTF, DDLS/BDEF/SRVD branches) — direct Create→Lock→UpdateSource
- `writeClassMethodUpdate`       — direct Lock→UpdateSource

`WriteSource` itself stays as-is: it intentionally delegates package
resolution to its inner workflow methods, which now do the gate-and-mark.

## Files changed

    pkg/adt/mutation_gate.go            — mutationGateSkipKey + helpers,
                                          checkMutation short-circuit
    pkg/adt/mutation_gate_skip_test.go  — three new tests (see below)
    pkg/adt/workflows_edit.go           — mark ctx after EditSourceWithOptions gate
    pkg/adt/workflows.go                — mark ctx after WriteProgram / WriteClass /
                                          CreateAndActivateProgram / CreateClassWithTests
    pkg/adt/workflows_deploy.go         — gate-and-mark in CreateFromFile / UpdateFromFile
                                          (replaces the prior bare checkSafety)
    pkg/adt/workflows_execute.go        — gate-and-mark in ExecuteABAP
    pkg/adt/workflows_fileio.go         — mark ctx after RenameObject's two gates
    pkg/adt/workflows_source.go         — gate-and-mark in writeSourceUpdate (INTF,
                                          DDLS/BDEF/SRVD), writeSourceCreate (INTF,
                                          DDLS/BDEF/SRVD), writeClassMethodUpdate

## Tests

`TestMutationGateSkip_EditSourceNoSearchBetweenLockAndPut` — full
EditSourceWithOptions happy path under `WithAllowedPackages("$TMP")`,
asserts no `informationsystem/search` request appears between the
Lock POST and the source PUT. Verified to FAIL when the
`withMutationGateAlreadyRan(ctx)` line in `EditSourceWithOptions` is
removed (reproduces the exact bug pattern from the trace).

`TestMutationGateSkip_FlagSkipsInnerCheck` — unit-tests the skip
plumbing: a deliberately invalid `MutationContext` (no `ObjectURL`,
no `Package`) that would normally fail closed under `AllowedPackages`
must short-circuit when the context is marked.

`TestMutationGateSkip_FlagDoesNotLeakAcrossContexts` — flag is scoped
to its derivation chain only; sibling contexts derived from the same
parent stay clean.

`go test ./pkg/adt/...` and `go test ./...` both green.

## Related

- **Commit 8cb45a5** — `fix(adt): move SyntaxCheck before Lock in
  deploy workflows`. Same bug class (stateless hop between stateful
  Lock and stateful Write retires the ICM session), different
  injection point. That fix moved a stateless `SyntaxCheck`; this
  fix removes a stateless `SearchObject` from the same window. The
  two together close the class for all currently known mutation
  workflows.

- **Issues #88 / #92 / #98** — session affinity. The Stateful flags
  on individual `RequestOptions` from 22517d4 are necessary but not
  sufficient; call ordering matters too. With both this PR and 8cb45a5
  in place, the `Lock → Write → Unlock → Activate` block is a single
  uninterrupted stateful run for every workflow that holds a lock.

## Non-goals

- Public-API leaf mutators (`UpdateSource`, `UpdateClassInclude`,
  `DeleteObject`, `CreateTestInclude`, `WriteMessageClassTexts`,
  `WriteDataElementLabels`) keep their inner gate. Callers that
  acquire their own lock and bypass the workflows still get
  policy enforcement; if they hit the same session-affinity bug,
  the fix is the same — gate-and-mark before the lock.
