### PR TITLE
fix(adt): program includes (INCL) fail before reaching SAP — issue #133

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,19 +8,45 @@
 
 ## Current Priorities
 
-### 1. Graph Engine (`pkg/graph/`) — In Progress
+### 1. Bug #132 — ALL objects fail PUT with 423 (on-prem) — Investigation
+**Scope correction (2026-05-27):** Initially reported as "transport-owned objects only" but confirmed to affect
+**all** objects including `$TMP` locals. The lock is always acquired (valid handle returned) but the subsequent
+PUT fails with `423 ExceptionResourceInvalidLockHandle`. `mcp-abap-abap-adt-api` works correctly for the same
+lock+write sequence, proving the ADT API is fine and the bug is in vsp's session handling.
+- Root cause: HTTP session/cookie affinity — SAP ENQUEUE lock is bound to the `sap-contextid` cookie of the
+  session that created it. vsp loses that cookie between the LOCK POST and the UPDATE PUT even when both use
+  `Stateful: true`. See `pkg/adt/http.go`.
+- Guard fix (`&& result.CorrNr == ""`) is still correct — transport-owned objects no longer rejected upfront.
+- Re-lock attempt (second POST with corrNr) also returns invalid handle — approach removed.
+- **Next step:** intercept HTTP from `mcp-abap-abap-adt-api` (mitmproxy) and compare `sap-contextid` cookie
+  between lock and PUT requests vs. vsp's requests.
+- Investigation: [004](reports/2026-05-27-004-issue-132-investigation.md) | Issue: [#132](https://github.com/oisee/vibing-steampunk/issues/132)
+- Workaround: use `mcp-abap-abap-adt-api` for lock+write+unlock. See `~/.claude/sap-mcp-servers.md`.
+
+### 2. Bug #133 — INCL package resolution + isClassInclude detection — FIXED (2026-05-27)
+Two bugs found and fixed:
+- `normalizeObjectURLForPackageCheck` stripped `/programs/includes/NAME` to `/programs` (matched the
+  `/includes/` class-strip before the `/source/main` strip). Fix: reorder strips, scope `/includes/` strip
+  to `/oo/classes/` URLs only. File: `pkg/adt/client.go`.
+- `isClassInclude` in `EditSourceWithOptions` fired on any URL containing `/includes/`, making program
+  includes skip `/source/main` and send wrong Accept header (406). Fix: require `/oo/classes/` too.
+  File: `pkg/adt/workflows_edit.go`.
+- Verified on-prem: source reads correctly (`matchCount: 1`). Write fails with #132 (same as CLAS) — not #133.
+- Issue: [#133](https://github.com/oisee/vibing-steampunk/issues/133)
+
+### 3. Graph Engine (`pkg/graph/`) — In Progress
 Sequence: unify existing dep logic → SQL/ADT adapters → impact/path queries.
 - Done: core types, parser dep extraction, boundary analyzer (11 tests)
 - Pending: SQL adapters (CROSS/WBCROSSGT/D010INC), ADT adapters, unify `cli_deps.go` + `cli_extra.go` + `ctxcomp/analyzer.go`
 - Design: [002](reports/2026-04-05-002-graph-engine-design.md), [003](reports/2026-04-05-003-graph-engine-alignment-for-claude.md)
 
-### 2. GUI Debugger (Issue #2) — Strategic
+### 4. GUI Debugger (Issue #2) — Strategic
 Plan: MCP debug sessions → DAP → Web UI. ADT REST API mapped from `CL_TPDA_ADT_RES_APP`. Design: [001](reports/2026-04-05-001-gui-debugger-design.md)
 
-### 3. Open Issues
-- **#88** Lock handle bug (EditSource/WriteSource) — real user report
+### 5. Open Issues
+- **#88** Lock handle bug (EditSource/WriteSource) — same root cause as #132 (session affinity)
 - **#55** RunReport in APC — architectural limit
-- **#46, #45** Sync script — low effort
+- **#46** / **#45** Sync script flags — closed upstream (script never existed in public repo)
 
 ---
 
@@ -165,3 +191,7 @@ Reports: `reports/YYYY-MM-DD-NNN-title.md`. SAP objects: `ZADT_<nn>_<name>`, `ZC
 | `pkg/llvm2abap/`, `pkg/wasmcomp/` | Research | Not production; don't treat as stable |
 | `pkg/adt/debugger.go` (REST) | Deprecated | Prefer `websocket_debug.go` |
 | `docs/cli-agents/*` | Config drift | Codex TOML format may differ from Claude/Gemini JSON docs |
+
+---
+
+> Workflow dual-server (vsp + mcp-abap-abap-adt-api): ver `~/.claude/sap-mcp-servers.md` (cargado globalmente).

--- a/pkg/adt/client.go
+++ b/pkg/adt/client.go
@@ -167,11 +167,19 @@ func (c *Client) getObjectPackage(ctx context.Context, objectURL string) (string
 func normalizeObjectURLForPackageCheck(objectURL string) string {
 	normalized := strings.TrimSuffix(objectURL, "/")
 
-	if idx := strings.Index(normalized, "/includes/"); idx >= 0 {
-		return normalized[:idx]
-	}
+	// Strip /source/main before any other transformation.
 	if strings.HasSuffix(normalized, "/source/main") {
-		return strings.TrimSuffix(normalized, "/source/main")
+		normalized = strings.TrimSuffix(normalized, "/source/main")
+	}
+
+	// Class includes: /oo/classes/{name}/includes/{type} → strip to parent class URL.
+	// This must NOT fire on program-include collection paths like
+	// /programs/includes/{name}, where "includes" is the object-type collection,
+	// not a component suffix appended to a specific object.
+	if strings.Contains(normalized, "/oo/classes/") {
+		if idx := strings.Index(normalized, "/includes/"); idx >= 0 {
+			return normalized[:idx]
+		}
 	}
 
 	return normalized

--- a/pkg/adt/crud_reconcile_test.go
+++ b/pkg/adt/crud_reconcile_test.go
@@ -639,3 +639,29 @@ func TestLockObject_AllowsNoModificationOnReadLock(t *testing.T) {
 		t.Errorf("LockHandle = %q, want HANDLE-X", result.LockHandle)
 	}
 }
+// TestNormalizeObjectURLForPackageCheck pins the fix for issue #133:
+// program include URLs (/programs/includes/{name}) must NOT be truncated
+// to /programs by the /includes/ strip that handles class includes.
+func TestNormalizeObjectURLForPackageCheck(t *testing.T) {
+	cases := []struct {
+		input string
+		want  string
+	}{
+		// Program includes (INCL) — must not be mangled
+		{"/sap/bc/adt/programs/includes/ZTEST_INCL", "/sap/bc/adt/programs/includes/ZTEST_INCL"},
+		{"/sap/bc/adt/programs/includes/ZTEST_INCL/source/main", "/sap/bc/adt/programs/includes/ZTEST_INCL"},
+		// Regular programs — unchanged
+		{"/sap/bc/adt/programs/programs/ZTEST/source/main", "/sap/bc/adt/programs/programs/ZTEST"},
+		// Class includes — strip to parent class
+		{"/sap/bc/adt/oo/classes/ZCL_FOO/includes/testclasses", "/sap/bc/adt/oo/classes/ZCL_FOO"},
+		{"/sap/bc/adt/oo/classes/ZCL_FOO/includes/definitions", "/sap/bc/adt/oo/classes/ZCL_FOO"},
+		// Class source — strip /source/main only
+		{"/sap/bc/adt/oo/classes/ZCL_FOO/source/main", "/sap/bc/adt/oo/classes/ZCL_FOO"},
+	}
+	for _, tc := range cases {
+		got := normalizeObjectURLForPackageCheck(tc.input)
+		if got != tc.want {
+			t.Errorf("normalizeObjectURLForPackageCheck(%q)\n  got  %q\n  want %q", tc.input, got, tc.want)
+		}
+	}
+}

--- a/pkg/adt/workflows_edit.go
+++ b/pkg/adt/workflows_edit.go
@@ -190,8 +190,10 @@ func (c *Client) EditSourceWithOptions(ctx context.Context, objectURL, oldString
 		result.Method = opts.Method
 	}
 
-	// Detect if this is a class include (e.g., /sap/bc/adt/oo/classes/ZCL_FOO/includes/testclasses)
-	isClassInclude := strings.Contains(objectURL, "/includes/")
+	// Detect if this is a class include (e.g., /sap/bc/adt/oo/classes/ZCL_FOO/includes/testclasses).
+	// Must NOT fire on program include paths (/programs/includes/{name}) — there "includes" is
+	// the object-type collection, not a component suffix appended to a specific class.
+	isClassInclude := strings.Contains(objectURL, "/oo/classes/") && strings.Contains(objectURL, "/includes/")
 	var className string
 	var includeType ClassIncludeType
 	var parentClassURL string


### PR DESCRIPTION
## Problem

Two bugs caused `/programs/includes/{name}` URLs (ABAP include programs) to fail
in the mutation gate **before any HTTP request was made**, so the error was never
a real 404 from SAP — it was a local pre-flight abort.

## Root cause

**Bug 1 — `normalizeObjectURLForPackageCheck` (`pkg/adt/client.go`)**

The `/includes/` strip intended for class sub-components
(`/oo/classes/{x}/includes/{type}`) also fired on program-include collection paths,
truncating `/sap/bc/adt/programs/includes/ZFOO` to `/sap/bc/adt/programs`.
The package resolver then found no package for that bare path and aborted with
"package metadata not found".

**Bug 2 — `isClassInclude` (`pkg/adt/workflows_edit.go`)**

`strings.Contains(url, "/includes/")` was too broad. It fired on program include
URLs, causing `EditSource` to skip appending `/source/main` to the source URL and
to send the wrong `Accept` header, producing a 406 Not Acceptable.

## Fix

Scope both checks to URLs that also contain `/oo/classes/`, which is the
unambiguous marker of a class component path (class includes look like
`/oo/classes/{name}/includes/{type}`; program include collection paths look like
`/programs/includes/{name}`).

No `parent` parameter is needed — the correct ADT URL for standalone includes
(`/sap/bc/adt/programs/includes/{NAME}`) works as-is once the normalizer stops
mangling it.

## Verification

Tested on-prem SAP S/4HANA 758:
- `ZREPORT_PRUEBA_TOP` (package `ZABAP01`, type `PROG/I`): `matchCount: 1` — source
  read correctly. Write now reaches SAP and returns `corrNr not found` (transport
  required for non-`$TMP` packages) instead of the pre-flight abort. ✅
- Class include path (`/oo/classes/ZCL_VSP_APC_HANDLER/includes/implementations`):
  source read without error, no regression. ✅

Write failures on objects still occur with 423 `InvalidLockHandle` — that is
bug #132 (HTTP session affinity), tracked separately.

## Changes

| File | Change |
|---|---|
| `pkg/adt/client.go` | Reorder `/source/main` strip before `/includes/` strip; scope `/includes/` strip to `/oo/classes/` URLs |
| `pkg/adt/workflows_edit.go` | Require `/oo/classes/` in `isClassInclude` check |
| `pkg/adt/crud_reconcile_test.go` | Add `TestNormalizeObjectURLForPackageCheck` pinning both program-include and class-include cases |
| `CLAUDE.md` | Document #132 scope correction and #133 as fixed |

Closes #133