### PR TITLE
fix: parse activation response root element correctly

### DIFF
--- a/pkg/adt/devtools.go
+++ b/pkg/adt/devtools.go
@@ -201,9 +201,6 @@ func parseActivationResult(data []byte) (*ActivationResult, error) {
 			Text string `xml:"txt"`
 		} `xml:"shortText"`
 	}
-	type messages struct {
-		Msgs []msg `xml:"msg"`
-	}
 	type inactiveRef struct {
 		URI       string `xml:"uri,attr"`
 		Type      string `xml:"type,attr"`
@@ -215,12 +212,14 @@ func parseActivationResult(data []byte) (*ActivationResult, error) {
 			Ref inactiveRef `xml:"ref"`
 		} `xml:"object"`
 	}
-	type inactiveObjects struct {
-		Entries []inactiveEntry `xml:"entry"`
-	}
+	// The response ROOT element is either <chkl:messages> (children: <msg>)
+	// or <ioc:inactiveObjects> (children: <ioc:entry>). xml.Unmarshal maps the
+	// root element onto this struct itself, so the root's children must be
+	// declared directly here — a nested `xml:"messages"` field would look for
+	// a <messages> child *inside* the root and silently match nothing.
 	type response struct {
-		Messages messages        `xml:"messages"`
-		Inactive inactiveObjects `xml:"inactiveObjects"`
+		Msgs    []msg           `xml:"msg"`
+		Entries []inactiveEntry `xml:"entry"`
 	}
 
 	var resp response
@@ -234,7 +233,7 @@ func parseActivationResult(data []byte) (*ActivationResult, error) {
 		return result, nil
 	}
 
-	for _, m := range resp.Messages.Msgs {
+	for _, m := range resp.Msgs {
 		result.Messages = append(result.Messages, ActivationResultMessage{
 			ObjDescr:       m.ObjDescr,
 			Type:           m.Type,
@@ -249,7 +248,7 @@ func parseActivationResult(data []byte) (*ActivationResult, error) {
 		}
 	}
 
-	for _, entry := range resp.Inactive.Entries {
+	for _, entry := range resp.Entries {
 		if entry.Object != nil {
 			result.Success = false
 			result.Inactive = append(result.Inactive, InactiveObject{

--- a/pkg/adt/devtools_activation_test.go
+++ b/pkg/adt/devtools_activation_test.go
@@ -1,0 +1,53 @@
+package adt
+
+import (
+	"strings"
+	"testing"
+)
+
+// Real response captured from POST /sap/bc/adt/activation?method=activate&preauditRequested=true
+// for a program containing a syntax error. Note the ROOT element is <chkl:messages>.
+const activationSyntaxErrorPayload = `<?xml version="1.0" encoding="utf-8"?><chkl:messages xmlns:chkl="http://www.sap.com/abapxml/checklist"><msg objDescr="Program Z_VSP_ACT_TEST" type="E" line="1" href="/sap/bc/adt/programs/programs/z_vsp_act_test/source/main#start=2,6" forceSupported="true"><shortText><txt>Field "LV_UNDEFINED_VARIABLE" is unknown.</txt></shortText><atom:link href="art.syntax:GTU" rel="http://www.sap.com/adt/categories/quickfixes" xmlns:atom="http://www.w3.org/2005/Atom"/></msg></chkl:messages>`
+
+func TestParseActivationResultSyntaxError(t *testing.T) {
+	res, err := parseActivationResult([]byte(activationSyntaxErrorPayload))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if res.Success {
+		t.Fatal("expected Success=false for activation response with type=E message")
+	}
+	if len(res.Messages) != 1 {
+		t.Fatalf("expected 1 message, got %d", len(res.Messages))
+	}
+	if res.Messages[0].Type != "E" {
+		t.Fatalf("expected type E, got %q", res.Messages[0].Type)
+	}
+	if !strings.Contains(res.Messages[0].ShortText, "LV_UNDEFINED_VARIABLE") {
+		t.Fatalf("unexpected message text: %q", res.Messages[0].ShortText)
+	}
+}
+
+func TestParseActivationResultEmptyBodySuccess(t *testing.T) {
+	res, err := parseActivationResult(nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !res.Success {
+		t.Fatal("expected Success=true for empty body")
+	}
+}
+
+func TestParseActivationResultInactiveObjects(t *testing.T) {
+	payload := `<?xml version="1.0" encoding="utf-8"?><ioc:inactiveObjects xmlns:ioc="http://www.sap.com/abapxml/inactiveCtsObjects" xmlns:adtcore="http://www.sap.com/adt/core"><ioc:entry><ioc:object><ioc:ref adtcore:uri="/sap/bc/adt/programs/programs/ztest" adtcore:type="PROG/P" adtcore:name="ZTEST"/></ioc:object><ioc:transport/></ioc:entry></ioc:inactiveObjects>`
+	res, err := parseActivationResult([]byte(payload))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if res.Success {
+		t.Fatal("expected Success=false when inactive objects are returned")
+	}
+	if len(res.Inactive) != 1 || res.Inactive[0].Name != "ZTEST" {
+		t.Fatalf("unexpected inactive list: %+v", res.Inactive)
+	}
+}


### PR DESCRIPTION
## Problem

`Activate` returns `success: true, messages: []` even when SAP rejects the activation — the object silently stays inactive. Every workflow that trusts `activation.Success` (`WriteSource`, `WriteClass`, `DeployFromFile`, `CreateTable`, `ActivatePackage` — ~20 call sites) inherits the false positive. Verified on v2.38.1 and current main.

**Repro:** write a program with a syntax error via `UpdateSource` (so the pre-save check doesn't block), call `Activate` → `{"success": true, "messages": []}`, but `GetInactiveObjects` shows the object still inactive.

## Root cause

Replaying the activation POST with curl shows SAP does return the error — HTTP 200 with:

```xml
<chkl:messages xmlns:chkl="http://www.sap.com/abapxml/checklist">
  <msg objDescr="Program Z_ACT_TEST" type="E" line="1"
       href="/sap/bc/adt/programs/programs/z_act_test/source/main#start=2,6" forceSupported="true">
    <shortText><txt>Field "LV_UNDEFINED_VARIABLE" is unknown.</txt></shortText>
  </msg>
</chkl:messages>
```

`parseActivationResult` declares `messages`/`inactiveObjects` as *child* fields, but `<chkl:messages>` (or `<ioc:inactiveObjects>`) is the **root** element. `xml.Unmarshal` maps the root onto the target struct itself, so the parser looked for a `<messages>` child inside the root, matched nothing, decoded zero messages without error, and `Success` stayed `true`. (The sibling `parseSyntaxCheckResults` declares its structs one level deeper, which is why `SyntaxCheck` works.)

## Fix

Declare the root's children (`<msg>` / `<entry>`) directly on the response struct — both known root forms parse with one struct since unmarshalling matches child local names.

## Testing

- New regression tests in `pkg/adt/devtools_activation_test.go` using a real payload captured from a NW 7.50 system: error-message root form, inactive-objects root form, empty-body success.
- Red/green verified: all three tests fail against the previous parser, pass with the fix.
- `go vet ./pkg/adt` clean.
