### PR TITLE
fix(search): server-side type filter so --max applies after --type

### DIFF
--- a/cmd/vsp/cli.go
+++ b/cmd/vsp/cli.go
@@ -285,6 +285,7 @@ func canonicalObjectType(s string) string {
 		return "MSAG/N"
 	case "TRAN":
 		return "TRAN/T"
+	// TODO: add INCL→PROG/I once https://github.com/oisee/vibing-steampunk/pull/121 is merged upstream
 	}
 	return s
 }

--- a/cmd/vsp/cli.go
+++ b/cmd/vsp/cli.go
@@ -255,41 +255,6 @@ func runExport(cmd *cobra.Command, args []string) error {
 
 // --- search command ---
 
-// canonicalObjectType maps the documented short forms (CLAS, INTF, PROG, ...)
-// to the ADT-canonical group codes the SAP server expects on the
-// informationsystem/search endpoint. Unknown values pass through verbatim,
-// covering already-canonical input ("CLAS/OC"), namespaced types, or custom codes.
-func canonicalObjectType(s string) string {
-	switch strings.ToUpper(s) {
-	case "":
-		return ""
-	case "CLAS":
-		return "CLAS/OC"
-	case "INTF":
-		return "INTF/OI"
-	case "PROG":
-		return "PROG/P"
-	case "FUGR":
-		return "FUGR/F"
-	case "FUNC":
-		return "FUGR/FF"
-	case "TABL":
-		return "TABL/DT"
-	case "DTEL":
-		return "DTEL/DE"
-	case "DOMA":
-		return "DOMA/DD"
-	case "DDLS":
-		return "DDLS/DF"
-	case "MSAG":
-		return "MSAG/N"
-	case "TRAN":
-		return "TRAN/T"
-	// TODO: add INCL→PROG/I once https://github.com/oisee/vibing-steampunk/pull/121 is merged upstream
-	}
-	return s
-}
-
 var searchCmd = &cobra.Command{
 	Use:   "search <query>",
 	Short: "Search for ABAP objects",
@@ -320,7 +285,7 @@ func runSearch(cmd *cobra.Command, args []string) error {
 	query := args[0]
 	ctx := context.Background()
 
-	adtType := canonicalObjectType(objectType)
+	adtType := adt.CanonicalObjectType(objectType)
 	if v, _ := cmd.Flags().GetBool("verbose"); v {
 		fmt.Fprintf(os.Stderr, "[DEBUG] search: query=%q objectType=%q maxResults=%d\n",
 			query, adtType, maxResults)
@@ -331,12 +296,14 @@ func runSearch(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("search failed: %w", err)
 	}
 
-	// Filter by type if specified
+	// Filter by type if specified. Compare against the canonical type, since
+	// the server returns canonical codes (e.g. FUNC -> FUGR/FF, INCL -> PROG/I)
+	// where the short form is not a prefix of the result type.
 	filtered := results
-	if objectType != "" {
+	if adtType != "" {
 		filtered = make([]adt.SearchResult, 0)
 		for _, r := range results {
-			if strings.EqualFold(r.Type, objectType) || strings.HasPrefix(r.Type, objectType+"/") {
+			if strings.EqualFold(r.Type, adtType) || strings.HasPrefix(r.Type, adtType+"/") {
 				filtered = append(filtered, r)
 			}
 		}

--- a/cmd/vsp/cli.go
+++ b/cmd/vsp/cli.go
@@ -255,6 +255,40 @@ func runExport(cmd *cobra.Command, args []string) error {
 
 // --- search command ---
 
+// canonicalObjectType maps the documented short forms (CLAS, INTF, PROG, ...)
+// to the ADT-canonical group codes the SAP server expects on the
+// informationsystem/search endpoint. Unknown values pass through verbatim,
+// covering already-canonical input ("CLAS/OC"), namespaced types, or custom codes.
+func canonicalObjectType(s string) string {
+	switch strings.ToUpper(s) {
+	case "":
+		return ""
+	case "CLAS":
+		return "CLAS/OC"
+	case "INTF":
+		return "INTF/OI"
+	case "PROG":
+		return "PROG/P"
+	case "FUGR":
+		return "FUGR/F"
+	case "FUNC":
+		return "FUGR/FF"
+	case "TABL":
+		return "TABL/DT"
+	case "DTEL":
+		return "DTEL/DE"
+	case "DOMA":
+		return "DOMA/DD"
+	case "DDLS":
+		return "DDLS/DF"
+	case "MSAG":
+		return "MSAG/N"
+	case "TRAN":
+		return "TRAN/T"
+	}
+	return s
+}
+
 var searchCmd = &cobra.Command{
 	Use:   "search <query>",
 	Short: "Search for ABAP objects",
@@ -285,7 +319,13 @@ func runSearch(cmd *cobra.Command, args []string) error {
 	query := args[0]
 	ctx := context.Background()
 
-	results, err := client.SearchObject(ctx, query, maxResults)
+	adtType := canonicalObjectType(objectType)
+	if v, _ := cmd.Flags().GetBool("verbose"); v {
+		fmt.Fprintf(os.Stderr, "[DEBUG] search: query=%q objectType=%q maxResults=%d\n",
+			query, adtType, maxResults)
+	}
+
+	results, err := client.SearchObjectByType(ctx, query, adtType, maxResults)
 	if err != nil {
 		return fmt.Errorf("search failed: %w", err)
 	}

--- a/cmd/vsp/cli.go
+++ b/cmd/vsp/cli.go
@@ -407,6 +407,40 @@ func runExport(cmd *cobra.Command, args []string) error {
 
 // --- search command ---
 
+// canonicalObjectType maps the documented short forms (CLAS, INTF, PROG, ...)
+// to the ADT-canonical group codes the SAP server expects on the
+// informationsystem/search endpoint. Unknown values pass through verbatim,
+// covering already-canonical input ("CLAS/OC"), namespaced types, or custom codes.
+func canonicalObjectType(s string) string {
+	switch strings.ToUpper(s) {
+	case "":
+		return ""
+	case "CLAS":
+		return "CLAS/OC"
+	case "INTF":
+		return "INTF/OI"
+	case "PROG":
+		return "PROG/P"
+	case "FUGR":
+		return "FUGR/F"
+	case "FUNC":
+		return "FUGR/FF"
+	case "TABL":
+		return "TABL/DT"
+	case "DTEL":
+		return "DTEL/DE"
+	case "DOMA":
+		return "DOMA/DD"
+	case "DDLS":
+		return "DDLS/DF"
+	case "MSAG":
+		return "MSAG/N"
+	case "TRAN":
+		return "TRAN/T"
+	}
+	return s
+}
+
 var searchCmd = &cobra.Command{
 	Use:   "search <query>",
 	Short: "Search for ABAP objects",
@@ -437,7 +471,13 @@ func runSearch(cmd *cobra.Command, args []string) error {
 	query := args[0]
 	ctx := context.Background()
 
-	results, err := client.SearchObject(ctx, query, maxResults)
+	adtType := canonicalObjectType(objectType)
+	if v, _ := cmd.Flags().GetBool("verbose"); v {
+		fmt.Fprintf(os.Stderr, "[DEBUG] search: query=%q objectType=%q maxResults=%d\n",
+			query, adtType, maxResults)
+	}
+
+	results, err := client.SearchObjectByType(ctx, query, adtType, maxResults)
 	if err != nil {
 		return fmt.Errorf("search failed: %w", err)
 	}

--- a/cmd/vsp/cli.go
+++ b/cmd/vsp/cli.go
@@ -437,6 +437,7 @@ func canonicalObjectType(s string) string {
 		return "MSAG/N"
 	case "TRAN":
 		return "TRAN/T"
+	// TODO: add INCL→PROG/I once https://github.com/oisee/vibing-steampunk/pull/121 is merged upstream
 	}
 	return s
 }

--- a/cmd/vsp/cli.go
+++ b/cmd/vsp/cli.go
@@ -407,41 +407,6 @@ func runExport(cmd *cobra.Command, args []string) error {
 
 // --- search command ---
 
-// canonicalObjectType maps the documented short forms (CLAS, INTF, PROG, ...)
-// to the ADT-canonical group codes the SAP server expects on the
-// informationsystem/search endpoint. Unknown values pass through verbatim,
-// covering already-canonical input ("CLAS/OC"), namespaced types, or custom codes.
-func canonicalObjectType(s string) string {
-	switch strings.ToUpper(s) {
-	case "":
-		return ""
-	case "CLAS":
-		return "CLAS/OC"
-	case "INTF":
-		return "INTF/OI"
-	case "PROG":
-		return "PROG/P"
-	case "FUGR":
-		return "FUGR/F"
-	case "FUNC":
-		return "FUGR/FF"
-	case "TABL":
-		return "TABL/DT"
-	case "DTEL":
-		return "DTEL/DE"
-	case "DOMA":
-		return "DOMA/DD"
-	case "DDLS":
-		return "DDLS/DF"
-	case "MSAG":
-		return "MSAG/N"
-	case "TRAN":
-		return "TRAN/T"
-	// TODO: add INCL→PROG/I once https://github.com/oisee/vibing-steampunk/pull/121 is merged upstream
-	}
-	return s
-}
-
 var searchCmd = &cobra.Command{
 	Use:   "search <query>",
 	Short: "Search for ABAP objects",
@@ -472,7 +437,7 @@ func runSearch(cmd *cobra.Command, args []string) error {
 	query := args[0]
 	ctx := context.Background()
 
-	adtType := canonicalObjectType(objectType)
+	adtType := adt.CanonicalObjectType(objectType)
 	if v, _ := cmd.Flags().GetBool("verbose"); v {
 		fmt.Fprintf(os.Stderr, "[DEBUG] search: query=%q objectType=%q maxResults=%d\n",
 			query, adtType, maxResults)
@@ -483,12 +448,14 @@ func runSearch(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("search failed: %w", err)
 	}
 
-	// Filter by type if specified
+	// Filter by type if specified. Compare against the canonical type, since
+	// the server returns canonical codes (e.g. FUNC -> FUGR/FF, INCL -> PROG/I)
+	// where the short form is not a prefix of the result type.
 	filtered := results
-	if objectType != "" {
+	if adtType != "" {
 		filtered = make([]adt.SearchResult, 0)
 		for _, r := range results {
-			if strings.EqualFold(r.Type, objectType) || strings.HasPrefix(r.Type, objectType+"/") {
+			if strings.EqualFold(r.Type, adtType) || strings.HasPrefix(r.Type, adtType+"/") {
 				filtered = append(filtered, r)
 			}
 		}

--- a/internal/mcp/handlers_search.go
+++ b/internal/mcp/handlers_search.go
@@ -33,6 +33,17 @@ func (s *Server) routeSearchAction(ctx context.Context, action, objectType, obje
 	if v, ok := getFloatParam(params, "max_results"); ok {
 		args["maxResults"] = v
 	}
+	if v, ok := getFloatParam(params, "max"); ok {
+		args["maxResults"] = v
+	}
+	// Pass object type for server-side filtering so max applies after the
+	// type filter (mirrors the CLI --type path).
+	if v := getStringParam(params, "type"); v != "" {
+		args["objectType"] = v
+	}
+	if v := getStringParam(params, "objectType"); v != "" {
+		args["objectType"] = v
+	}
 	return s.callHandler(ctx, s.handleSearchObject, args)
 }
 
@@ -49,7 +60,9 @@ func (s *Server) handleSearchObject(ctx context.Context, request mcp.CallToolReq
 		maxResults = int(mr)
 	}
 
-	results, err := s.adtClient.SearchObject(ctx, query, maxResults)
+	objectType, _ := request.GetArguments()["objectType"].(string)
+
+	results, err := s.adtClient.SearchObjectByType(ctx, query, objectType, maxResults)
 	if err != nil {
 		return newToolResultError(fmt.Sprintf("Failed to search: %v", err)), nil
 	}

--- a/internal/mcp/handlers_search.go
+++ b/internal/mcp/handlers_search.go
@@ -33,6 +33,17 @@ func (s *Server) routeSearchAction(ctx context.Context, action, objectType, obje
 	if v, ok := getFloatParam(params, "max_results"); ok {
 		args["maxResults"] = v
 	}
+	if v, ok := getFloatParam(params, "max"); ok {
+		args["maxResults"] = v
+	}
+	// Pass object type for server-side filtering so max applies after the
+	// type filter (mirrors the CLI --type path).
+	if v := getStringParam(params, "type"); v != "" {
+		args["objectType"] = v
+	}
+	if v := getStringParam(params, "objectType"); v != "" {
+		args["objectType"] = v
+	}
 	return s.callHandler(ctx, s.handleSearchObject, args)
 }
 
@@ -49,11 +60,13 @@ func (s *Server) handleSearchObject(ctx context.Context, request mcp.CallToolReq
 		maxResults = int(mr)
 	}
 
+	objectType, _ := request.GetArguments()["objectType"].(string)
+
 	// One more than asked for, so a full page can be told from a page that
 	// happens to be exactly the size of the limit. Without it a search that
 	// returns forty of four thousand is indistinguishable from one that found
 	// forty and stopped, and the caller has no reason to look further.
-	results, err := s.adtClient.SearchObject(ctx, query, maxResults+1)
+	results, err := s.adtClient.SearchObjectByType(ctx, query, objectType, maxResults+1)
 	if err != nil {
 		return newToolResultError(fmt.Sprintf("Failed to search: %v", err)), nil
 	}

--- a/internal/mcp/handlers_search_test.go
+++ b/internal/mcp/handlers_search_test.go
@@ -1,0 +1,71 @@
+package mcp
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+)
+
+// TestHandleSearchObject_ServerSideTypeFilter verifies the MCP search path goes
+// through SearchObjectByType: the short-form type is canonicalized and sent to
+// the server as the objectType query param, and maxResults is forwarded — so
+// max applies after the type filter (the bug txape10 flagged on PR #126).
+func TestHandleSearchObject_ServerSideTypeFilter(t *testing.T) {
+	var searchQuery string
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.Contains(r.URL.Path, "informationsystem/search") {
+			searchQuery = r.URL.RawQuery
+		}
+		w.Header().Set("X-CSRF-Token", "test-token")
+		w.Header().Set("Content-Type", "application/xml")
+		_, _ = w.Write([]byte(`<?xml version="1.0" encoding="UTF-8"?>` +
+			`<adtcore:objectReferences xmlns:adtcore="http://www.sap.com/adt/core"/>`))
+	}))
+	defer ts.Close()
+
+	cfg := &Config{
+		BaseURL:            ts.URL,
+		Username:           "u",
+		Password:           "p",
+		Client:             "001",
+		Language:           "EN",
+		InsecureSkipVerify: true,
+	}
+	server := NewServer(cfg)
+	if server == nil {
+		t.Fatal("NewServer returned nil")
+	}
+
+	req := newRequest(map[string]any{
+		"query":      "Z*",
+		"objectType": "CLAS",
+		"maxResults": float64(5),
+	})
+	res, err := server.handleSearchObject(context.Background(), req)
+	if err != nil {
+		t.Fatalf("handleSearchObject error: %v", err)
+	}
+	if res.IsError {
+		t.Fatalf("handleSearchObject returned an error result: %+v", res)
+	}
+
+	if searchQuery == "" {
+		t.Fatal("no search request reached the server")
+	}
+	q, err := url.ParseQuery(searchQuery)
+	if err != nil {
+		t.Fatalf("parsing captured query %q: %v", searchQuery, err)
+	}
+	if got := q.Get("objectType"); got != "CLAS/OC" {
+		t.Errorf("objectType = %q, want %q (short form should be canonicalized)", got, "CLAS/OC")
+	}
+	if got := q.Get("maxResults"); got != "5" {
+		t.Errorf("maxResults = %q, want %q", got, "5")
+	}
+	if got := q.Get("query"); got != "Z*" {
+		t.Errorf("query = %q, want %q", got, "Z*")
+	}
+}

--- a/internal/mcp/handlers_search_test.go
+++ b/internal/mcp/handlers_search_test.go
@@ -1,0 +1,73 @@
+package mcp
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+)
+
+// TestHandleSearchObject_ServerSideTypeFilter verifies the MCP search path goes
+// through SearchObjectByType: the short-form type is canonicalized and sent to
+// the server as the objectType query param, and maxResults is forwarded — so
+// max applies after the type filter (the bug txape10 flagged on PR #126).
+// The handler asks for one more than requested (see handleSearchObject) so it
+// can tell a full page from a truncated one; that over-fetch applies here too.
+func TestHandleSearchObject_ServerSideTypeFilter(t *testing.T) {
+	var searchQuery string
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.Contains(r.URL.Path, "informationsystem/search") {
+			searchQuery = r.URL.RawQuery
+		}
+		w.Header().Set("X-CSRF-Token", "test-token")
+		w.Header().Set("Content-Type", "application/xml")
+		_, _ = w.Write([]byte(`<?xml version="1.0" encoding="UTF-8"?>` +
+			`<adtcore:objectReferences xmlns:adtcore="http://www.sap.com/adt/core"/>`))
+	}))
+	defer ts.Close()
+
+	cfg := &Config{
+		BaseURL:            ts.URL,
+		Username:           "u",
+		Password:           "p",
+		Client:             "001",
+		Language:           "EN",
+		InsecureSkipVerify: true,
+	}
+	server := NewServer(cfg)
+	if server == nil {
+		t.Fatal("NewServer returned nil")
+	}
+
+	req := newRequest(map[string]any{
+		"query":      "Z*",
+		"objectType": "CLAS",
+		"maxResults": float64(5),
+	})
+	res, err := server.handleSearchObject(context.Background(), req)
+	if err != nil {
+		t.Fatalf("handleSearchObject error: %v", err)
+	}
+	if res.IsError {
+		t.Fatalf("handleSearchObject returned an error result: %+v", res)
+	}
+
+	if searchQuery == "" {
+		t.Fatal("no search request reached the server")
+	}
+	q, err := url.ParseQuery(searchQuery)
+	if err != nil {
+		t.Fatalf("parsing captured query %q: %v", searchQuery, err)
+	}
+	if got := q.Get("objectType"); got != "CLAS/OC" {
+		t.Errorf("objectType = %q, want %q (short form should be canonicalized)", got, "CLAS/OC")
+	}
+	if got := q.Get("maxResults"); got != "6" {
+		t.Errorf("maxResults = %q, want %q (requested 5, plus the truncation-detection over-fetch)", got, "6")
+	}
+	if got := q.Get("query"); got != "Z*" {
+		t.Errorf("query = %q, want %q", got, "Z*")
+	}
+}

--- a/pkg/adt/client.go
+++ b/pkg/adt/client.go
@@ -247,6 +247,16 @@ func (c *Client) AllowPackageTemporarily(pkg string) func() {
 // SearchObject searches for ABAP objects by name pattern.
 // The query parameter supports wildcards (* for multiple chars, ? for single char).
 func (c *Client) SearchObject(ctx context.Context, query string, maxResults int) ([]SearchResult, error) {
+	return c.SearchObjectByType(ctx, query, "", maxResults)
+}
+
+// SearchObjectByType searches for ABAP objects by name pattern, optionally
+// constrained to a specific ADT object type code (e.g. "CLAS/OC", "PROG/P",
+// "INTF/OI"). An empty objectType means "any type" and behaves identically
+// to SearchObject. Server-side type filtering is required when combined with
+// maxResults: filtering after the fact silently drops results that didn't
+// fit in the pre-filter window.
+func (c *Client) SearchObjectByType(ctx context.Context, query, objectType string, maxResults int) ([]SearchResult, error) {
 	if maxResults <= 0 {
 		maxResults = 100
 	}
@@ -255,6 +265,9 @@ func (c *Client) SearchObject(ctx context.Context, query string, maxResults int)
 	params.Set("operation", "quickSearch")
 	params.Set("query", query)
 	params.Set("maxResults", fmt.Sprintf("%d", maxResults))
+	if objectType != "" {
+		params.Set("objectType", objectType)
+	}
 
 	resp, err := c.transport.Request(ctx, "/sap/bc/adt/repository/informationsystem/search", &RequestOptions{
 		Method: http.MethodGet,

--- a/pkg/adt/client.go
+++ b/pkg/adt/client.go
@@ -250,6 +250,48 @@ func (c *Client) SearchObject(ctx context.Context, query string, maxResults int)
 	return c.SearchObjectByType(ctx, query, "", maxResults)
 }
 
+// CanonicalObjectType maps the documented short forms (CLAS, INTF, PROG, ...)
+// to the ADT-canonical group codes the SAP server expects on the
+// informationsystem/search endpoint. Unknown values pass through verbatim,
+// covering already-canonical input ("CLAS/OC"), namespaced types, or custom codes.
+// Exported so every caller (CLI, MCP, direct API) gets the same expansion;
+// SearchObjectByType applies it internally.
+func CanonicalObjectType(s string) string {
+	switch strings.ToUpper(s) {
+	case "":
+		return ""
+	case "CLAS":
+		return "CLAS/OC"
+	case "INTF":
+		return "INTF/OI"
+	case "PROG":
+		return "PROG/P"
+	case "INCL":
+		return "PROG/I"
+	case "FUGR":
+		return "FUGR/F"
+	case "FUNC":
+		return "FUGR/FF"
+	case "TABL":
+		return "TABL/DT"
+	case "DTEL":
+		return "DTEL/DE"
+	case "DOMA":
+		return "DOMA/DD"
+	case "TTYP":
+		return "TTYP/DA"
+	case "ENQU":
+		return "ENQU/DL"
+	case "DDLS":
+		return "DDLS/DF"
+	case "MSAG":
+		return "MSAG/N"
+	case "TRAN":
+		return "TRAN/T"
+	}
+	return s
+}
+
 // SearchObjectByType searches for ABAP objects by name pattern, optionally
 // constrained to a specific ADT object type code (e.g. "CLAS/OC", "PROG/P",
 // "INTF/OI"). An empty objectType means "any type" and behaves identically
@@ -260,6 +302,11 @@ func (c *Client) SearchObjectByType(ctx context.Context, query, objectType strin
 	if maxResults <= 0 {
 		maxResults = 100
 	}
+
+	// Expand documented short forms (CLAS, FUNC, INCL, ...) to ADT-canonical
+	// group codes so callers can pass either form. No-op for already-canonical
+	// or unknown input.
+	objectType = CanonicalObjectType(objectType)
 
 	params := url.Values{}
 	params.Set("operation", "quickSearch")

--- a/pkg/adt/client.go
+++ b/pkg/adt/client.go
@@ -258,6 +258,16 @@ func (c *Client) CurrentCookies() map[string]string {
 // SearchObject searches for ABAP objects by name pattern.
 // The query parameter supports wildcards (* for multiple chars, ? for single char).
 func (c *Client) SearchObject(ctx context.Context, query string, maxResults int) ([]SearchResult, error) {
+	return c.SearchObjectByType(ctx, query, "", maxResults)
+}
+
+// SearchObjectByType searches for ABAP objects by name pattern, optionally
+// constrained to a specific ADT object type code (e.g. "CLAS/OC", "PROG/P",
+// "INTF/OI"). An empty objectType means "any type" and behaves identically
+// to SearchObject. Server-side type filtering is required when combined with
+// maxResults: filtering after the fact silently drops results that didn't
+// fit in the pre-filter window.
+func (c *Client) SearchObjectByType(ctx context.Context, query, objectType string, maxResults int) ([]SearchResult, error) {
 	if maxResults <= 0 {
 		maxResults = 100
 	}
@@ -266,6 +276,9 @@ func (c *Client) SearchObject(ctx context.Context, query string, maxResults int)
 	params.Set("operation", "quickSearch")
 	params.Set("query", query)
 	params.Set("maxResults", fmt.Sprintf("%d", maxResults))
+	if objectType != "" {
+		params.Set("objectType", objectType)
+	}
 
 	resp, err := c.transport.Request(ctx, "/sap/bc/adt/repository/informationsystem/search", &RequestOptions{
 		Method: http.MethodGet,

--- a/pkg/adt/client.go
+++ b/pkg/adt/client.go
@@ -261,6 +261,48 @@ func (c *Client) SearchObject(ctx context.Context, query string, maxResults int)
 	return c.SearchObjectByType(ctx, query, "", maxResults)
 }
 
+// CanonicalObjectType maps the documented short forms (CLAS, INTF, PROG, ...)
+// to the ADT-canonical group codes the SAP server expects on the
+// informationsystem/search endpoint. Unknown values pass through verbatim,
+// covering already-canonical input ("CLAS/OC"), namespaced types, or custom codes.
+// Exported so every caller (CLI, MCP, direct API) gets the same expansion;
+// SearchObjectByType applies it internally.
+func CanonicalObjectType(s string) string {
+	switch strings.ToUpper(s) {
+	case "":
+		return ""
+	case "CLAS":
+		return "CLAS/OC"
+	case "INTF":
+		return "INTF/OI"
+	case "PROG":
+		return "PROG/P"
+	case "INCL":
+		return "PROG/I"
+	case "FUGR":
+		return "FUGR/F"
+	case "FUNC":
+		return "FUGR/FF"
+	case "TABL":
+		return "TABL/DT"
+	case "DTEL":
+		return "DTEL/DE"
+	case "DOMA":
+		return "DOMA/DD"
+	case "TTYP":
+		return "TTYP/DA"
+	case "ENQU":
+		return "ENQU/DL"
+	case "DDLS":
+		return "DDLS/DF"
+	case "MSAG":
+		return "MSAG/N"
+	case "TRAN":
+		return "TRAN/T"
+	}
+	return s
+}
+
 // SearchObjectByType searches for ABAP objects by name pattern, optionally
 // constrained to a specific ADT object type code (e.g. "CLAS/OC", "PROG/P",
 // "INTF/OI"). An empty objectType means "any type" and behaves identically
@@ -271,6 +313,11 @@ func (c *Client) SearchObjectByType(ctx context.Context, query, objectType strin
 	if maxResults <= 0 {
 		maxResults = 100
 	}
+
+	// Expand documented short forms (CLAS, FUNC, INCL, ...) to ADT-canonical
+	// group codes so callers can pass either form. No-op for already-canonical
+	// or unknown input.
+	objectType = CanonicalObjectType(objectType)
 
 	params := url.Values{}
 	params.Set("operation", "quickSearch")

--- a/pkg/adt/client_test.go
+++ b/pkg/adt/client_test.go
@@ -83,6 +83,41 @@ func TestClient_SearchObject(t *testing.T) {
 	}
 }
 
+func TestCanonicalObjectType(t *testing.T) {
+	cases := []struct {
+		in   string
+		want string
+	}{
+		// Short forms expand to ADT-canonical group codes
+		{"CLAS", "CLAS/OC"},
+		{"INTF", "INTF/OI"},
+		{"PROG", "PROG/P"},
+		{"INCL", "PROG/I"},
+		{"FUGR", "FUGR/F"},
+		{"FUNC", "FUGR/FF"},
+		{"TABL", "TABL/DT"},
+		{"DTEL", "DTEL/DE"},
+		{"DOMA", "DOMA/DD"},
+		{"TTYP", "TTYP/DA"},
+		{"ENQU", "ENQU/DL"},
+		{"DDLS", "DDLS/DF"},
+		{"MSAG", "MSAG/N"},
+		{"TRAN", "TRAN/T"},
+		// Case-insensitive
+		{"clas", "CLAS/OC"},
+		// Empty stays empty (means "any type")
+		{"", ""},
+		// Already-canonical and unknown values pass through verbatim
+		{"CLAS/OC", "CLAS/OC"},
+		{"ZCUSTOM/XX", "ZCUSTOM/XX"},
+	}
+	for _, tc := range cases {
+		if got := CanonicalObjectType(tc.in); got != tc.want {
+			t.Errorf("CanonicalObjectType(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}
+
 func TestClient_SearchObjectByType_QueryParams(t *testing.T) {
 	emptyResponse := `<?xml version="1.0" encoding="UTF-8"?>
 <adtcore:objectReferences xmlns:adtcore="http://www.sap.com/adt/core"/>`
@@ -95,6 +130,8 @@ func TestClient_SearchObjectByType_QueryParams(t *testing.T) {
 	}{
 		{"with type sends objectType param", "CLAS/OC", true, "CLAS/OC"},
 		{"empty type omits objectType param", "", false, ""},
+		{"short form CLAS expands to CLAS/OC", "CLAS", true, "CLAS/OC"},
+		{"short form FUNC expands to FUGR/FF", "FUNC", true, "FUGR/FF"},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/pkg/adt/client_test.go
+++ b/pkg/adt/client_test.go
@@ -83,6 +83,65 @@ func TestClient_SearchObject(t *testing.T) {
 	}
 }
 
+func TestClient_SearchObjectByType_QueryParams(t *testing.T) {
+	emptyResponse := `<?xml version="1.0" encoding="UTF-8"?>
+<adtcore:objectReferences xmlns:adtcore="http://www.sap.com/adt/core"/>`
+
+	cases := []struct {
+		name        string
+		objectType  string
+		wantPresent bool
+		wantValue   string
+	}{
+		{"with type sends objectType param", "CLAS/OC", true, "CLAS/OC"},
+		{"empty type omits objectType param", "", false, ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			mock := &mockTransportClient{
+				responses: map[string]*http.Response{
+					"search":    newTestResponse(emptyResponse),
+					"discovery": newTestResponse("OK"),
+				},
+			}
+
+			cfg := NewConfig("https://sap.example.com:44300", "user", "pass")
+			transport := NewTransportWithClient(cfg, mock)
+			client := NewClientWithTransport(cfg, transport)
+
+			if _, err := client.SearchObjectByType(context.Background(), "Z*", tc.objectType, 50); err != nil {
+				t.Fatalf("SearchObjectByType failed: %v", err)
+			}
+
+			var searchReq *http.Request
+			for _, r := range mock.requests {
+				if strings.Contains(r.URL.Path, "informationsystem/search") {
+					searchReq = r
+					break
+				}
+			}
+			if searchReq == nil {
+				t.Fatalf("no search request captured (got %d requests)", len(mock.requests))
+			}
+
+			q := searchReq.URL.Query()
+			if got := q.Get("query"); got != "Z*" {
+				t.Errorf("query = %q, want %q", got, "Z*")
+			}
+			if got := q.Get("maxResults"); got != "50" {
+				t.Errorf("maxResults = %q, want %q", got, "50")
+			}
+			values, present := q["objectType"]
+			if present != tc.wantPresent {
+				t.Errorf("objectType present = %v, want %v (values=%v)", present, tc.wantPresent, values)
+			}
+			if tc.wantPresent && (len(values) == 0 || values[0] != tc.wantValue) {
+				t.Errorf("objectType = %v, want %q", values, tc.wantValue)
+			}
+		})
+	}
+}
+
 func TestClient_CheckObjectPackageSafety_NormalizesObjectURLs(t *testing.T) {
 	tests := []struct {
 		name      string


### PR DESCRIPTION
## Problem

`vsp search "Z*" --type CLAS --max 50` returned fewer results than expected (issue #119).

The ADT server returned up to `--max` mixed-type objects, and `--type` was applied client-side afterwards — so any CLAS objects outside the first 50 mixed results were silently dropped.

## Solution

Add `SearchObjectByType` that passes `objectType` to the ADT `informationsystem/search` endpoint so the server filters before applying `maxResults`. `SearchObject` becomes a thin shim, leaving all existing callers untouched.

Short-form types are canonicalized at the CLI boundary (`CLAS→CLAS/OC`, `INTF→INTF/OI`, `PROG→PROG/P`, etc.) via `canonicalObjectType`. `--verbose` prints the effective query for debugging.

## Test plan

- [x] `vsp search "Z*" --type CLAS --max 50` returns up to 50 CLAS objects
- [x] `vsp search "Z*"` (no `--type`) still works unchanged
- [x] Unit tests in `pkg/adt/client_test.go` pass

Closes #119