### PR TITLE
fix(srvb): unblock read for SRVB + correct inverted binding_category docs

### DIFF
--- a/internal/mcp/handlers_source.go
+++ b/internal/mcp/handlers_source.go
@@ -16,9 +16,9 @@ import (
 // routeSourceAction routes "read" for GetSource and "edit" for WriteSource/EditSource.
 func (s *Server) routeSourceAction(ctx context.Context, action, objectType, objectName string, params map[string]any) (*mcp.CallToolResult, bool, error) {
 	if action == "read" {
-		// GetSource covers: CLAS, PROG, INTF, FUNC, FUGR, INCL, DDLS, BDEF, SRVD, MSAG, VIEW
+		// GetSource covers: CLAS, PROG, INTF, FUNC, FUGR, INCL, DDLS, BDEF, SRVD, SRVB, MSAG, VIEW
 		switch objectType {
-		case "CLAS", "PROG", "INTF", "FUNC", "FUGR", "INCL", "DDLS", "BDEF", "SRVD", "MSAG", "VIEW":
+		case "CLAS", "PROG", "INTF", "FUNC", "FUGR", "INCL", "DDLS", "BDEF", "SRVD", "SRVB", "MSAG", "VIEW":
 			args := map[string]any{
 				"object_type": objectType,
 				"name":        objectName,

--- a/internal/mcp/tools_register.go
+++ b/internal/mcp/tools_register.go
@@ -964,10 +964,10 @@ func (s *Server) registerCRUDTools(shouldRegister func(string) bool) {
 				mcp.Description("For SRVB: the service definition name to bind"),
 			),
 			mcp.WithString("binding_version",
-				mcp.Description("For SRVB: OData version 'V2' or 'V4' (default: V2)"),
+				mcp.Description("For SRVB: OData version 'V2' or 'V4'. Defaults to 'V2' - pass 'V4' explicitly for Fiori Elements V4 apps, otherwise a V2 binding is created silently."),
 			),
 			mcp.WithString("binding_category",
-				mcp.Description("For SRVB: '0' for Web API, '1' for UI (default: 0)"),
+				mcp.Description("For SRVB: '0' = UI (User Interface), '1' = A2X (Web API). Default: '0' (UI). Values follow SAP domain SRVB_BND_CATEGORY."),
 			),
 		), s.handleCreateObject)
 	}

--- a/pkg/adt/crud.go
+++ b/pkg/adt/crud.go
@@ -217,7 +217,8 @@ type CreateObjectOptions struct {
 	BindingType string `json:"bindingType,omitempty"`
 	// For SRVB: binding version ("V2" or "V4")
 	BindingVersion string `json:"bindingVersion,omitempty"`
-	// For SRVB: category ("0" for Web API, "1" for UI)
+	// For SRVB: category per SAP domain SRVB_BND_CATEGORY:
+	// "0" = UI (User Interface), "1" = A2X (Application to X users, i.e. Web API)
 	BindingCategory string `json:"bindingCategory,omitempty"`
 
 	// For BDEF: source code (required for creation - ADT API embeds source in creation request)
@@ -765,7 +766,7 @@ func buildCreateObjectBody(opts CreateObjectOptions, typeInfo objectTypeInfo, de
 		}
 		bindingCategory := opts.BindingCategory
 		if bindingCategory == "" {
-			bindingCategory = "0" // Web API
+			bindingCategory = "0" // UI (SRVB_BND_CATEGORY: 0=UI, 1=A2X/Web API)
 		}
 		return fmt.Sprintf(`<?xml version="1.0" encoding="UTF-8"?>
 <%s %s xmlns:adtcore="http://www.sap.com/adt/core"

--- a/pkg/adt/crud_srvb_test.go
+++ b/pkg/adt/crud_srvb_test.go
@@ -1,0 +1,93 @@
+package adt
+
+import (
+	"strings"
+	"testing"
+)
+
+// srvbTypeInfo mirrors what CreateObject resolves for ObjectTypeSRVB.
+func srvbTestTypeInfo(t *testing.T) objectTypeInfo {
+	t.Helper()
+	ti, ok := objectTypes[ObjectTypeSRVB]
+	if !ok {
+		t.Fatalf("ObjectTypeSRVB not present in objectTypes registry")
+	}
+	return ti
+}
+
+func buildSRVB(t *testing.T, opts CreateObjectOptions) string {
+	t.Helper()
+	opts.ObjectType = ObjectTypeSRVB
+	if opts.Name == "" {
+		opts.Name = "ZUI_TEST_O4"
+	}
+	if opts.PackageName == "" {
+		opts.PackageName = "$TMP"
+	}
+	if opts.ServiceDefinition == "" {
+		opts.ServiceDefinition = "ZUI_TEST"
+	}
+	return buildCreateObjectBody(opts, srvbTestTypeInfo(t), "DEVELOPER")
+}
+
+// The binding category values come from SAP domain SRVB_BND_CATEGORY:
+//
+//	0 = UI (User Interface)
+//	1 = A2X (Application to X users) i.e. Web API
+//
+// The default must be UI ("0"), and an explicitly requested category must survive.
+func TestBuildCreateObjectBody_SRVBCategory(t *testing.T) {
+	tests := []struct {
+		name         string
+		category     string
+		wantCategory string
+	}{
+		{name: "default is UI", category: "", wantCategory: `srvb:category="0"`},
+		{name: "explicit UI", category: "0", wantCategory: `srvb:category="0"`},
+		{name: "explicit A2X/Web API", category: "1", wantCategory: `srvb:category="1"`},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			body := buildSRVB(t, CreateObjectOptions{BindingCategory: tc.category})
+			if !strings.Contains(body, tc.wantCategory) {
+				t.Errorf("want %s in body, got:\n%s", tc.wantCategory, body)
+			}
+		})
+	}
+}
+
+// Regression: passing binding_version must actually reach the ADT payload.
+// A silently-defaulted V2 binding for a caller that asked for V4 produces a
+// service that cannot drive a Fiori Elements V4 app.
+func TestBuildCreateObjectBody_SRVBVersion(t *testing.T) {
+	tests := []struct {
+		name        string
+		version     string
+		wantVersion string
+	}{
+		{name: "default is V2", version: "", wantVersion: `srvb:version="V2"`},
+		{name: "explicit V2", version: "V2", wantVersion: `srvb:version="V2"`},
+		{name: "explicit V4", version: "V4", wantVersion: `srvb:version="V4"`},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			body := buildSRVB(t, CreateObjectOptions{BindingVersion: tc.version})
+			if !strings.Contains(body, tc.wantVersion) {
+				t.Errorf("want %s in body, got:\n%s", tc.wantVersion, body)
+			}
+		})
+	}
+}
+
+// The bound service definition must be upper-cased and present.
+func TestBuildCreateObjectBody_SRVBServiceDefinition(t *testing.T) {
+	body := buildSRVB(t, CreateObjectOptions{ServiceDefinition: "zui_flight_o4"})
+	if !strings.Contains(body, `<srvb:serviceDefinition adtcore:name="ZUI_FLIGHT_O4"/>`) {
+		t.Errorf("service definition not bound/upper-cased, got:\n%s", body)
+	}
+	if !strings.Contains(body, `srvb:type="ODATA"`) {
+		t.Errorf(`want srvb:type="ODATA", got:\n%s`, body)
+	}
+}


### PR DESCRIPTION
Two independent SRVB defects found while building a RAP OData V4 service through the MCP surface against a live S/4HANA 2021 (SAP_BASIS 7.56) system. Both are small; the first one is what let the second one bite.

## 1. `read SRVB` is advertised but unreachable

`GetSource`'s own tool description already lists `SRVB (service binding)` as a supported `object_type`, and `pkg/adt` implements it end to end (`workflows_source.go` `case "SRVB"` → `Client.GetSRVB` → JSON). But the MCP router's allow-list in `routeSourceAction` omits `"SRVB"`, so the call is rejected:

```
No handler found for action="read" target="SRVB"
Supported read targets: CLAS, PROG, INTF, FUNC, FUGR, INCL, DDLS, BDEF, SRVD, ...
```

Consequence: a caller can *create* a service binding but cannot read back what it actually got. This is what made defect 2 silent.

Fix: add `"SRVB"` to the read allow-list — no new capability, it just reaches the existing implementation and matches the documented contract.

Verified live:

```
before: No handler found for action="read" target="SRVB"
after : {"name":"...","type":"SRVB/SVB","published":false,
         "bindingType":"ODATA","bindingVersion":"V4","serviceDefName":"..."}
```

## 2. `binding_category` is documented backwards

Per SAP's domain `SRVB_BND_CATEGORY` (verified on 7.56 via `DD07L`/`DD07T`):

| value | meaning |
|-------|---------|
| `0`   | UI ( User Interface ) |
| `1`   | A2X ( Application to X users ) — i.e. Web API |

`CreateObjectOptions`, `buildCreateObjectBody` and the `CreateObject` tool schema all state the opposite (`"0" for Web API, "1" for UI`). A caller who wants a UI binding and follows the documentation passes `"1"` and silently gets an A2X/Web API binding.

The emitted default (`"0"`) was already correct in practice — it produces a UI binding — only the label was wrong. **Docs/semantics only, no behavior change.**

Also clarified `binding_version`: it silently defaults to `V2`, producing a binding that cannot drive a Fiori Elements V4 app. Callers needing V4 must pass it explicitly; the schema now says so. (This is exactly how a binding named `..._O4` ended up as V2 for us, undetected because of defect 1.)

## Tests

Added `pkg/adt/crud_srvb_test.go` pinning the ADT payload:

- category: default → `srvb:category="0"`, explicit UI `0`, explicit A2X `1`
- version: default → `srvb:version="V2"`, explicit `V2` / `V4`
- service definition bound and upper-cased, `srvb:type="ODATA"`

`go vet` clean. `internal/mcp` and `pkg/adt` suites pass.

Note: the `Recording*` tests in `pkg/adt` appear flaky on this machine independently of this change — they pass in isolation on both this branch and clean `main`, and across repeated full-suite runs different `Recording*` tests fail on unchanged code (2 of 3 runs fully green). Unrelated to this PR, flagging in case it is useful.
