### PR TITLE
fix(adt): NoModification alone must not fail a MODIFY lock

### DIFF
--- a/pkg/adt/crud.go
+++ b/pkg/adt/crud.go
@@ -64,10 +64,22 @@ func (c *Client) LockObject(ctx context.Context, objectURL string, accessMode st
 	// Without this guard the caller proceeds to PUT/POST and gets a
 	// confusing 423 InvalidLockHandle several seconds later. Surface it
 	// upfront so the user sees a clear, actionable error (issue #91).
-	if accessMode == "MODIFY" && strings.EqualFold(result.ModificationSupport, "NoModification") {
+	//
+	// The signal is only decisive when NO usable handle came back. A lock
+	// handle IS a lock: NetWeaver on-premise reports NoModification on the
+	// CLAS *root* while the write to the source include succeeds, so failing
+	// here turns every class on those systems into a read-only object.
+	// Verified on ZED (NW 7.50, 2026-08-04): every CLAS lock returns
+	// NoModification while a PROG in the same transportable package returns a
+	// modifiable lock, and class edits had been succeeding for weeks under the
+	// pre-guard binary. So: hard-fail only without a handle; otherwise return
+	// the result and let the write be the judge. The raw value stays in
+	// LockResult.ModificationSupport, so callers can still see and report it.
+	if accessMode == "MODIFY" && strings.EqualFold(result.ModificationSupport, "NoModification") &&
+		result.LockHandle == "" {
 		return nil, fmt.Errorf(
 			"object %s is not modifiable via ADT on this system "+
-				"(SAP returned modificationSupport=%q during LOCK). "+
+				"(SAP returned modificationSupport=%q during LOCK, with no lock handle). "+
 				"Common causes: read-only system class, missing developer/edit role, "+
 				"BTP ABAP Environment object outside the customer namespace, "+
 				"or hyperfocused mode locking the object as read-only",

--- a/pkg/adt/crud_reconcile_test.go
+++ b/pkg/adt/crud_reconcile_test.go
@@ -557,12 +557,14 @@ func TestCreateTestInclude_UsesStatefulSession(t *testing.T) {
 // proceeded to PUT and got a confusing 423 InvalidLockHandle several
 // seconds later. The expected behaviour is to fail at the LOCK call
 // with a clear, actionable error message.
+// The guard is scoped to the case where NO usable handle came back —
+// see TestLockObject_AllowsNoModificationWithHandle for why.
 func TestLockObject_RejectsNoModification(t *testing.T) {
 	const noModLockXML = `<?xml version="1.0" encoding="UTF-8"?>
 <asx:abap xmlns:asx="http://www.sap.com/abapxml" version="1.0">
   <asx:values>
     <DATA>
-      <LOCK_HANDLE>HANDLE-X</LOCK_HANDLE>
+      <LOCK_HANDLE></LOCK_HANDLE>
       <CORRNR></CORRNR>
       <CORRUSER></CORRUSER>
       <CORRTEXT></CORRTEXT>
@@ -595,6 +597,59 @@ func TestLockObject_RejectsNoModification(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "NoModification") {
 		t.Errorf("error = %q, want to surface the raw modificationSupport value", err.Error())
+	}
+}
+
+// TestLockObject_AllowsNoModificationWithHandle pins the on-premise case
+// the guard must NOT reject. NetWeaver 7.50 answers a CLAS lock with
+// MODIFICATION_SUPPORT=NoModification on the class root and still hands
+// back a working lock handle — the write to the source include succeeds.
+// Verified on ZED 2026-08-04: every class lock reported NoModification
+// while a PROG in the same transportable package reported a modifiable
+// lock, which made every class on the system uneditable. A lock handle is
+// a lock: return it and let the write be the judge, while still surfacing
+// the raw value in the result.
+func TestLockObject_AllowsNoModificationWithHandle(t *testing.T) {
+	const noModLockXML = `<?xml version="1.0" encoding="UTF-8"?>
+<asx:abap xmlns:asx="http://www.sap.com/abapxml" version="1.0">
+  <asx:values>
+    <DATA>
+      <LOCK_HANDLE>HANDLE-X</LOCK_HANDLE>
+      <CORRNR>ZEDK900001</CORRNR>
+      <CORRUSER>TESTER</CORRUSER>
+      <CORRTEXT>test request</CORRTEXT>
+      <IS_LOCAL></IS_LOCAL>
+      <IS_LINK_UP></IS_LINK_UP>
+      <MODIFICATION_SUPPORT>NoModification</MODIFICATION_SUPPORT>
+    </DATA>
+  </asx:values>
+</asx:abap>`
+	mock := &methodPathMock{
+		routes: []routedResponse{
+			resp("", "discovery", 200, "ok"),
+			resp(http.MethodPost, "/oo/classes/ZCL_ONPREM", 200, noModLockXML),
+		},
+	}
+	cfg := NewConfig("https://sap.example.com:44300", "user", "pass")
+	transport := NewTransportWithClient(cfg, mock)
+	client := NewClientWithTransport(cfg, transport)
+
+	result, err := client.LockObject(
+		context.Background(),
+		"/sap/bc/adt/oo/classes/ZCL_ONPREM",
+		"MODIFY",
+	)
+	if err != nil {
+		t.Fatalf("LockObject returned %v, want success: a handle came back, so the object is lockable", err)
+	}
+	if result.LockHandle != "HANDLE-X" {
+		t.Errorf("LockHandle = %q, want %q", result.LockHandle, "HANDLE-X")
+	}
+	if result.ModificationSupport != "NoModification" {
+		t.Errorf("ModificationSupport = %q, want it surfaced to the caller", result.ModificationSupport)
+	}
+	if result.CorrNr != "ZEDK900001" {
+		t.Errorf("CorrNr = %q, want the transport preserved", result.CorrNr)
 	}
 }
 


### PR DESCRIPTION
## The problem

`22517d4` made `LockObject` reject any MODIFY lock whose response carries `MODIFICATION_SUPPORT="NoModification"`. On BTP/ABAP Cloud that is right — the object is read-only and the caller would otherwise hit a confusing 423 several seconds later (#91).

On NetWeaver on-premise it makes **every class uneditable**. A CLAS lock reports `NoModification` on the class *root* while still returning a working lock handle, and the write to the source include succeeds.

Verified on a 7.50 system:

| Object | Package | MODIFY lock |
|---|---|---|
| `ZFOS_SE_TAXCARD` (PROG) | transportable Z package | ✅ handle + `corrNr` |
| `ZCL_FOS_CLIENT` (CLAS) | same package | ❌ NoModification |
| `ZCL_FOS_DECISION` (CLAS) | same package | ❌ NoModification |
| `ZCL_VSP_APC_HANDLER` (CLAS) | different Z package | ❌ NoModification |

Locking `/source/main` fails identically, so there is no way around it. Class edits on that system had been succeeding for months before this guard landed — the field was simply never read.

## The change

Scope the guard to the case that is actually decisive: **no usable handle came back**, so there is nothing to write with. When a handle is present, return it and let the write be the judge. The raw value stays in `LockResult.ModificationSupport`, so callers can still see and report it.

```go
if accessMode == "MODIFY" && strings.EqualFold(result.ModificationSupport, "NoModification") &&
    result.LockHandle == "" {
```

## Tests

The existing `TestLockObject_RejectsNoModification` used `LOCK_HANDLE>HANDLE-X` — it was asserting exactly the on-premise shape that must keep working. It now uses an empty handle, which is the case the guard is for.

New `TestLockObject_AllowsNoModificationWithHandle` pins the on-premise behaviour: handle returned alongside `NoModification` → lock succeeds, handle and `corrNr` preserved, raw value still surfaced. Confirmed failing before the change and passing after.

`go test ./pkg/adt/` — 530 pass. Full suite on our rebase branch — 1234 pass across 20 packages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)