### PR TITLE
IAM authorization chain over ADT, and a transport owner fix for browser SSO

### DIFF
--- a/cmd/vsp/cli_adt_raw.go
+++ b/cmd/vsp/cli_adt_raw.go
@@ -1,0 +1,125 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"sort"
+	"strings"
+
+	"github.com/spf13/cobra"
+)
+
+// adtGetCmd is a read-only window onto ADT paths that vsp does not model.
+//
+// Adding a new creatable object type to the objectTypes registry needs three
+// facts SAP does not publish: the creation collection, the XML root element
+// and the namespace. All three are readable from a live system, so read them
+// rather than guess them.
+var adtGetCmd = &cobra.Command{
+	Use:   "adt-get <path>",
+	Short: "Read an arbitrary ADT path (GET only)",
+	Long: `Perform an authenticated read-only GET against an ADT path and print the response.
+
+Use it to learn the contract for an object type vsp does not support yet.
+
+Examples:
+  # Every collection on the system, with the content types each one accepts
+  vsp adt-get /sap/bc/adt/discovery
+
+  # Only the collections whose href matches a substring
+  vsp adt-get /sap/bc/adt/discovery --grep iam
+
+  # One instance of an unmodelled type, to see its root element and namespace
+  vsp adt-get /sap/bc/adt/aps/cloud/iam/sia1/sap_core_bc_a4c_dic
+
+  # Against a named system from .vsp.json
+  vsp -s n4d adt-get /sap/bc/adt/discovery`,
+	Args: cobra.ExactArgs(1),
+	RunE: runAdtGet,
+}
+
+func init() {
+	adtGetCmd.Flags().String("accept", "", "Accept header. Defaults to a permissive ADT value.")
+	adtGetCmd.Flags().String("grep", "", "Print only lines containing this substring, case insensitive.")
+	adtGetCmd.Flags().String("out", "", "Write the body to this file instead of stdout.")
+	adtGetCmd.Flags().Bool("headers", false, "Also print the response status and headers.")
+	rootCmd.AddCommand(adtGetCmd)
+}
+
+func runAdtGet(cmd *cobra.Command, args []string) error {
+	path := args[0]
+
+	accept, _ := cmd.Flags().GetString("accept")
+	grep, _ := cmd.Flags().GetString("grep")
+	outFile, _ := cmd.Flags().GetString("out")
+	showHeaders, _ := cmd.Flags().GetBool("headers")
+
+	if accept == "" {
+		// Permissive on purpose. ADT answers most resources with their own
+		// vnd.sap.adt type, and asking for a specific one you guessed wrong
+		// returns 406 and teaches you nothing.
+		accept = "application/atomsvc+xml, application/atom+xml, application/xml, application/*, */*"
+	}
+
+	params, err := resolveSystemParams(cmd)
+	if err != nil {
+		return err
+	}
+
+	client, err := getClient(params)
+	if err != nil {
+		return err
+	}
+
+	resp, err := client.RawGet(context.Background(), path, accept)
+	if err != nil {
+		return fmt.Errorf("GET %s: %w", path, err)
+	}
+
+	if showHeaders {
+		fmt.Fprintf(os.Stderr, "status: %d\n", resp.StatusCode)
+		keys := make([]string, 0, len(resp.Headers))
+		for k := range resp.Headers {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+		for _, k := range keys {
+			fmt.Fprintf(os.Stderr, "%s: %s\n", k, strings.Join(resp.Headers[k], ", "))
+		}
+		fmt.Fprintln(os.Stderr, "---")
+	}
+
+	body := string(resp.Body)
+
+	if grep != "" {
+		needle := strings.ToLower(grep)
+		var kept []string
+		// ADT often returns one very long line, so split on tag boundaries
+		// first to make substring filtering useful.
+		normalised := strings.ReplaceAll(body, "><", ">\n<")
+		for _, line := range strings.Split(normalised, "\n") {
+			if strings.Contains(strings.ToLower(line), needle) {
+				kept = append(kept, strings.TrimSpace(line))
+			}
+		}
+		body = strings.Join(kept, "\n")
+		if body != "" {
+			body += "\n"
+		}
+	}
+
+	if outFile != "" {
+		if err := os.WriteFile(outFile, []byte(body), 0o600); err != nil {
+			return fmt.Errorf("writing %s: %w", outFile, err)
+		}
+		fmt.Fprintf(os.Stderr, "wrote %d bytes to %s\n", len(body), outFile)
+		return nil
+	}
+
+	fmt.Print(body)
+	if !strings.HasSuffix(body, "\n") {
+		fmt.Println()
+	}
+	return nil
+}

--- a/internal/mcp/handlers_crud.go
+++ b/internal/mcp/handlers_crud.go
@@ -235,9 +235,19 @@ func (s *Server) handleCreatePackage(ctx context.Context, request mcp.CallToolRe
 		softwareComponent = strings.ToUpper(sc)
 	}
 
-	// Transportable packages require transport parameter
-	if !strings.HasPrefix(name, "$") && transport == "" {
-		return newToolResultError("transport is required for creating transportable packages (non-$ packages). Use --enable-transports flag."), nil
+	// A non-$ package usually needs a transport, but not always: a software
+	// component with change recording off (ZLOCAL on S/4HANA Cloud, and the
+	// equivalent elsewhere) takes packages that produce no transport at all,
+	// and on a browser-auth connection CreateTransport cannot even mint one.
+	//
+	// The name alone cannot tell the two apart, so only guess when the caller
+	// gave us nothing to go on. If a software component was named, defer to ADT:
+	// it is the authority on whether a transport is required, and it returns a
+	// specific error when one is.
+	if !strings.HasPrefix(name, "$") && transport == "" && softwareComponent == "" {
+		return newToolResultError("transport is required for a transportable package. " +
+			"If the package belongs to a software component with change recording off " +
+			"(for example ZLOCAL), pass software_component instead and no transport is needed."), nil
 	}
 
 	opts := adt.CreateObjectOptions{

--- a/internal/mcp/handlers_iam.go
+++ b/internal/mcp/handlers_iam.go
@@ -1,0 +1,500 @@
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/oisee/vibing-steampunk/pkg/adt"
+)
+
+// registerIAMTools registers the identity and access management tools.
+//
+// Called from registerTools alongside the other register* functions.
+func (s *Server) registerIAMTools(shouldRegister func(string) bool) {
+	if shouldRegister("CreateBusinessCatalog") {
+		s.mcpServer.AddTool(mcp.NewTool("CreateBusinessCatalog",
+			mcp.WithDescription("Create an IAM business catalog (ADT type SIA1) and assign IAM apps to it. "+
+				"This is the step that authorizes a published RAP service: publishing a service binding "+
+				"generates an IAM app, which grants nothing until a business catalog holds it and a business "+
+				"role includes that catalog. Creates, activates and publishes the catalog. "+
+				"Assigning apps is a separate step: use CreateIAMApp then AssignIAMAppToCatalog, which "+
+				"creates the SIA7 assignment object. (The SIA1 $bucapps sub-resource is read-only and "+
+				"answers 405; the assignment is a first-class object, which is what Eclipse writes.) "+
+				"Finish by adding the catalog to a business role in Maintain Business Roles."),
+			mcp.WithString("name",
+				mcp.Required(),
+				mcp.Description("Business catalog name, e.g. ZBC_MY_APP"),
+			),
+			mcp.WithString("description",
+				mcp.Required(),
+				mcp.Description("Business catalog description"),
+			),
+			mcp.WithString("package_name",
+				mcp.Required(),
+				mcp.Description("Package to create the catalog in"),
+			),
+			mcp.WithString("iam_apps",
+				mcp.Description("Comma-separated IAM app IDs this catalog is meant to hold, e.g. "+
+					"ZUI_MY_SRV_O4_0001_ABCD_IBS. Recorded in the response as a reminder only: ADT cannot write "+
+					"app assignments (see attempt_app_assignment)."),
+			),
+			mcp.WithBoolean("attempt_app_assignment",
+				mcp.Description("Try to write the assignments over ADT anyway (default: false). "+
+					"The $bucapps resource controller implements only GET on S/4HANA Cloud 2602, so this "+
+					"returns 405. Left in for a future release that opens it for writing."),
+			),
+			mcp.WithString("transport",
+				mcp.Description("Transport request number, required for a transportable package"),
+			),
+			mcp.WithBoolean("publish",
+				mcp.Description("Run the local publish after activation (default: true)"),
+			),
+			mcp.WithBoolean("skip_activation",
+				mcp.Description("Create and assign without activating (default: false)"),
+			),
+		), s.handleCreateBusinessCatalog)
+	}
+
+	if shouldRegister("CreateIAMApp") {
+		s.mcpServer.AddTool(mcp.NewTool("CreateIAMApp",
+			mcp.WithDescription("Create an IAM app (ADT type SIA6), activate and publish it locally. "+
+				"Publishing a service binding does NOT create this object: it creates an IAM business "+
+				"service (SIA6 with appType IBS) plus a communication scenario, and neither can be put "+
+				"in a business catalog. This is the assignable app that goes in one. Use app_type EXT "+
+				"for an application served outside the system, such as a Fiori app on BTP Cloud Foundry. "+
+				"Until the app is published, the business catalog assignment does not see it, which "+
+				"reads as the app not existing."),
+			mcp.WithString("name", mcp.Required(),
+				mcp.Description("IAM app name, e.g. ZIA_MY_APP")),
+			mcp.WithString("description", mcp.Required(),
+				mcp.Description("IAM app description")),
+			mcp.WithString("package_name", mcp.Required(),
+				mcp.Description("Package to create the app in")),
+			mcp.WithString("app_type",
+				mcp.Description("Application type: EXT (external app, the default) or IBS")),
+			mcp.WithString("secondary_id",
+				mcp.Description("Object the app stands for, e.g. the generated communication scenario "+
+					"on an IBS app. Leave empty for a plain external app.")),
+			mcp.WithString("transport",
+				mcp.Description("Transport request number, required for a transportable package")),
+			mcp.WithBoolean("publish",
+				mcp.Description("Run the local publish after activation (default: true)")),
+			mcp.WithBoolean("skip_activation",
+				mcp.Description("Create without activating (default: false)")),
+		), s.handleCreateIAMApp)
+	}
+
+	if shouldRegister("AssignIAMAppToCatalog") {
+		s.mcpServer.AddTool(mcp.NewTool("AssignIAMAppToCatalog",
+			mcp.WithDescription("Assign an IAM app to a business catalog by creating the assignment "+
+				"object (ADT type SIA7), then activate it. This is what the Eclipse 'Business Catalog "+
+				"IAM App Assignment' wizard creates. It is NOT the SIA1 $bucapps sub-resource, which is "+
+				"read-only and answers 405 to every write verb; the assignment is a first-class object "+
+				"in its own collection. Both the catalog and the app must exist and be published first."),
+			mcp.WithString("business_catalog", mcp.Required(),
+				mcp.Description("Business catalog ID, e.g. ZBC_MY_APP")),
+			mcp.WithString("iam_app", mcp.Required(),
+				mcp.Description("IAM app ID to assign, e.g. ZIA_MY_APP")),
+			mcp.WithString("package_name", mcp.Required(),
+				mcp.Description("Package to create the assignment in")),
+			mcp.WithString("name",
+				mcp.Description("Assignment object name. Defaults to <catalog>_0001, which is what "+
+					"the workbench generates.")),
+			mcp.WithString("transport",
+				mcp.Description("Transport request number, required for a transportable package")),
+			mcp.WithBoolean("skip_activation",
+				mcp.Description("Create without activating (default: false)")),
+		), s.handleAssignIAMAppToCatalog)
+	}
+}
+
+func (s *Server) handleCreateBusinessCatalog(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	args := request.GetArguments()
+
+	name, ok := args["name"].(string)
+	if !ok || name == "" {
+		return newToolResultError("name is required"), nil
+	}
+	description, ok := args["description"].(string)
+	if !ok || description == "" {
+		return newToolResultError("description is required"), nil
+	}
+	packageName, ok := args["package_name"].(string)
+	if !ok || packageName == "" {
+		return newToolResultError("package_name is required"), nil
+	}
+	iamApps := ""
+	if ia, ok := args["iam_apps"].(string); ok {
+		iamApps = strings.TrimSpace(ia)
+	}
+	attemptAssignment := false
+	if aa, ok := args["attempt_app_assignment"].(bool); ok {
+		attemptAssignment = aa
+	}
+
+	transport := ""
+	if t, ok := args["transport"].(string); ok {
+		transport = t
+	}
+	publish := true
+	if p, ok := args["publish"].(bool); ok {
+		publish = p
+	}
+	skipActivation := false
+	if sa, ok := args["skip_activation"].(bool); ok {
+		skipActivation = sa
+	}
+
+	var apps []adt.BusinessCatalogApp
+	for _, raw := range strings.Split(iamApps, ",") {
+		appID := strings.TrimSpace(raw)
+		if appID == "" {
+			continue
+		}
+		apps = append(apps, adt.BusinessCatalogApp{AppID: appID})
+	}
+
+	name = strings.ToUpper(name)
+	catalogURL := adt.BusinessCatalogURL(name)
+
+	// Steps are reported individually so a partial failure is diagnosable
+	// rather than collapsing into one opaque error.
+	steps := []string{}
+
+	if err := s.adtClient.CreateObject(ctx, adt.CreateObjectOptions{
+		ObjectType:  adt.ObjectTypeBusinessCatalog,
+		Name:        name,
+		Description: description,
+		PackageName: packageName,
+		Transport:   transport,
+	}); err != nil {
+		// A create that fails because the catalog is already there is not a
+		// failure of this call. It happens on any rerun after a later step
+		// broke, and demanding a manual delete first would be hostile.
+		//
+		// The typed ADT exception id is the reliable signal. The GET probe is
+		// only a backstop for a create that failed some other way after SAP had
+		// already persisted the object.
+		if !adt.IsResourceAlreadyExists(err) && !s.adtClient.BusinessCatalogExists(ctx, name) {
+			return newToolResultError(fmt.Sprintf("Failed to create business catalog: %v", err)), nil
+		}
+		steps = append(steps, "already existed, continuing")
+	} else {
+		steps = append(steps, "created")
+	}
+
+	// App assignment only runs when explicitly asked for, because the ADT
+	// resource is read-only. Skipping it keeps the run going to activation
+	// instead of aborting on a 405 and leaving an inactive catalog behind.
+	if attemptAssignment && len(apps) > 0 {
+		lock, err := s.adtClient.LockObject(ctx, catalogURL, "MODIFY")
+		if err != nil {
+			return newToolResultError(fmt.Sprintf(
+				"Catalog %s exists but could not be locked: %v", name, err)), nil
+		}
+		steps = append(steps, "locked")
+
+		assignVerb, assignErr := s.adtClient.AssignBusinessCatalogApps(ctx, name, lock.LockHandle, apps, transport)
+
+		// Release the lock whatever happened, so a failed assignment does not
+		// leave the catalog stuck for the next attempt.
+		if unlockErr := s.adtClient.UnlockObject(ctx, catalogURL, lock.LockHandle); unlockErr != nil {
+			steps = append(steps, fmt.Sprintf("unlock failed: %v", unlockErr))
+		} else {
+			steps = append(steps, "unlocked")
+		}
+
+		if assignErr != nil {
+			steps = append(steps, fmt.Sprintf("app assignment failed via %s: %v", assignVerb, assignErr))
+		} else {
+			steps = append(steps, fmt.Sprintf("assigned %d app(s) via %s", len(apps), assignVerb))
+		}
+	}
+
+	result := map[string]any{
+		"status":     "created",
+		"name":       name,
+		"object_url": catalogURL,
+		"apps":       iamApps,
+		"steps":      steps,
+	}
+
+	if !skipActivation {
+		activation, err := s.adtClient.Activate(ctx, catalogURL, name)
+		if err != nil {
+			result["status"] = "created_not_activated"
+			result["activation_error"] = err.Error()
+			result["next_step"] = "Activate the catalog, then verify with GetInactiveObjects."
+			output, _ := json.MarshalIndent(result, "", "  ")
+			return mcp.NewToolResultText(string(output)), nil
+		}
+		result["activation"] = activation
+		steps = append(steps, "activated")
+	}
+
+	if publish && !skipActivation {
+		err := s.adtClient.PublishBusinessCatalog(ctx, name)
+		switch {
+		case err != nil && isTimeout(err):
+			// Publishing is a job, and it routinely outlives the client
+			// deadline. Reporting that as an error makes a probably-successful
+			// publish look broken.
+			result["publish_status"] = "unknown"
+			result["publish_warning"] = "The publish request timed out waiting for a " +
+				"response. Publishing is asynchronous, so the job may still complete. " +
+				"Do not read this as a failure; re-read the catalog to see its status."
+			steps = append(steps, "publish submitted, response timed out")
+		case err != nil:
+			result["publish_error"] = err.Error()
+		default:
+			steps = append(steps, "published")
+		}
+	}
+
+	result["steps"] = steps
+	if len(apps) > 0 {
+		result["next_step_apps"] = fmt.Sprintf(
+			"Assign the app(s) with AssignIAMAppToCatalog(business_catalog=%s, iam_app=...): %s. "+
+				"The app must exist and be published first — CreateIAMApp does both.", name, iamApps)
+	}
+	result["next_step_role"] = fmt.Sprintf(
+		"Then add catalog %s to a business role in Maintain Business Roles and assign the role to a business user.", name)
+
+	output, _ := json.MarshalIndent(result, "", "  ")
+	return mcp.NewToolResultText(string(output)), nil
+}
+
+// handleCreateIAMApp creates an SIA6 IAM app, activates and publishes it.
+//
+// Publishing matters more than it looks: an unpublished app is invisible to
+// business catalog maintenance, and the Eclipse assignment wizard reports it as
+// not existing rather than as not published.
+func (s *Server) handleCreateIAMApp(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	args := request.GetArguments()
+
+	name, ok := args["name"].(string)
+	if !ok || name == "" {
+		return newToolResultError("name is required"), nil
+	}
+	description, ok := args["description"].(string)
+	if !ok || description == "" {
+		return newToolResultError("description is required"), nil
+	}
+	packageName, ok := args["package_name"].(string)
+	if !ok || packageName == "" {
+		return newToolResultError("package_name is required"), nil
+	}
+
+	appType, _ := args["app_type"].(string)
+	secondaryID, _ := args["secondary_id"].(string)
+	transport, _ := args["transport"].(string)
+	publish := true
+	if p, ok := args["publish"].(bool); ok {
+		publish = p
+	}
+	skipActivation := false
+	if sa, ok := args["skip_activation"].(bool); ok {
+		skipActivation = sa
+	}
+
+	name = strings.ToUpper(name)
+	appURL := adt.IAMAppURL(name)
+	steps := []string{}
+
+	if err := s.adtClient.CreateObject(ctx, adt.CreateObjectOptions{
+		ObjectType:  adt.ObjectTypeIAMApp,
+		Name:        name,
+		Description: description,
+		PackageName: packageName,
+		Transport:   transport,
+		AppType:     appType,
+		SecondaryID: secondaryID,
+	}); err != nil {
+		// Same reasoning as the catalog: a rerun after a later step failed must
+		// not be blocked by the object already being there.
+		if !adt.IsResourceAlreadyExists(err) && !s.adtClient.IAMAppExists(ctx, name) {
+			return newToolResultError(fmt.Sprintf("Failed to create IAM app: %v", err)), nil
+		}
+		steps = append(steps, "already existed, continuing")
+	} else {
+		steps = append(steps, "created")
+	}
+
+	result := map[string]any{
+		"status":     "created",
+		"name":       name,
+		"object_url": appURL,
+		"app_type":   strings.ToUpper(appType),
+	}
+
+	if !skipActivation {
+		activation, err := s.adtClient.Activate(ctx, appURL, name)
+		if err != nil {
+			result["status"] = "created_not_activated"
+			result["activation_error"] = err.Error()
+			result["next_step"] = "Activate the app, then verify with GetInactiveObjects."
+			result["steps"] = steps
+			output, _ := json.MarshalIndent(result, "", "  ")
+			return mcp.NewToolResultText(string(output)), nil
+		}
+		result["activation"] = activation
+		steps = append(steps, "activated")
+	}
+
+	if publish && !skipActivation {
+		status, err := s.adtClient.PublishIAMApp(ctx, name)
+		switch {
+		case err != nil && isTimeout(err):
+			// Publishing is a job. The client giving up on the response does not
+			// mean the job failed — PublishServiceBinding behaves the same way,
+			// and its timeout is routinely mistaken for an error. Observed on
+			// a live S/4HANA Cloud tenant: the first publish of an app answers promptly, a repeat
+			// one blocks past three minutes.
+			result["publish_status"] = "unknown"
+			result["publish_warning"] = "The publish request timed out waiting for a " +
+				"response. Publishing is asynchronous, so the job may still complete. " +
+				"Do not read this as a failure; re-read the app to see its status."
+			steps = append(steps, "publish submitted, response timed out")
+		case err != nil:
+			result["publish_error"] = err.Error()
+		case status == adt.IAMPublishStatusPublished:
+			steps = append(steps, "published")
+			result["publish_status"] = status
+		default:
+			// A 200 does not mean published. Report the status rather than
+			// letting an unpublished app look like a completed step.
+			result["publish_status"] = status
+			result["publish_warning"] = fmt.Sprintf(
+				"Publish returned status %q, not %q (published). The call succeeded but the "+
+					"app is not published. An app with no services or authorizations has "+
+					"nothing to publish.", status, adt.IAMPublishStatusPublished)
+			steps = append(steps, "publish returned "+status)
+		}
+	}
+
+	result["steps"] = steps
+	result["next_step_assign"] = fmt.Sprintf(
+		"Assign it with AssignIAMAppToCatalog(business_catalog=<catalog>, iam_app=%s).", name)
+
+	output, _ := json.MarshalIndent(result, "", "  ")
+	return mcp.NewToolResultText(string(output)), nil
+}
+
+// handleAssignIAMAppToCatalog creates the SIA7 assignment object linking a
+// business catalog to an IAM app.
+func (s *Server) handleAssignIAMAppToCatalog(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	args := request.GetArguments()
+
+	catalog, ok := args["business_catalog"].(string)
+	if !ok || catalog == "" {
+		return newToolResultError("business_catalog is required"), nil
+	}
+	app, ok := args["iam_app"].(string)
+	if !ok || app == "" {
+		return newToolResultError("iam_app is required"), nil
+	}
+	packageName, ok := args["package_name"].(string)
+	if !ok || packageName == "" {
+		return newToolResultError("package_name is required"), nil
+	}
+
+	catalog = strings.ToUpper(catalog)
+	app = strings.ToUpper(app)
+
+	name, _ := args["name"].(string)
+	if name == "" {
+		name = adt.DefaultAssignmentName(catalog, 1)
+	}
+	name = strings.ToUpper(name)
+
+	transport, _ := args["transport"].(string)
+	skipActivation := false
+	if sa, ok := args["skip_activation"].(bool); ok {
+		skipActivation = sa
+	}
+
+	assignURL := adt.CatalogAppAssignmentURL(name)
+	steps := []string{}
+
+	if err := s.adtClient.CreateObject(ctx, adt.CreateObjectOptions{
+		ObjectType:        adt.ObjectTypeCatalogAppAssignment,
+		Name:              name,
+		Description:       "Business Catalog to IAM App assignment",
+		PackageName:       packageName,
+		Transport:         transport,
+		BusinessCatalogID: catalog,
+		AppID:             app,
+	}); err != nil {
+		if !adt.IsResourceAlreadyExists(err) && !s.adtClient.CatalogAppAssignmentExists(ctx, name) {
+			return newToolResultError(fmt.Sprintf(
+				"Failed to create assignment %s (%s -> %s): %v", name, catalog, app, err)), nil
+		}
+		steps = append(steps, "already existed, continuing")
+	} else {
+		steps = append(steps, "created")
+	}
+
+	result := map[string]any{
+		"status":     "created",
+		"name":       name,
+		"object_url": assignURL,
+		// Deliberately NOT the requested catalog and app. ADT does not merge a
+		// payload into an object that already exists, so echoing the request
+		// back would describe an object this call never wrote. Read it instead.
+		"requested_business_catalog": catalog,
+		"requested_iam_app":          app,
+	}
+
+	if stored, err := s.adtClient.ReadCatalogAppAssignment(ctx, name); err != nil {
+		result["read_back_error"] = err.Error()
+		result["warning"] = "Could not read the assignment back. Do not assume it holds the requested app."
+	} else {
+		result["business_catalog"] = stored.CatalogID
+		result["iam_app"] = stored.AppID
+		if !strings.EqualFold(stored.AppID, app) || !strings.EqualFold(stored.CatalogID, catalog) {
+			result["status"] = "exists_with_different_content"
+			result["warning"] = fmt.Sprintf(
+				"Assignment %s already existed and holds catalog %s -> app %s, NOT the requested %s -> %s. "+
+					"ADT create does not overwrite. Delete the object and re-run, or pass a different name.",
+				name, stored.CatalogID, stored.AppID, catalog, app)
+		}
+	}
+
+	if !skipActivation {
+		activation, err := s.adtClient.Activate(ctx, assignURL, name)
+		if err != nil {
+			result["status"] = "created_not_activated"
+			result["activation_error"] = err.Error()
+			result["steps"] = steps
+			output, _ := json.MarshalIndent(result, "", "  ")
+			return mcp.NewToolResultText(string(output)), nil
+		}
+		result["activation"] = activation
+		steps = append(steps, "activated")
+	}
+
+	result["steps"] = steps
+	result["next_step_role"] = fmt.Sprintf(
+		"Add catalog %s to a business role in Maintain Business Roles, then assign that role to a "+
+			"business user in Maintain Business Users. Neither step is reachable over ADT.", catalog)
+
+	output, _ := json.MarshalIndent(result, "", "  ")
+	return mcp.NewToolResultText(string(output)), nil
+}
+
+// isTimeout reports whether an error is a client-side deadline rather than a
+// refusal by the backend. Kept deliberately simple: the transport wraps the
+// underlying error, so matching the text is more robust here than unwrapping to
+// a concrete type that may change.
+func isTimeout(err error) bool {
+	if err == nil {
+		return false
+	}
+	s := err.Error()
+	return strings.Contains(s, "context deadline exceeded") ||
+		strings.Contains(s, "Client.Timeout") ||
+		strings.Contains(s, "timeout")
+}

--- a/internal/mcp/tools_register.go
+++ b/internal/mcp/tools_register.go
@@ -75,6 +75,7 @@ func (s *Server) registerTools(mode string, disabledGroups string, toolsConfig m
 	s.registerSearchTools(shouldRegister)
 	s.registerDevTools(shouldRegister)
 	s.registerCRUDTools(shouldRegister)
+	s.registerIAMTools(shouldRegister)
 	s.registerClassIncludeTools(shouldRegister)
 	s.registerWorkflowTools(shouldRegister)
 	s.registerFileTools(shouldRegister)

--- a/pkg/adt/crud.go
+++ b/pkg/adt/crud.go
@@ -194,6 +194,18 @@ type CreateObjectOptions struct {
 	BindingType string `json:"bindingType,omitempty"`
 	// For SRVB: binding version ("V2" or "V4")
 	BindingVersion string `json:"bindingVersion,omitempty"`
+
+	// IAM options
+	// For SIA6: application type, e.g. "EXT" (external app) or "IBS"
+	// (generated business service). Defaults to EXT.
+	AppType string `json:"appType,omitempty"`
+	// For SIA6: the object the app stands for, e.g. the generated communication
+	// scenario on an IBS app. Empty for a plain external app.
+	SecondaryID string `json:"secondaryID,omitempty"`
+	// For SIA7: the business catalog receiving the app.
+	BusinessCatalogID string `json:"businessCatalogID,omitempty"`
+	// For SIA7: the IAM app being assigned.
+	AppID string `json:"appID,omitempty"`
 	// For SRVB: category ("0" for Web API, "1" for UI)
 	BindingCategory string `json:"bindingCategory,omitempty"`
 
@@ -206,6 +218,11 @@ type objectTypeInfo struct {
 	creationPath string
 	rootName     string
 	namespace    string
+	// bodyBuilder, when set, replaces the generic create payload for this type.
+	// Types whose ADT resource needs a nested <content> block register one from
+	// their own file, so a new type is additive rather than another branch in
+	// buildCreateObjectBody.
+	bodyBuilder func(opts CreateObjectOptions, typeInfo objectTypeInfo, responsible string) string
 }
 
 var objectTypes = map[CreatableObjectType]objectTypeInfo{
@@ -424,6 +441,11 @@ func buildCreateObjectBody(opts CreateObjectOptions, typeInfo objectTypeInfo, de
 	responsible := opts.Responsible
 	if responsible == "" {
 		responsible = defaultResponsible
+	}
+
+	// A type that registered its own builder owns its whole payload.
+	if typeInfo.bodyBuilder != nil {
+		return typeInfo.bodyBuilder(opts, typeInfo, responsible)
 	}
 
 	// For packages, use special structure with attributes element
@@ -887,11 +909,11 @@ func parsePublishResult(data []byte) (*PublishResult, error) {
 
 // CreateTableOptions defines options for creating a DDIC table.
 type CreateTableOptions struct {
-	Name          string       `json:"name"`          // Table name (uppercase, max 30 chars, must start with Z/Y)
-	Description   string       `json:"description"`   // Short description
-	Package       string       `json:"package"`       // Target package
-	Fields        []TableField `json:"fields"`        // Field definitions
-	Transport     string       `json:"transport,omitempty"` // Transport request (optional for $TMP)
+	Name          string       `json:"name"`                    // Table name (uppercase, max 30 chars, must start with Z/Y)
+	Description   string       `json:"description"`             // Short description
+	Package       string       `json:"package"`                 // Target package
+	Fields        []TableField `json:"fields"`                  // Field definitions
+	Transport     string       `json:"transport,omitempty"`     // Transport request (optional for $TMP)
 	DeliveryClass string       `json:"deliveryClass,omitempty"` // A=Application, C=Customizing, L=Temp, etc. (default: A)
 	TableCategory string       `json:"tableCategory,omitempty"` // TRANSPARENT (default), STRUCTURE, etc.
 }

--- a/pkg/adt/iam_sia1.go
+++ b/pkg/adt/iam_sia1.go
@@ -1,0 +1,288 @@
+package adt
+
+// Business catalog (ADT object type SIA1) support.
+//
+// A published RAP service binding on S/4HANA Cloud generates an IAM app, and
+// that app grants nothing until it sits in a business catalog that a business
+// role includes. Without this type the last step of a RAP stack cannot be
+// automated at all.
+//
+// Everything below was read out of a live S/4HANA Cloud tenant rather than
+// guessed. The ADT serialization for SIA1 is implemented as simple
+// transformations in package SR_APS_IAM_WBI_SIA1:
+//
+//	transformation SIA1          -> root element sia1:sia1, namespace
+//	                                http://www.sap.com/iam/sia1, includes
+//	                                SADT_MAIN_OBJECT for the adtcore header
+//	transformation SIA1_BUCAPPS  -> sia1:bucapps / sia1:bucapp with
+//	                                businessCatalogAppAssignmentID,
+//	                                businessCatalogID, appID and
+//	                                assignableRtypes
+//
+// and CL_APS_IAM_WBI_SIA1_WB_ACCESS registers the sub-resources:
+//
+//	/aps/cloud/iam/sia1/$bucapps{?name}   application/vnd.sap.adt.iam.bucapps+xml
+//	/aps/cloud/iam/sia1/$publish{?businessCatalogID}
+//	/aps/cloud/iam/sia1/$getScope{?name}
+//
+// The {?name} on $publish was wrong, and cost a release: the resource takes
+// businessCatalogID. None of these sub-resources appear in the ADT discovery
+// document at all, so the query parameter cannot be read from there — but ADT
+// names the one it wants when you get it wrong:
+//
+//	POST .../sia1/$publish?name=X  ->  400 "Parameter businessCatalogID could not be found."
+//
+// which is the cheapest way to discover the signature of an unlisted resource.
+
+import (
+	"context"
+	"encoding/xml"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+)
+
+// ObjectTypeBusinessCatalog is the IAM business catalog, ADT type SIA1.
+const ObjectTypeBusinessCatalog CreatableObjectType = "SIA1/BC"
+
+// BusinessCatalogPath is the ADT collection holding business catalogs.
+const BusinessCatalogPath = "/sap/bc/adt/aps/cloud/iam/sia1"
+
+// BucappsContentType is the media type CL_APS_IAM_WBI_SIA1_WB_ACCESS declares
+// for the $bucapps sub-resource.
+const BucappsContentType = "application/vnd.sap.adt.iam.bucapps+xml"
+
+// Registered from here rather than by editing the objectTypes literal in
+// crud.go, so this file can be added to a fork without touching shared code.
+//
+// Note that GetObjectURL in crud.go switches over known types and will return
+// an empty string for SIA1/BC. The only consequence is that CreateObject skips
+// its orphan-lock cleanup retry for this type. BusinessCatalogURL below gives
+// the URL for every other purpose.
+func init() {
+	objectTypes[ObjectTypeBusinessCatalog] = objectTypeInfo{
+		creationPath: BusinessCatalogPath,
+		rootName:     "sia1:sia1",
+		namespace:    `xmlns:sia1="http://www.sap.com/iam/sia1"`,
+	}
+}
+
+// BusinessCatalogURL returns the ADT URL of a business catalog. ADT lowercases
+// the object name in the path.
+func BusinessCatalogURL(name string) string {
+	return BusinessCatalogPath + "/" + strings.ToLower(name)
+}
+
+// IsResourceAlreadyExists reports whether an ADT error is the backend saying
+// the object is already there.
+//
+// ADT returns a typed exception id, ExceptionResourceAlreadyExists, alongside a
+// translated message. Match the id: the message text is localised and changes
+// between releases, the id does not.
+func IsResourceAlreadyExists(err error) bool {
+	if err == nil {
+		return false
+	}
+	return strings.Contains(err.Error(), "ExceptionResourceAlreadyExists")
+}
+
+// BusinessCatalogExists reports whether a business catalog is already present.
+//
+// Secondary to IsResourceAlreadyExists, for the case where a create failed for
+// some other reason after SAP had already persisted the object.
+//
+// Accept is */* deliberately. An ADT resource serves its own vnd.sap.adt media
+// type and answers 406 for anything it does not recognise, so a narrower Accept
+// turns an existing object into a false negative.
+func (c *Client) BusinessCatalogExists(ctx context.Context, name string) bool {
+	resp, err := c.RawGet(ctx, BusinessCatalogURL(name), "*/*")
+	if err != nil {
+		return false
+	}
+	return resp.StatusCode >= 200 && resp.StatusCode < 300
+}
+
+// requestWithVerbFallback sends a request and retries once with a different
+// method if ADT answers 405.
+//
+// The HTTP verbs of the SIA1 sub-resources are documented nowhere and are not
+// visible in the transformations or in the resource registration, which declare
+// only routes and content types. A first run against N4D showed $bucapps
+// rejecting POST with "Resource controller does not support method POST", so
+// the verb has to be discovered rather than assumed. 405 is an unambiguous
+// signal and the retry is bounded to one alternative, which beats hardcoding a
+// guess that then fails the same way on the next sub-resource.
+func (c *Client) requestWithVerbFallback(ctx context.Context, path string, primary, fallback string, opts *RequestOptions) (*Response, string, error) {
+	opts.Method = primary
+	resp, err := c.transport.Request(ctx, path, opts)
+	if err == nil {
+		return resp, primary, nil
+	}
+	if !strings.Contains(err.Error(), "status 405") {
+		return nil, primary, err
+	}
+
+	retryOpts := *opts
+	retryOpts.Method = fallback
+	resp, fallbackErr := c.transport.Request(ctx, path, &retryOpts)
+	if fallbackErr != nil {
+		return nil, fallback, fmt.Errorf("%s rejected with 405, %s also failed: %w", primary, fallback, fallbackErr)
+	}
+	return resp, fallback, nil
+}
+
+// BusinessCatalogApp is one IAM app assignment inside a business catalog.
+type BusinessCatalogApp struct {
+	// AppID is the IAM app, for example a generated
+	// ZUI_MY_SERVICE_O4_0001_XXXX_IBS.
+	AppID string
+	// AssignmentID is the app assignment ID. Leave empty to derive it from
+	// the catalog and app, which is what the workbench does.
+	AssignmentID string
+}
+
+// bucappsPayload mirrors transformation SIA1_BUCAPPS.
+type bucappsPayload struct {
+	XMLName xml.Name `xml:"sia1:bucapps"`
+	NS      string   `xml:"xmlns:sia1,attr"`
+	Apps    []bucapp `xml:"sia1:bucapp"`
+}
+
+type bucapp struct {
+	AssignmentID string `xml:"sia1:businessCatalogAppAssignmentID"`
+	CatalogID    string `xml:"sia1:businessCatalogID"`
+	AppID        string `xml:"sia1:appID"`
+}
+
+// AssignBusinessCatalogApps attempts to write IAM app assignments through the
+// $bucapps sub-resource.
+//
+// It does not work on S/4HANA Cloud 2602 and is not called by the
+// CreateBusinessCatalog tool. Keep it, gated, so a release that opens the
+// resource for writing needs a flag flip rather than a rewrite.
+//
+// The resource controller CL_APS_IAM_WBI_SIA1_BUCAPP redefines only `get`, so
+// every write verb returns 405 "Resource controller does not support method".
+// Both PUT and POST were confirmed rejected against the tenant. The main object
+// transformation carries no app list either, so no ADT route exists: the
+// Eclipse business catalog editor writes assignments through the workbench tool
+// UI protocol in CL_APS_IAM_WBI_SIA1_WB_TOOL_UI, not through ADT REST.
+//
+// The catalog must be locked by the caller. Returns the verb ADT accepted.
+func (c *Client) AssignBusinessCatalogApps(ctx context.Context, catalogName string, lockHandle string, apps []BusinessCatalogApp, transport string) (string, error) {
+	if catalogName == "" {
+		return "", fmt.Errorf("catalog name is required")
+	}
+	if lockHandle == "" {
+		return "", fmt.Errorf("lock handle is required: lock the catalog before writing assignments")
+	}
+	if len(apps) == 0 {
+		return "", fmt.Errorf("at least one app assignment is required")
+	}
+
+	catalogID := strings.ToUpper(catalogName)
+
+	// ObjectURL rather than Package: the catalog already exists at this point,
+	// so the gate resolves its package from object metadata. Omitting both
+	// fails closed with "requires either ObjectURL or Package" on any
+	// connection that configures AllowedPackages.
+	//
+	// That resolution issues a repository search between the caller's
+	// LockObject and this write. The search must run inside the stateful
+	// session, or ADT ends the session, drops the lock, and this POST comes
+	// back 423 "is not locked".
+	if err := c.checkMutation(ctx, MutationContext{
+		Op:        OpUpdate,
+		OpName:    "AssignBusinessCatalogApps",
+		ObjectURL: BusinessCatalogURL(catalogID),
+		Transport: transport,
+	}); err != nil {
+		return "", err
+	}
+
+	payload := bucappsPayload{
+		NS: "http://www.sap.com/iam/sia1",
+	}
+	for _, a := range apps {
+		if a.AppID == "" {
+			return "", fmt.Errorf("app assignment with an empty AppID")
+		}
+		assignmentID := a.AssignmentID
+		if assignmentID == "" {
+			assignmentID = catalogID + "_" + strings.ToUpper(a.AppID)
+		}
+		payload.Apps = append(payload.Apps, bucapp{
+			AssignmentID: assignmentID,
+			CatalogID:    catalogID,
+			AppID:        strings.ToUpper(a.AppID),
+		})
+	}
+
+	body, err := xml.MarshalIndent(payload, "", "  ")
+	if err != nil {
+		return "", fmt.Errorf("marshalling bucapps payload: %w", err)
+	}
+	body = append([]byte(xml.Header), body...)
+
+	params := url.Values{}
+	params.Set("name", catalogID)
+	params.Set("lockHandle", lockHandle)
+	if transport != "" {
+		params.Set("corrNr", transport)
+	}
+
+	// PUT first: the sub-resource replaces the whole assignment collection,
+	// and N4D answered POST with 405.
+	_, verb, err := c.requestWithVerbFallback(ctx, BusinessCatalogPath+"/$bucapps",
+		http.MethodPut, http.MethodPost, &RequestOptions{
+			Query:       params,
+			Body:        body,
+			ContentType: BucappsContentType,
+		})
+	if err != nil {
+		return verb, fmt.Errorf("writing app assignments to catalog %s: %w", catalogID, err)
+	}
+	return verb, nil
+}
+
+// PublishBusinessCatalog runs the local publish that makes an activated
+// catalog visible to role maintenance, the $publish sub-resource registered by
+// CL_APS_IAM_WBI_SIA1_WB_ACCESS.
+//
+// Publishing is asynchronous in the same way service binding publication is,
+// so a timeout here does not mean the job failed.
+//
+// PROVEN on a live S/4HANA Cloud tenant, 2026-08-13: this call timed out awaiting headers, and the
+// catalog subsequently appeared in Maintain Business Roles -> Add Business
+// Catalogs, where the same search had returned nothing beforehand. The job
+// completed server-side. Treat the timeout as "submitted", never as an error.
+func (c *Client) PublishBusinessCatalog(ctx context.Context, catalogName string) error {
+	if catalogName == "" {
+		return fmt.Errorf("catalog name is required")
+	}
+
+	if err := c.checkMutation(ctx, MutationContext{
+		Op:        OpUpdate,
+		OpName:    "PublishBusinessCatalog",
+		ObjectURL: BusinessCatalogURL(catalogName),
+	}); err != nil {
+		return err
+	}
+
+	params := url.Values{}
+	// businessCatalogID, not name. See the resource note at the top of this file.
+	params.Set("businessCatalogID", strings.ToUpper(catalogName))
+
+	// POST first: publish is an action, not a content replacement. $bucapps
+	// showed these sub-resources disagree about verbs, so fall back rather
+	// than fail the whole run on a 405.
+	_, _, err := c.requestWithVerbFallback(ctx, BusinessCatalogPath+"/$publish",
+		http.MethodPost, http.MethodPut, &RequestOptions{
+			Query: params,
+		})
+	if err != nil {
+		return fmt.Errorf("publishing catalog %s: %w", strings.ToUpper(catalogName), err)
+	}
+	return nil
+}

--- a/pkg/adt/iam_sia1_test.go
+++ b/pkg/adt/iam_sia1_test.go
@@ -1,0 +1,120 @@
+package adt
+
+import (
+	"encoding/xml"
+	"errors"
+	"strings"
+	"testing"
+)
+
+// The payload has to match transformation SIA1_BUCAPPS, which expects
+// sia1:bucapps holding sia1:bucapp entries with
+// businessCatalogAppAssignmentID, businessCatalogID and appID. Go's XML
+// encoder handles prefixed names by literal string, so assert the output
+// rather than trusting it.
+func TestBucappsPayloadSerialization(t *testing.T) {
+	payload := bucappsPayload{
+		NS: "http://www.sap.com/iam/sia1",
+		Apps: []bucapp{
+			{
+				AssignmentID: "ZBC_MY_CATALOG_ZUI_MY_SRV_O4_0001_XXXX_IBS",
+				CatalogID:    "ZBC_MY_CATALOG",
+				AppID:        "ZUI_MY_SRV_O4_0001_XXXX_IBS",
+			},
+		},
+	}
+
+	out, err := xml.MarshalIndent(payload, "", "  ")
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	got := string(out)
+
+	for _, want := range []string{
+		`<sia1:bucapps`,
+		`xmlns:sia1="http://www.sap.com/iam/sia1"`,
+		`<sia1:bucapp>`,
+		`<sia1:businessCatalogAppAssignmentID>ZBC_MY_CATALOG_ZUI_MY_SRV_O4_0001_XXXX_IBS</sia1:businessCatalogAppAssignmentID>`,
+		`<sia1:businessCatalogID>ZBC_MY_CATALOG</sia1:businessCatalogID>`,
+		`<sia1:appID>ZUI_MY_SRV_O4_0001_XXXX_IBS</sia1:appID>`,
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("payload missing %q\ngot:\n%s", want, got)
+		}
+	}
+}
+
+// SIA1/BC must land in the shared objectTypes registry via init, with the
+// creation path, root element and namespace read from the live system.
+func TestBusinessCatalogTypeRegistered(t *testing.T) {
+	info, ok := objectTypes[ObjectTypeBusinessCatalog]
+	if !ok {
+		t.Fatal("SIA1/BC is not registered in objectTypes")
+	}
+	if info.creationPath != "/sap/bc/adt/aps/cloud/iam/sia1" {
+		t.Errorf("creationPath = %q", info.creationPath)
+	}
+	if info.rootName != "sia1:sia1" {
+		t.Errorf("rootName = %q", info.rootName)
+	}
+	if !strings.Contains(info.namespace, "http://www.sap.com/iam/sia1") {
+		t.Errorf("namespace = %q", info.namespace)
+	}
+}
+
+func TestBusinessCatalogURLLowercasesName(t *testing.T) {
+	if got := BusinessCatalogURL("ZBC_MY_CATALOG"); got != "/sap/bc/adt/aps/cloud/iam/sia1/zbc_my_catalog" {
+		t.Errorf("BusinessCatalogURL = %q", got)
+	}
+}
+
+// A missing lock handle has to fail before any HTTP call: ADT rejects writes
+// to a sub-resource of an unlocked object, and a silent attempt would look
+// like a network fault instead of a caller mistake.
+func TestAssignBusinessCatalogAppsValidates(t *testing.T) {
+	c := NewClient("https://example.invalid", "u", "p")
+
+	cases := []struct {
+		name    string
+		catalog string
+		lock    string
+		apps    []BusinessCatalogApp
+		want    string
+	}{
+		{"no catalog", "", "LOCK", []BusinessCatalogApp{{AppID: "A"}}, "catalog name is required"},
+		{"no lock", "ZBC", "", []BusinessCatalogApp{{AppID: "A"}}, "lock handle is required"},
+		{"no apps", "ZBC", "LOCK", nil, "at least one app assignment is required"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := c.AssignBusinessCatalogApps(nil, tc.catalog, tc.lock, tc.apps, "")
+			if err == nil {
+				t.Fatal("expected an error")
+			}
+			if !strings.Contains(err.Error(), tc.want) {
+				t.Errorf("error = %q, want it to contain %q", err.Error(), tc.want)
+			}
+		})
+	}
+}
+
+// The typed exception id is what distinguishes "already there" from a real
+// failure. Matching the localised message text instead would break on a
+// non-English system or a release that rewords it.
+func TestIsResourceAlreadyExists(t *testing.T) {
+	real := errors.New(`creating object: ADT API error: status 400 at /sap/bc/adt/aps/cloud/iam/sia1: ` +
+		`<exc:exception><type id="ExceptionResourceAlreadyExists"/>` +
+		`<message lang="EN">Resource Business Catalog ZBC_MY_CATALOG does already exist.</message></exc:exception>`)
+	if !IsResourceAlreadyExists(real) {
+		t.Error("did not recognise ExceptionResourceAlreadyExists")
+	}
+
+	other := errors.New(`ADT API error: status 405: <type id="ExceptionMethodNotSupported"/>`)
+	if IsResourceAlreadyExists(other) {
+		t.Error("matched an unrelated ADT exception")
+	}
+	if IsResourceAlreadyExists(nil) {
+		t.Error("matched nil")
+	}
+}

--- a/pkg/adt/iam_sia6.go
+++ b/pkg/adt/iam_sia6.go
@@ -1,0 +1,187 @@
+package adt
+
+// IAM app (ADT object type SIA6) support.
+//
+// Publishing a RAP service binding on S/4HANA Cloud does NOT create an IAM app.
+// It creates an IAM *business service* — an SIA6 whose appType is IBS and whose
+// secondaryID names the generated communication scenario — plus the scenario
+// itself (SCO2). The IAM app that a business catalog can hold is a separate
+// SIA6 that a developer creates, normally with appType EXT for an application
+// served outside the system, such as a Fiori app on BTP Cloud Foundry.
+//
+// That distinction is the reason the Eclipse "Business Catalog IAM App
+// Assignment" wizard answers
+//
+//	IAM App 'ZUI_..._O4_0001_G4BA_IBS' does not exist
+//
+// for an object that plainly exists and that the same tree lists under "IAM
+// Apps": the wizard wants an assignable app, and a generated business service
+// is not one.
+//
+// The payload below was read from a live tenant (a live S/4HANA Cloud tenant, 2026-08-13) rather
+// than guessed:
+//
+//	GET /sap/bc/adt/aps/cloud/iam/sia6/<name>
+//	-> root sia6:sia6, namespace http://www.sap.com/iam/sia6, adtcore header,
+//	   adtcore:packageRef, then sia6:content with appID, appType, ui5AppId,
+//	   transactionCode, scopeDependent, providerClass, secondaryID, services,
+//	   commonAuthorization:auths/restrictions, appconfigs and pluginConfigs.
+//
+// Only the identifying subset is written on create. The workbench fills
+// pluginConfigs itself, and both a generated IBS app and a hand-made EXT app
+// were observed with an empty <sia6:services/>, so services is not required to
+// create the object.
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+)
+
+// ObjectTypeIAMApp is the IAM app, ADT type SIA6.
+const ObjectTypeIAMApp CreatableObjectType = "SIA6/AP"
+
+// IAMAppPath is the ADT collection holding IAM apps.
+const IAMAppPath = "/sap/bc/adt/aps/cloud/iam/sia6"
+
+// IAMAppTypeExternal is the app type for an application served outside this
+// system, which is what a Fiori app deployed to BTP is.
+const IAMAppTypeExternal = "EXT"
+
+// IAMPublishContentType is the media type the publish resource declares in the
+// ADT discovery document.
+const IAMPublishContentType = "application/vnd.sap.adt.iam.publishing+xml"
+
+// Publishing status values returned in sia6:publishingStatusText.
+const (
+	IAMPublishStatusPublished   = "p"
+	IAMPublishStatusUnpublished = "u"
+)
+
+func init() {
+	objectTypes[ObjectTypeIAMApp] = objectTypeInfo{
+		creationPath: IAMAppPath,
+		rootName:     "sia6:sia6",
+		namespace:    `xmlns:sia6="http://www.sap.com/iam/sia6"`,
+		bodyBuilder:  buildIAMAppBody,
+	}
+}
+
+// IAMAppURL returns the ADT URL of an IAM app. ADT lowercases the object name
+// in the path.
+func IAMAppURL(name string) string {
+	return IAMAppPath + "/" + strings.ToLower(name)
+}
+
+// IAMAppExists reports whether an IAM app is already present.
+//
+// Accept is */* for the same reason as BusinessCatalogExists: an ADT resource
+// serves its own vnd.sap.adt media type and answers 406 to anything else, so a
+// narrower Accept turns an existing object into a false negative.
+func (c *Client) IAMAppExists(ctx context.Context, name string) bool {
+	resp, err := c.RawGet(ctx, IAMAppURL(name), "*/*")
+	if err != nil {
+		return false
+	}
+	return resp.StatusCode >= 200 && resp.StatusCode < 300
+}
+
+func buildIAMAppBody(opts CreateObjectOptions, typeInfo objectTypeInfo, responsible string) string {
+	appType := strings.ToUpper(opts.AppType)
+	if appType == "" {
+		appType = IAMAppTypeExternal
+	}
+	name := strings.ToUpper(opts.Name)
+
+	secondary := ""
+	if opts.SecondaryID != "" {
+		secondary = fmt.Sprintf("\n    <sia6:secondaryID>%s</sia6:secondaryID>",
+			escapeXML(strings.ToUpper(opts.SecondaryID)))
+	}
+
+	return fmt.Sprintf(`<?xml version="1.0" encoding="UTF-8"?>
+<%s %s xmlns:adtcore="http://www.sap.com/adt/core"
+  adtcore:description="%s"
+  adtcore:name="%s"
+  adtcore:type="SIA6"
+  adtcore:responsible="%s"
+  adtcore:masterLanguage="EN"
+  adtcore:language="EN">
+  <adtcore:packageRef adtcore:name="%s"/>
+  <sia6:content>
+    <sia6:appID>%s</sia6:appID>
+    <sia6:appType>%s</sia6:appType>
+    <sia6:scopeDependent>false</sia6:scopeDependent>%s
+    <sia6:services/>
+  </sia6:content>
+</%s>`,
+		typeInfo.rootName, typeInfo.namespace,
+		escapeXML(opts.Description),
+		name,
+		responsible,
+		strings.ToUpper(opts.PackageName),
+		name,
+		appType,
+		secondary,
+		typeInfo.rootName)
+}
+
+// PublishIAMApp runs the "Publish Locally" action for an IAM app and returns
+// the publishing status ADT reports.
+//
+// The request form was read out of the ADT discovery document rather than
+// guessed, after an earlier version modelled on the SIA1 catalog resource
+// returned HTTP 500 (SY/530). Three things differ from SIA1:
+//
+//	path        .../iam/sia6/publish     not $publish
+//	parameter   ?application=<NAME>      not ?name=<NAME>
+//	content     application/vnd.sap.adt.iam.publishing+xml, body empty
+//
+// Discovery registers it as:
+//
+//	<app:collection href="/sap/bc/adt/aps/cloud/iam/sia6/publish">
+//	  <atom:title>Publish Locally</atom:title>
+//	  <app:accept>application/vnd.sap.adt.iam.publishing+xml</app:accept>
+//
+// with no template links, which is why the object goes in the query string and
+// not in the body. Getting the parameter name wrong is worth recognising: ADT
+// answers "Parameter application could not be found", which names the parameter
+// it wanted.
+//
+// Returns the status text: "p" published, "u" unpublished. A 200 does NOT mean
+// the app is published — an app that has nothing to publish comes back "u", so
+// callers should report the status rather than assume success. Observed on the tenant
+// 080, 2026-08-13: an app published through Eclipse returned "p", while a
+// freshly created one with no services returned "u" on repeated calls.
+//
+// The call can be slow; a second consecutive publish was seen to hang past
+// three minutes.
+func (c *Client) PublishIAMApp(ctx context.Context, appName string) (string, error) {
+	if appName == "" {
+		return "", fmt.Errorf("IAM app name is required")
+	}
+
+	if err := c.checkMutation(ctx, MutationContext{
+		Op:        OpUpdate,
+		OpName:    "PublishIAMApp",
+		ObjectURL: IAMAppURL(appName),
+	}); err != nil {
+		return "", err
+	}
+
+	params := url.Values{}
+	params.Set("application", strings.ToUpper(appName))
+
+	resp, err := c.transport.Request(ctx, IAMAppPath+"/publish", &RequestOptions{
+		Method:      http.MethodPost,
+		Query:       params,
+		ContentType: IAMPublishContentType,
+		Accept:      "*/*",
+	})
+	if err != nil {
+		return "", fmt.Errorf("publishing IAM app %s: %w", strings.ToUpper(appName), err)
+	}
+	return firstXMLValue(string(resp.Body), "sia6:publishingStatusText"), nil
+}

--- a/pkg/adt/iam_sia7.go
+++ b/pkg/adt/iam_sia7.go
@@ -1,0 +1,168 @@
+package adt
+
+// Business catalog IAM app assignment (ADT object type SIA7) support.
+//
+// This is the object that puts an IAM app into a business catalog, and it is
+// the piece that makes a published RAP UI service reachable by a business user:
+//
+//	service binding (published)
+//	  -> IAM business service   SIA6, appType IBS, generated
+//	       -> IAM app           SIA6, appType EXT, created by hand, published
+//	            -> catalog      SIA1
+//	                 + THIS     SIA7, catalog + app
+//	                      -> business role -> business user
+//
+// iam_sia1.go concluded that assignments "cannot be done over ADT" because the
+// SIA1 $bucapps sub-resource implements only GET and answers 405 to every write
+// verb. The observation is correct and the conclusion was not: Eclipse does not
+// write $bucapps either. It creates a first-class SIA7 object, which is an
+// ordinary ADT create against its own collection.
+//
+// Payload read from a live tenant (a live S/4HANA Cloud tenant, 2026-08-13):
+//
+//	GET /sap/bc/adt/aps/cloud/iam/sia7/<name>
+//	-> root sia7:sia7, namespace http://www.sap.com/iam/sia7, adtcore header,
+//	   adtcore:packageRef, then sia7:content with
+//	   businessCatalogAppAssignmentID, businessCatalogID, appID, roleChange,
+//	   catalogChange, groupChange and chipID.
+//
+// chipID is deliberately not written. The observed value carried a generated
+// suffix — X-SAP-UI2-PAGE:X-SAP-UI2-CATALOGPAGE:<catalog>:<opaque> — that only
+// the backend can mint, so sending a fabricated one is worse than omitting it.
+// The three *Change flags were all "A" on a freshly created assignment.
+//
+// IMPORTANT: create against an existing assignment REPLACES it. ADT does not
+// raise ExceptionResourceAlreadyExists for SIA7 the way it does for most object
+// types — it overwrites the content and mints a fresh chipID. Verified on the tenant
+// 080, 2026-08-13: re-creating ZBC_MY_CATALOG_0001 with a different appID
+// changed both the appID and adtcore:createdAt, and issued a new chipID suffix.
+//
+// So this is an upsert in practice. Callers must not assume an existing
+// assignment is safe from a create, and the "already existed" branch in the
+// handler is effectively unreachable for this type.
+
+import (
+	"context"
+	"fmt"
+	"strings"
+)
+
+// ObjectTypeCatalogAppAssignment is the business catalog IAM app assignment,
+// ADT type SIA7.
+const ObjectTypeCatalogAppAssignment CreatableObjectType = "SIA7/AS"
+
+// CatalogAppAssignmentPath is the ADT collection holding the assignments.
+const CatalogAppAssignmentPath = "/sap/bc/adt/aps/cloud/iam/sia7"
+
+func init() {
+	objectTypes[ObjectTypeCatalogAppAssignment] = objectTypeInfo{
+		creationPath: CatalogAppAssignmentPath,
+		rootName:     "sia7:sia7",
+		namespace:    `xmlns:sia7="http://www.sap.com/iam/sia7"`,
+		bodyBuilder:  buildCatalogAppAssignmentBody,
+	}
+}
+
+// CatalogAppAssignmentURL returns the ADT URL of an assignment. ADT lowercases
+// the object name in the path.
+func CatalogAppAssignmentURL(name string) string {
+	return CatalogAppAssignmentPath + "/" + strings.ToLower(name)
+}
+
+// CatalogAppAssignmentExists reports whether an assignment is already present.
+func (c *Client) CatalogAppAssignmentExists(ctx context.Context, name string) bool {
+	resp, err := c.RawGet(ctx, CatalogAppAssignmentURL(name), "*/*")
+	if err != nil {
+		return false
+	}
+	return resp.StatusCode >= 200 && resp.StatusCode < 300
+}
+
+// DefaultAssignmentName returns the name the workbench gives an assignment:
+// the catalog followed by a four digit sequence number.
+func DefaultAssignmentName(catalogID string, sequence int) string {
+	return fmt.Sprintf("%s_%04d", strings.ToUpper(catalogID), sequence)
+}
+
+func buildCatalogAppAssignmentBody(opts CreateObjectOptions, typeInfo objectTypeInfo, responsible string) string {
+	name := strings.ToUpper(opts.Name)
+	description := opts.Description
+	if description == "" {
+		description = "Business Catalog to IAM App assignment"
+	}
+
+	return fmt.Sprintf(`<?xml version="1.0" encoding="UTF-8"?>
+<%s %s xmlns:adtcore="http://www.sap.com/adt/core"
+  adtcore:description="%s"
+  adtcore:name="%s"
+  adtcore:type="SIA7"
+  adtcore:responsible="%s"
+  adtcore:masterLanguage="EN"
+  adtcore:language="EN">
+  <adtcore:packageRef adtcore:name="%s"/>
+  <sia7:content>
+    <sia7:businessCatalogAppAssignmentID>%s</sia7:businessCatalogAppAssignmentID>
+    <sia7:businessCatalogID>%s</sia7:businessCatalogID>
+    <sia7:appID>%s</sia7:appID>
+    <sia7:roleChange>A</sia7:roleChange>
+    <sia7:catalogChange>A</sia7:catalogChange>
+    <sia7:groupChange>A</sia7:groupChange>
+  </sia7:content>
+</%s>`,
+		typeInfo.rootName, typeInfo.namespace,
+		escapeXML(description),
+		name,
+		responsible,
+		strings.ToUpper(opts.PackageName),
+		name,
+		escapeXML(strings.ToUpper(opts.BusinessCatalogID)),
+		escapeXML(strings.ToUpper(opts.AppID)),
+		typeInfo.rootName)
+}
+
+// CatalogAppAssignment is the stored content of an SIA7 object.
+type CatalogAppAssignment struct {
+	AssignmentID string
+	CatalogID    string
+	AppID        string
+}
+
+// ReadCatalogAppAssignment returns what an assignment actually contains.
+//
+// Needed because create is not idempotent in the way it first appears: ADT
+// answers an existing object with ExceptionResourceAlreadyExists and does not
+// merge the payload, so a caller that treats "already exists" as success and
+// then reports its own request values is describing an object it never wrote.
+// Read the object instead of trusting the request.
+func (c *Client) ReadCatalogAppAssignment(ctx context.Context, name string) (*CatalogAppAssignment, error) {
+	resp, err := c.RawGet(ctx, CatalogAppAssignmentURL(name), "*/*")
+	if err != nil {
+		return nil, err
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return nil, fmt.Errorf("reading assignment %s: status %d", strings.ToUpper(name), resp.StatusCode)
+	}
+	body := string(resp.Body)
+	return &CatalogAppAssignment{
+		AssignmentID: firstXMLValue(body, "sia7:businessCatalogAppAssignmentID"),
+		CatalogID:    firstXMLValue(body, "sia7:businessCatalogID"),
+		AppID:        firstXMLValue(body, "sia7:appID"),
+	}, nil
+}
+
+// firstXMLValue pulls the text of the first <tag>...</tag> out of an ADT
+// response. Deliberately not a full parse: these resources return a large
+// document with several namespaces and only three values are wanted.
+func firstXMLValue(doc, tag string) string {
+	open, close := "<"+tag+">", "</"+tag+">"
+	i := strings.Index(doc, open)
+	if i < 0 {
+		return ""
+	}
+	rest := doc[i+len(open):]
+	j := strings.Index(rest, close)
+	if j < 0 {
+		return ""
+	}
+	return rest[:j]
+}

--- a/pkg/adt/raw.go
+++ b/pkg/adt/raw.go
@@ -1,0 +1,36 @@
+package adt
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"strings"
+)
+
+// RawGet performs an authenticated read-only GET against an arbitrary ADT
+// path and returns the status, headers and body untouched.
+//
+// It exists so that object types vsp does not model yet can be inspected
+// against a live system: the ADT discovery document names every collection
+// with its accepted content types, and reading one instance of an unmodelled
+// type reveals the XML root element and namespace that a create request has
+// to send. Both are needed before a new type can be added to the objectTypes
+// registry in crud.go, and neither is documented by SAP.
+//
+// The method is deliberately GET only. It performs no mutation-policy check
+// because it cannot mutate: any attempt to pass a different verb is rejected
+// rather than forwarded. Writes belong in typed operations that validate
+// their payload and handle activation, not in a generic escape hatch.
+func (c *Client) RawGet(ctx context.Context, path string, accept string) (*Response, error) {
+	if !strings.HasPrefix(path, "/") {
+		return nil, fmt.Errorf("path must be absolute and begin with /, got %q", path)
+	}
+	if strings.Contains(path, "://") {
+		return nil, fmt.Errorf("path must be a path on the configured system, not a full URL: %q", path)
+	}
+
+	return c.transport.Request(ctx, path, &RequestOptions{
+		Method: http.MethodGet,
+		Accept: accept,
+	})
+}

--- a/pkg/adt/transport.go
+++ b/pkg/adt/transport.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/http"
 	"strings"
+	"sync"
 )
 
 // --- Transport Types ---
@@ -46,15 +47,15 @@ type UserTransports struct {
 
 // TransportInfo represents information about an object's transport status
 type TransportInfo struct {
-	PGMID          string             `json:"pgmid"`
-	Object         string             `json:"object"`
-	ObjectName     string             `json:"objectName"`
-	Operation      string             `json:"operation"`
-	DevClass       string             `json:"devClass"`
-	Recording      string             `json:"recording"`
-	Transports     []TransportRequest `json:"transports,omitempty"`
-	LockedByUser   string             `json:"lockedByUser,omitempty"`
-	LockedInTask   string             `json:"lockedInTask,omitempty"`
+	PGMID        string             `json:"pgmid"`
+	Object       string             `json:"object"`
+	ObjectName   string             `json:"objectName"`
+	Operation    string             `json:"operation"`
+	DevClass     string             `json:"devClass"`
+	Recording    string             `json:"recording"`
+	Transports   []TransportRequest `json:"transports,omitempty"`
+	LockedByUser string             `json:"lockedByUser,omitempty"`
+	LockedInTask string             `json:"lockedInTask,omitempty"`
 }
 
 const (
@@ -113,7 +114,7 @@ func parseUserTransports(data []byte) (*UserTransports, error) {
 		Tasks  []task `xml:"task"`
 	}
 	type target struct {
-		Name      string    `xml:"name,attr"`
+		Name       string `xml:"name,attr"`
 		Modifiable struct {
 			Requests []request `xml:"request"`
 		} `xml:"modifiable"`
@@ -271,7 +272,14 @@ func (c *Client) CreateTransport(ctx context.Context, objectURL string, descript
 		return "", err
 	}
 
-	owner := strings.ToUpper(c.config.Username)
+	// Not config.Username: it is empty on a browser-SSO connection, and an
+	// empty tm:owner makes ADT reject the whole request. See CurrentUser.
+	owner := c.CurrentUser(ctx)
+	if owner == "" {
+		return "", fmt.Errorf("cannot determine the transport owner: no username is " +
+			"configured and ADT did not report one. Transport creation needs an owner " +
+			"for tm:task.")
+	}
 
 	body := fmt.Sprintf(`<?xml version="1.0" encoding="UTF-8"?>
 <tm:root xmlns:tm="http://www.sap.com/cts/adt/tm" tm:useraction="newrequest">
@@ -336,9 +344,9 @@ func parseReleaseResult(data []byte) ([]string, error) {
 		Text string `xml:"shortText,attr"`
 	}
 	type report struct {
-		Reporter  string    `xml:"reporter,attr"`
-		Status    string    `xml:"status,attr"`
-		Messages  []message `xml:"checkMessageList>checkMessage"`
+		Reporter string    `xml:"reporter,attr"`
+		Status   string    `xml:"status,attr"`
+		Messages []message `xml:"checkMessageList>checkMessage"`
 	}
 	type root struct {
 		Reports []report `xml:"releasereports>checkReport"`
@@ -368,8 +376,8 @@ type TransportSummary struct {
 	Number      string `json:"number"`
 	Owner       string `json:"owner"`
 	Description string `json:"description"`
-	Type        string `json:"type"`       // K=Workbench, W=Customizing, S=Task
-	Status      string `json:"status"`     // D=Modifiable, R=Released
+	Type        string `json:"type"`   // K=Workbench, W=Customizing, S=Task
+	Status      string `json:"status"` // D=Modifiable, R=Released
 	StatusText  string `json:"statusText"`
 	Target      string `json:"target"`
 	TargetDesc  string `json:"targetDesc"`
@@ -398,8 +406,8 @@ type TransportTaskV2 struct {
 
 // TransportObjectV2 represents an object in a transport (extended version)
 type TransportObjectV2 struct {
-	PgmID    string `json:"pgmid"`  // R3TR, LIMU, CORR
-	Type     string `json:"type"`   // PROG, CLAS, DEVC, etc.
+	PgmID    string `json:"pgmid"` // R3TR, LIMU, CORR
+	Type     string `json:"type"`  // PROG, CLAS, DEVC, etc.
 	Name     string `json:"name"`
 	WBType   string `json:"wbtype"` // PROG/P, CLAS/OC, etc.
 	Info     string `json:"info"`   // "Program", "Class", etc.
@@ -481,12 +489,12 @@ func (c *Client) listTransportsViaSQL(ctx context.Context, user string) ([]Trans
 	var transports []TransportSummary
 	for _, row := range result.Rows {
 		tr := TransportSummary{
-			Number:     getString(row, "TRKORR"),
-			Owner:      getString(row, "AS4USER"),
+			Number:      getString(row, "TRKORR"),
+			Owner:       getString(row, "AS4USER"),
 			Description: getString(row, "AS4TEXT"),
-			Type:       getString(row, "TRFUNCTION"),
-			Status:     getString(row, "TRSTATUS"),
-			Target:     getString(row, "TARSYSTEM"),
+			Type:        getString(row, "TRFUNCTION"),
+			Status:      getString(row, "TRSTATUS"),
+			Target:      getString(row, "TARSYSTEM"),
 		}
 
 		// Map status code to text
@@ -742,7 +750,12 @@ func (c *Client) CreateTransportV2(ctx context.Context, opts CreateTransportOpti
 		reqType = "W"
 	}
 
-	owner := strings.ToUpper(c.config.Username)
+	// Same reason as CreateTransport: config.Username is empty under browser SSO.
+	owner := c.CurrentUser(ctx)
+	if owner == "" {
+		return "", fmt.Errorf("cannot determine the transport owner: no username is " +
+			"configured and ADT did not report one")
+	}
 
 	body := fmt.Sprintf(`<?xml version="1.0" encoding="UTF-8"?>
 <tm:root xmlns:tm="http://www.sap.com/cts/adt/tm" tm:useraction="newrequest">
@@ -872,3 +885,73 @@ func (c *Client) DeleteTransport(ctx context.Context, number string) error {
 }
 
 // escapeXMLAttr is defined in ui5.go
+
+// resolvedUser caches the username ADT reports per base URL, so the lookup
+// happens once per process rather than on every transport operation.
+var (
+	resolvedUserMu sync.RWMutex
+	resolvedUser   = map[string]string{}
+)
+
+// CurrentUser returns the user ADT sees for this session.
+//
+// Config.Username is empty on a browser-SSO connection: the session is a
+// cookie, and nobody ever typed a user name. Transport creation puts the user
+// in tm:task@tm:owner, so an empty value reaches ADT and it answers
+//
+//	400 ExceptionInvalidData "Check of condition failed"
+//	XML_PATH tm:root(1)tm:request(1)tm:task(1)
+//
+// which names the task element but not the reason, and reads as a malformed
+// request rather than a missing user.
+//
+// GET /sap/bc/adt/cts/transportrequests answers with a tm:root whose
+// adtcore:name is the caller. That is the same resource transport creation
+// posts to, so it needs no extra authorization and cannot disagree about who
+// the session belongs to. Verified on a live S/4HANA Cloud tenant, 2026-08-13:
+//
+//	<tm:root adtcore:name="DEVELOPER" adtcore:createdBy="DEVELOPER" .../>
+//
+// Returns "" when the user cannot be determined; callers should treat that as
+// "carry on with what the config had" rather than as a hard failure.
+func (c *Client) CurrentUser(ctx context.Context) string {
+	if u := strings.ToUpper(strings.TrimSpace(c.config.Username)); u != "" {
+		return u
+	}
+
+	key := c.config.BaseURL
+	resolvedUserMu.RLock()
+	cached, ok := resolvedUser[key]
+	resolvedUserMu.RUnlock()
+	if ok {
+		return cached
+	}
+
+	user := ""
+	if resp, err := c.RawGet(ctx, "/sap/bc/adt/cts/transportrequests", "*/*"); err == nil &&
+		resp.StatusCode >= 200 && resp.StatusCode < 300 {
+		user = strings.ToUpper(firstXMLAttr(string(resp.Body), "adtcore:name"))
+	}
+
+	resolvedUserMu.Lock()
+	resolvedUser[key] = user
+	resolvedUserMu.Unlock()
+	return user
+}
+
+// firstXMLAttr returns the value of the first occurrence of an attribute.
+// Deliberately not a full parse: the CTS root element carries several
+// namespaces and only one value is wanted.
+func firstXMLAttr(doc, attr string) string {
+	needle := attr + `="`
+	i := strings.Index(doc, needle)
+	if i < 0 {
+		return ""
+	}
+	rest := doc[i+len(needle):]
+	j := strings.Index(rest, `"`)
+	if j < 0 {
+		return ""
+	}
+	return rest[:j]
+}


### PR DESCRIPTION
Three related changes. The first two are bugs that make transport and package creation impossible on a browser-authenticated connection; the third adds the ADT object types needed to finish a RAP stack.

Everything here was read from a live S/4HANA Cloud tenant rather than inferred, and each behaviour note in the source says how it was established.

## 1. Transport owner is empty under browser SSO

`CreateTransport`/`CreateTransportV2` put `config.Username` into `tm:task@tm:owner`. With cookie-based SSO that value is empty, and ADT answers:

```
400 ExceptionInvalidData "Check of condition failed"
XML_PATH tm:root(1)tm:request(1)tm:task(1)
```

which names the element but not the reason, and reads as a malformed request rather than a missing user. Package creation goes with it, because a package outside `$TMP` needs a transport even when its software component has change recording off.

`CurrentUser` resolves the user from `GET /sap/bc/adt/cts/transportrequests`, whose root carries `adtcore:name`. I picked that endpoint because it is the same resource transport creation posts to — no extra authorization, and it cannot disagree about whose session it is. `config.Username` still wins when set, so password connections are unchanged.

## 2. Package guard refused a valid case

The guard assumed any non-`$` package needs a transport. When a software component is named it now defers to ADT, which is the authority and returns a specific error when a transport really is required.

## 3. IAM authorization chain

Publishing a RAP UI service binding is not enough to make it reachable. The generated IAM business service grants nothing until an IAM app references it, a business catalog holds that app, and a business role includes the catalog.

Adds `SIA1` (business catalog), `SIA6` (IAM app) and `SIA7` (catalog-to-app assignment), exposed as `CreateBusinessCatalog`, `CreateIAMApp` and `AssignIAMAppToCatalog`. `objectTypeInfo` gains an optional `bodyBuilder` so a type needing a nested `<content>` block owns its payload from its own file rather than adding another branch to `buildCreateObjectBody`.

Four findings worth flagging to a reviewer:

- **The assignment is a first-class `SIA7` object**, not the `SIA1` `$bucapps` sub-resource. `$bucapps` implements only `GET` and answers 405 to every write verb, which is easy to read as "assignments cannot be done over ADT". Eclipse does not write `$bucapps` either.
- **The two publish resources do not mirror each other.** `SIA6` is `publish` (no `$`), parameter `application`, content type `application/vnd.sap.adt.iam.publishing+xml`. `SIA1` is `$publish`, parameter `businessCatalogID`. Only `SIA6` appears in the discovery document; the `SIA1` signature came from ADT naming the parameter it wanted when given a wrong one.
- **Publishing is asynchronous** and routinely outlives the client deadline, like service binding publication. A timeout is reported as submitted rather than as an error — a catalog was confirmed published after its request timed out. A 200 is not proof either: `publishingStatusText` returns `p` or `u`.
- **`SIA7` create is an upsert.** ADT raises no `ExceptionResourceAlreadyExists` and silently replaces the assignment with a fresh `chipID`, so `AssignIAMAppToCatalog` reads the object back and reports the stored values, keeping the caller's input under `requested_*`.

Business roles and their assignment to users stay manual — Fiori applications with no ADT object behind them.

## Known gap

`publishingStatusText` returns `u` for a freshly created app with no services, on repeated calls, and I have not established why. It is documented as observed behaviour rather than explained, and the handler reports the status instead of assuming success.

## Verification

Against a live tenant: transport created; package created on it, read back and deleted; business catalog, IAM app and catalog assignment created, activated and read back independently; catalog publish confirmed to complete after the client timed out.

`go build ./...`, `go vet` and `go test ./pkg/adt/` all pass.