### PR TITLE
fix(adt): treat program includes as source-bearing objects, not class includes

### DIFF
--- a/pkg/adt/client.go
+++ b/pkg/adt/client.go
@@ -167,8 +167,14 @@ func (c *Client) getObjectPackage(ctx context.Context, objectURL string) (string
 func normalizeObjectURLForPackageCheck(objectURL string) string {
 	normalized := strings.TrimSuffix(objectURL, "/")
 
-	if idx := strings.Index(normalized, "/includes/"); idx >= 0 {
-		return normalized[:idx]
+	// Strip the include segment ONLY for class includes, whose parent (the class)
+	// carries the package/transport assignment. A program include
+	// (/sap/bc/adt/programs/includes/<NAME>) is itself the repository object, so
+	// stripping at "/includes/" would wrongly collapse it to /sap/bc/adt/programs.
+	if strings.Contains(normalized, "/oo/classes/") {
+		if idx := strings.Index(normalized, "/includes/"); idx >= 0 {
+			return normalized[:idx]
+		}
 	}
 	if strings.HasSuffix(normalized, "/source/main") {
 		return strings.TrimSuffix(normalized, "/source/main")

--- a/pkg/adt/devtools.go
+++ b/pkg/adt/devtools.go
@@ -39,7 +39,11 @@ func (c *Client) SyntaxCheck(ctx context.Context, objectURL string, content stri
 	// SAP's URI length limit for long namespaced classes.
 	checkObjectURI := objectURL
 	artifactURI := objectURL
-	if !strings.Contains(objectURL, "/includes/") {
+	// Only *class* includes expose their source at the bare include URL. A program
+	// include (/sap/bc/adt/programs/includes/<NAME>) also contains "/includes/" but
+	// its source is at <url>/source/main, so it must get the suffix like any program.
+	isClassInclude := strings.Contains(objectURL, "/oo/classes/") && strings.Contains(objectURL, "/includes/")
+	if !isClassInclude {
 		artifactURI = objectURL + "/source/main"
 	}
 	encodedContent := base64.StdEncoding.EncodeToString([]byte(content))

--- a/pkg/adt/workflows_edit.go
+++ b/pkg/adt/workflows_edit.go
@@ -191,7 +191,13 @@ func (c *Client) EditSourceWithOptions(ctx context.Context, objectURL, oldString
 	}
 
 	// Detect if this is a class include (e.g., /sap/bc/adt/oo/classes/ZCL_FOO/includes/testclasses)
-	isClassInclude := strings.Contains(objectURL, "/includes/")
+	// IMPORTANT: must require the /oo/classes/ prefix. A *program* include URL is
+	// /sap/bc/adt/programs/includes/<NAME> and also contains "/includes/", but its
+	// source lives at <url>/source/main (like a program), NOT at the bare object URL.
+	// Without the /oo/classes/ guard, program includes are misdetected as class
+	// includes, the /source/main suffix is skipped, and the GET hits the object
+	// metadata endpoint with Accept: text/plain -> HTTP 406 (not acceptable).
+	isClassInclude := strings.Contains(objectURL, "/oo/classes/") && strings.Contains(objectURL, "/includes/")
 	var className string
 	var includeType ClassIncludeType
 	var parentClassURL string


### PR DESCRIPTION
## fix(adt): treat program includes as source-bearing objects, not class includes

`EditSource`, `SyntaxCheck` and the package/transport safety check all treated
any URL containing `/includes/` as an ABAP **class** include. A **program**
include URL -- `/sap/bc/adt/programs/includes/<NAME>` -- also contains
`/includes/` but behaves like a program: its source lives at `<url>/source/main`
and the include itself is the repository object carrying the package/transport.

### Symptom
Editing any program include fails at the read step:

```
status 406 at /sap/bc/adt/programs/includes/<NAME>:
Accepted content types: application/vnd.sap.adt.programs.includes.v2+xml
```

`GetSource` on the same include works (it uses `GetSourceURL`, which already
appends `/source/main` for `ObjectTypeInclude`), so the object and backend are
healthy -- only the edit / syntax-check / package-gate paths break.

### Root cause
Three spots use a naive `strings.Contains(objectURL, "/includes/")`:

- **`pkg/adt/workflows_edit.go`** (`EditSourceWithOptions`): when it thinks the
  object is a class include it skips the `/source/main` suffix, so it GETs the
  bare object URL with `Accept: text/plain` and the backend returns **HTTP 406**.
- **`pkg/adt/devtools.go`** (`SyntaxCheck`): sets the artifact URI to the bare
  object URL instead of the source location.
- **`pkg/adt/client.go`** (`normalizeObjectURLForPackageCheck`): strips
  everything from `/includes/` to get the parent class, which collapses
  `/sap/bc/adt/programs/includes/<NAME>` down to `/sap/bc/adt/programs`, losing
  the object for the package/transport gate and for `objectNameFromURL`.

A program-include URL `/sap/bc/adt/programs/includes/<NAME>` also contains
`/includes/`, while a *program* include's source is at `<url>/source/main` and
the include itself is the repository object. Only *class* includes
(`/sap/bc/adt/oo/classes/<CLASS>/includes/<type>`) expose source at the bare
include URL and delegate package/transport to the parent class.

### Fix
Qualify the class-include detection with the `/oo/classes/` prefix in all three
spots, so program includes fall through to the normal `/source/main` path that
`GetSourceURL` / `GetSource` already use. Class includes are unaffected -- their
URLs contain both `/oo/classes/` and `/includes/`.

### Testing
- Reproduced on a live S/4 backend with v2.38.1: `EditSource` on a program
  include returns HTTP 406, while `GetSource` on the same include succeeds --
  because `GetSource` already routes through `<url>/source/main` and `EditSource`
  did not.
- After the fix, program includes take that same `/source/main` route for the
  read, syntax-check, update and package-gate steps; class-include handling
  (test classes etc.) is unchanged by construction (`/oo/classes/` still matches).
- Builds clean (`go build ./cmd/vsp`, windows/arm64). End-to-end verification of
  an edit on the patched binary is still pending and not yet confirmed here.
