### PR TITLE
feat(adt): ActivateMultiple — batch activation with dependency resolution

### DIFF
--- a/internal/mcp/handlers_devtools.go
+++ b/internal/mcp/handlers_devtools.go
@@ -46,6 +46,8 @@ func (s *Server) routeDevToolsAction(ctx context.Context, action, objectType, ob
 		switch objectType {
 		case "ACTIVATE":
 			return s.callHandler(ctx, s.handleActivate, params)
+		case "ACTIVATE_MULTI":
+			return s.callHandler(ctx, s.handleActivateMultiple, params)
 		case "ACTIVATE_PACKAGE":
 			return s.callHandler(ctx, s.handleActivatePackage, params)
 		}
@@ -88,6 +90,51 @@ func (s *Server) handleActivate(ctx context.Context, request mcp.CallToolRequest
 	}
 
 	result, err := s.adtClient.Activate(ctx, objectURL, objectName)
+	if err != nil {
+		return newToolResultError(fmt.Sprintf("Activation failed: %v", err)), nil
+	}
+
+	output, _ := json.MarshalIndent(result, "", "  ")
+	return mcp.NewToolResultText(string(output)), nil
+}
+
+// handleActivateMultiple activates multiple objects in a single ADT request.
+// params.objects: array of {"url": "...", "name": "..."} pairs, or
+//                 array of strings in "TYPE NAME" format (e.g. "INCL ZREP_F01").
+func (s *Server) handleActivateMultiple(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	raw, ok := request.GetArguments()["objects"]
+	if !ok {
+		return newToolResultError("objects is required (array of {url, name} or [\"TYPE NAME\", ...])"), nil
+	}
+
+	items, ok := raw.([]any)
+	if !ok || len(items) == 0 {
+		return newToolResultError("objects must be a non-empty array"), nil
+	}
+
+	refs := make([]adt.ObjectRef, 0, len(items))
+	for i, item := range items {
+		switch v := item.(type) {
+		case map[string]any:
+			u, _ := v["url"].(string)
+			n, _ := v["name"].(string)
+			if u == "" || n == "" {
+				return newToolResultError(fmt.Sprintf("objects[%d]: both 'url' and 'name' are required", i)), nil
+			}
+			refs = append(refs, adt.ObjectRef{URI: u, Name: n})
+		case string:
+			// "TYPE NAME" shorthand → resolve to ADT URL
+			u, n, err := s.adtClient.ResolveObjectRef(v)
+			if err != nil {
+				return newToolResultError(fmt.Sprintf("objects[%d]: cannot resolve %q: %v", i, v, err)), nil
+			}
+			refs = append(refs, adt.ObjectRef{URI: u, Name: n})
+		default:
+			return newToolResultError(fmt.Sprintf("objects[%d]: unsupported type %T", i, item)), nil
+		}
+	}
+
+	result, err := s.adtClient.ActivateMultiple(ctx, refs)
 	if err != nil {
 		return newToolResultError(fmt.Sprintf("Activation failed: %v", err)), nil
 	}

--- a/internal/mcp/tools_focused.go
+++ b/internal/mcp/tools_focused.go
@@ -41,6 +41,7 @@ func focusedToolSet() map[string]bool {
 		"RunUnitTests":       true,
 		"RunATCCheck":        true,  // Code quality checks
 		"Activate":           true,  // Re-activate objects without editing
+		"ActivateMultiple":   true,  // Batch activation of specific objects (dependency-aware, like Eclipse)
 		"ActivatePackage":    true,  // Batch activation of all inactive objects
 		"PrettyPrint":        true,  // Format ABAP code
 		"GetInactiveObjects": true,  // List pending activations

--- a/internal/mcp/tools_register.go
+++ b/internal/mcp/tools_register.go
@@ -774,6 +774,18 @@ func (s *Server) registerDevTools(shouldRegister func(string) bool) {
 		), s.handleActivate)
 	}
 
+	if shouldRegister("ActivateMultiple") {
+		s.mcpServer.AddTool(mcp.NewTool("ActivateMultiple",
+			mcp.WithDescription("Activate multiple ABAP objects in a single ADT request, resolving mutual dependencies between them (same behaviour as Eclipse ADT). Use when includes and their main program must be activated together."),
+			mcp.WithArray("objects",
+				mcp.Required(),
+				mcp.Description(`Objects to activate. Each item can be:
+  - {"url": "/sap/bc/adt/programs/programs/zprog", "name": "ZPROG"}
+  - "TYPE NAME" shorthand, e.g. "PROG ZPROG", "INCL ZPROG_TOP", "CLAS ZCL_X"`),
+			),
+		), s.handleActivateMultiple)
+	}
+
 	if shouldRegister("ActivatePackage") {
 		s.mcpServer.AddTool(mcp.NewTool("ActivatePackage",
 			mcp.WithDescription("Activate all inactive objects. Objects are sorted by dependency order (interfaces before classes). If no package specified, activates ALL inactive objects for current user."),

--- a/pkg/adt/client.go
+++ b/pkg/adt/client.go
@@ -268,6 +268,34 @@ func (c *Client) SearchObject(ctx context.Context, query string, maxResults int)
 	return ParseSearchResults(resp.Body)
 }
 
+// ResolveObjectRef converts a "TYPE NAME" shorthand (e.g. "INCL ZREP_F01", "PROG ZREPORT")
+// into the (objectURL, objectName) pair needed for activation or other ADT operations.
+// The name is returned in UPPERCASE; the URL uses lowercase path encoding.
+func (c *Client) ResolveObjectRef(typeAndName string) (objectURL, objectName string, err error) {
+	parts := strings.Fields(strings.ToUpper(strings.TrimSpace(typeAndName)))
+	if len(parts) != 2 {
+		return "", "", fmt.Errorf("expected \"TYPE NAME\", got %q", typeAndName)
+	}
+	objType, name := parts[0], parts[1]
+	encoded := url.PathEscape(strings.ToLower(name))
+	switch objType {
+	case "PROG":
+		return "/sap/bc/adt/programs/programs/" + encoded, name, nil
+	case "INCL":
+		return "/sap/bc/adt/programs/includes/" + encoded, name, nil
+	case "CLAS":
+		return "/sap/bc/adt/oo/classes/" + encoded, name, nil
+	case "INTF":
+		return "/sap/bc/adt/oo/interfaces/" + encoded, name, nil
+	case "FUGR":
+		return "/sap/bc/adt/function/groups/" + encoded, name, nil
+	case "DDLS":
+		return "/sap/bc/adt/ddic/ddl/sources/" + encoded, name, nil
+	default:
+		return "", "", fmt.Errorf("unsupported object type %q (supported: PROG, INCL, CLAS, INTF, FUGR, DDLS)", objType)
+	}
+}
+
 // --- Program Operations ---
 
 // GetProgram retrieves the source code of an ABAP program.

--- a/pkg/adt/devtools.go
+++ b/pkg/adt/devtools.go
@@ -343,6 +343,47 @@ func parseInactiveObjects(data []byte) ([]InactiveObjectRecord, error) {
 
 // --- Batch Activation ---
 
+// ObjectRef is a URI + name pair used to reference an ADT object in activation requests.
+type ObjectRef struct {
+	URI  string `json:"uri"`
+	Name string `json:"name"`
+}
+
+// ActivateMultiple activates multiple objects in a single ADT request, allowing SAP to
+// resolve mutual dependencies between them (e.g., a program and all its includes).
+// This is the correct approach when objects reference symbols defined in each other —
+// activating them one by one fails because the first object can't see the others.
+func (c *Client) ActivateMultiple(ctx context.Context, objects []ObjectRef) (*ActivationResult, error) {
+	if err := c.checkSafety(OpActivate, "ActivateMultiple"); err != nil {
+		return nil, err
+	}
+	if len(objects) == 0 {
+		return &ActivationResult{Success: true, Messages: []ActivationResultMessage{}, Inactive: []InactiveObject{}}, nil
+	}
+	if len(objects) == 1 {
+		return c.Activate(ctx, objects[0].URI, objects[0].Name)
+	}
+
+	var sb strings.Builder
+	sb.WriteString("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n")
+	sb.WriteString("<adtcore:objectReferences xmlns:adtcore=\"http://www.sap.com/adt/core\">\n")
+	for _, obj := range objects {
+		sb.WriteString(fmt.Sprintf("  <adtcore:objectReference adtcore:uri=\"%s\" adtcore:name=\"%s\"/>\n",
+			obj.URI, obj.Name))
+	}
+	sb.WriteString("</adtcore:objectReferences>")
+
+	resp, err := c.transport.Request(ctx, "/sap/bc/adt/activation?method=activate&preauditRequested=true", &RequestOptions{
+		Method:      http.MethodPost,
+		Body:        []byte(sb.String()),
+		ContentType: "application/xml",
+	})
+	if err != nil {
+		return nil, fmt.Errorf("batch activation failed: %w", err)
+	}
+	return parseActivationResult(resp.Body)
+}
+
 // ActivatePackageResult represents the result of batch activation.
 type ActivatePackageResult struct {
 	Activated []ActivatedObject  `json:"activated"`
@@ -430,24 +471,61 @@ func (c *Client) ActivatePackage(ctx context.Context, packageName string, maxObj
 		Failed:    []ActivationFailed{},
 	}
 
-	// Activate each object
+	if len(toActivate) == 0 {
+		result.Summary = "No inactive objects to activate"
+		return result, nil
+	}
+
+	// Build ObjectRef list and activate all in a single request so SAP can resolve
+	// mutual dependencies between objects (same behaviour as Eclipse ADT).
+	refs := make([]ObjectRef, 0, len(toActivate))
+	refMeta := make(map[string]InactiveObject, len(toActivate)) // URI → meta
 	for _, rec := range toActivate {
 		if rec.Object == nil {
 			continue
 		}
-		obj := rec.Object
-		_, err := c.Activate(ctx, obj.URI, obj.Name)
-		if err != nil {
+		refs = append(refs, ObjectRef{URI: rec.Object.URI, Name: rec.Object.Name})
+		refMeta[rec.Object.URI] = *rec.Object
+	}
+
+	activation, err := c.ActivateMultiple(ctx, refs)
+	if err != nil {
+		return nil, fmt.Errorf("batch activation failed: %w", err)
+	}
+
+	// Build per-object reason strings from activation messages (keyed by ObjDescr/name).
+	reasons := make(map[string]string)
+	for _, msg := range activation.Messages {
+		if strings.ContainsAny(msg.Type, "EAX") && msg.ObjDescr != "" {
+			if reasons[msg.ObjDescr] == "" {
+				reasons[msg.ObjDescr] = msg.ShortText
+			}
+		}
+	}
+
+	// Objects still inactive after the request → Failed; the rest → Activated.
+	stillInactive := make(map[string]bool, len(activation.Inactive))
+	for _, obj := range activation.Inactive {
+		stillInactive[obj.URI] = true
+	}
+
+	for _, ref := range refs {
+		meta := refMeta[ref.URI]
+		if stillInactive[ref.URI] {
+			reason := reasons[ref.Name]
+			if reason == "" {
+				reason = "still inactive after activation attempt"
+			}
 			result.Failed = append(result.Failed, ActivationFailed{
-				Name:   obj.Name,
-				Type:   obj.Type,
-				Reason: err.Error(),
+				Name:   ref.Name,
+				Type:   meta.Type,
+				Reason: reason,
 			})
 		} else {
 			result.Activated = append(result.Activated, ActivatedObject{
-				Name: obj.Name,
-				Type: obj.Type,
-				URI:  obj.URI,
+				Name: ref.Name,
+				Type: meta.Type,
+				URI:  ref.URI,
 			})
 		}
 	}


### PR DESCRIPTION
Closes #137.

## Summary

Adds `ActivateMultiple()` — sends all objects in a single ADT activation
request instead of one-by-one, matching Eclipse ADT behaviour. SAP resolves
mutual dependencies between the objects when they arrive together;
activating them individually fails when includes reference symbols defined
in each other or in the main program.

## Change

- `pkg/adt/devtools.go`: `ObjectRef` type + `ActivateMultiple()`.
  `ActivatePackage` updated to use it (one batch request instead of N
  individual calls); maps the `Inactive` list back to Failed/Activated per
  object.
- `pkg/adt/client.go`: `ResolveObjectRef("TYPE NAME")` — converts
  "INCL ZPROG_F01", "PROG ZPROG", etc. to (url, name) pairs. Self-contained,
  no dependency on the type-filtering work in #126 (kept out of scope here
  on purpose to avoid overlapping with that PR).
- `internal/mcp/handlers_devtools.go` / `tools_register.go` /
  `tools_focused.go`: MCP tool wiring, accepts objects as `[{url, name}]`
  or `["TYPE NAME"]` strings.

## Verified

Live-tested on-prem S/4HANA against real objects with mutual dependencies
in an active development package (2026-06-03) — individual activation
failed as expected, batch activation via this change succeeded. Full
`go test ./pkg/adt/... ./internal/mcp/...` green (one pre-existing flaky
test, `TestRecordingFilterMinSteps` in `history_test.go`, unrelated to this
change — reproduces intermittently on clean `main` too, not touched here).

## Usage

    SAP(action="edit", target="ACTIVATE_MULTI", params={
      "objects": ["PROG ZPROG", "INCL ZPROG_TOP", "INCL ZPROG_F01"]
    })