### PR TITLE
fix: harden write safety, ADT sessions, and result verification

### DIFF
--- a/cmd/vsp/cli.go
+++ b/cmd/vsp/cli.go
@@ -45,6 +45,8 @@ type systemParams struct {
 
 	Cache     bool
 	CachePath string
+
+	Safety adt.SafetyConfig
 }
 
 // resolveSystemParams resolves system parameters from --system flag or env vars.
@@ -106,6 +108,7 @@ func resolveSystemParams(cmd *cobra.Command) (*systemParams, error) {
 			TransportAttribute: sys.TransportAttribute,
 			Cache:              sys.Cache,
 			CachePath:          sys.CachePath,
+			Safety:             resolveCLISafety(cmd, sys),
 		}, nil
 	}
 
@@ -137,7 +140,65 @@ func resolveSystemParams(cmd *cobra.Command) (*systemParams, error) {
 		TransportAttribute: resolveTransportAttributeFromEnv(),
 		Cache:              cacheEnabled,
 		CachePath:          cachePath,
+		Safety:             resolveCLISafety(cmd, nil),
 	}, nil
+}
+
+// resolveCLISafety merges a system profile with explicitly supplied root flags
+// and SAP_* environment variables. Explicit CLI/environment settings win over
+// .vsp.json; otherwise the per-system policy is retained.
+func resolveCLISafety(cmd *cobra.Command, sys *config.SystemConfig) adt.SafetyConfig {
+	safety := adt.UnrestrictedSafetyConfig()
+	if sys != nil {
+		safety.ReadOnly = sys.ReadOnly
+		safety.BlockFreeSQL = sys.BlockFreeSQL
+		safety.AllowedOps = sys.AllowedOps
+		safety.DisallowedOps = sys.DisallowedOps
+		safety.AllowedPackages = append([]string(nil), sys.AllowedPackages...)
+		safety.EnableTransports = sys.EnableTransports
+		safety.TransportReadOnly = sys.TransportReadOnly
+		safety.AllowedTransports = append([]string(nil), sys.AllowedTransports...)
+		safety.AllowTransportableEdits = sys.AllowTransportableEdits
+	}
+
+	applyAll := sys == nil
+	if applyAll || safetySettingExplicit(cmd, "read-only", "SAP_READ_ONLY") {
+		safety.ReadOnly = cfg.ReadOnly
+	}
+	if applyAll || safetySettingExplicit(cmd, "block-free-sql", "SAP_BLOCK_FREE_SQL") {
+		safety.BlockFreeSQL = cfg.BlockFreeSQL
+	}
+	if applyAll || safetySettingExplicit(cmd, "allowed-ops", "SAP_ALLOWED_OPS") {
+		safety.AllowedOps = cfg.AllowedOps
+	}
+	if applyAll || safetySettingExplicit(cmd, "disallowed-ops", "SAP_DISALLOWED_OPS") {
+		safety.DisallowedOps = cfg.DisallowedOps
+	}
+	if applyAll || safetySettingExplicit(cmd, "allowed-packages", "SAP_ALLOWED_PACKAGES") {
+		safety.AllowedPackages = append([]string(nil), cfg.AllowedPackages...)
+	}
+	if applyAll || safetySettingExplicit(cmd, "enable-transports", "SAP_ENABLE_TRANSPORTS") {
+		safety.EnableTransports = cfg.EnableTransports
+	}
+	if applyAll || safetySettingExplicit(cmd, "transport-read-only", "SAP_TRANSPORT_READ_ONLY") {
+		safety.TransportReadOnly = cfg.TransportReadOnly
+	}
+	if applyAll || safetySettingExplicit(cmd, "allowed-transports", "SAP_ALLOWED_TRANSPORTS") {
+		safety.AllowedTransports = append([]string(nil), cfg.AllowedTransports...)
+	}
+	if applyAll || safetySettingExplicit(cmd, "allow-transportable-edits", "SAP_ALLOW_TRANSPORTABLE_EDITS") {
+		safety.AllowTransportableEdits = cfg.AllowTransportableEdits
+	}
+	return safety
+}
+
+func safetySettingExplicit(cmd *cobra.Command, flagName, envName string) bool {
+	return cmd.Flags().Changed(flagName) || envIsSet(envName)
+}
+
+func envIsSet(name string) bool {
+	_, ok := os.LookupEnv(name)
+	return ok
 }
 
 func resolveTransportAttributeFromEnv() string {
@@ -152,6 +213,7 @@ func getClient(params *systemParams) (*adt.Client, error) {
 	opts := []adt.Option{
 		adt.WithClient(params.Client),
 		adt.WithLanguage(params.Language),
+		adt.WithSafety(params.Safety),
 	}
 	if params.Insecure {
 		opts = append(opts, adt.WithInsecureSkipVerify())

--- a/cmd/vsp/cli_extra.go
+++ b/cmd/vsp/cli_extra.go
@@ -95,7 +95,9 @@ var executeCmd = &cobra.Command{
 	Use:   "execute [code|file]",
 	Short: "Execute ABAP code on SAP",
 	Long: `Execute arbitrary ABAP code via ExecuteABAP (unit test wrapper).
-Requires write permissions. Code can be inline or from a file.
+Requires write permissions. Code can be inline or from a file. The payload runs
+under ABAP Unit transactional semantics; normal database changes are rolled
+back. This command is not an API for persistent writes.
 
 Examples:
   vsp execute "WRITE 'Hello from CLI'."
@@ -615,6 +617,12 @@ func runExecute(cmd *cobra.Command, args []string) error {
 			return fmt.Errorf("%w\n\nExecuteABAP requires write permissions.\nCheck --read-only and --allowed-ops settings", err)
 		}
 		return fmt.Errorf("execute failed: %w\n\nNote: ExecuteABAP wraps code in a unit test class.\nFor advanced execution, use ZADT_VSP WebSocket (vsp install zadt-vsp)", err)
+	}
+	if result == nil {
+		return fmt.Errorf("execute failed: no result returned")
+	}
+	if !result.Success {
+		return fmt.Errorf("execute failed: %s", result.Message)
 	}
 
 	if len(result.Output) > 0 {

--- a/cmd/vsp/cli_safety_test.go
+++ b/cmd/vsp/cli_safety_test.go
@@ -1,0 +1,94 @@
+package main
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/oisee/vibing-steampunk/internal/mcp"
+	"github.com/oisee/vibing-steampunk/pkg/config"
+	"github.com/spf13/cobra"
+)
+
+func TestSafetyFlagsAreInheritedByCLISubcommands(t *testing.T) {
+	flag := searchCmd.InheritedFlags().Lookup("allow-transportable-edits")
+	if flag == nil {
+		t.Fatal("--allow-transportable-edits is not inherited by CLI subcommands")
+	}
+}
+
+func TestResolveCLISafetyPreservesProfileAndAppliesExplicitOverrides(t *testing.T) {
+	oldCfg := cfg
+	cfg = &mcp.Config{
+		ReadOnly:                false,
+		AllowedPackages:         []string{"ZFLAG*"},
+		AllowedTransports:       []string{"REQ-FLAG*"},
+		AllowTransportableEdits: true,
+	}
+	t.Cleanup(func() { cfg = oldCfg })
+
+	cmd := &cobra.Command{Use: "test"}
+	cmd.Flags().Bool("read-only", false, "")
+	cmd.Flags().StringSlice("allowed-packages", nil, "")
+	cmd.Flags().StringSlice("allowed-transports", nil, "")
+	cmd.Flags().Bool("allow-transportable-edits", false, "")
+	if err := cmd.Flags().Set("allow-transportable-edits", "true"); err != nil {
+		t.Fatal(err)
+	}
+
+	profile := &config.SystemConfig{
+		ReadOnly:          true,
+		AllowedPackages:   []string{"ZPROFILE*"},
+		AllowedTransports: []string{"REQ-PROFILE*"},
+	}
+	safety := resolveCLISafety(cmd, profile)
+
+	if !safety.ReadOnly {
+		t.Error("profile read_only setting was not preserved")
+	}
+	if !reflect.DeepEqual(safety.AllowedPackages, profile.AllowedPackages) {
+		t.Fatalf("allowed packages = %v, want %v", safety.AllowedPackages, profile.AllowedPackages)
+	}
+	if !reflect.DeepEqual(safety.AllowedTransports, profile.AllowedTransports) {
+		t.Fatalf("allowed transports = %v, want %v", safety.AllowedTransports, profile.AllowedTransports)
+	}
+	if !safety.AllowTransportableEdits {
+		t.Error("explicit flag did not override the profile")
+	}
+}
+
+func TestResolveCLISafetyUsesEnvironmentOverride(t *testing.T) {
+	oldCfg := cfg
+	cfg = &mcp.Config{AllowTransportableEdits: true}
+	t.Cleanup(func() { cfg = oldCfg })
+	t.Setenv("SAP_ALLOW_TRANSPORTABLE_EDITS", "true")
+
+	cmd := &cobra.Command{Use: "test"}
+	cmd.Flags().Bool("allow-transportable-edits", false, "")
+	safety := resolveCLISafety(cmd, &config.SystemConfig{})
+	if !safety.AllowTransportableEdits {
+		t.Error("SAP_ALLOW_TRANSPORTABLE_EDITS was not propagated")
+	}
+}
+
+func TestGetClientInstallsResolvedSafety(t *testing.T) {
+	params := &systemParams{
+		URL:      "https://example.invalid",
+		User:     "user",
+		Password: "password",
+		Client:   "001",
+		Language: "EN",
+	}
+	params.Safety.AllowTransportableEdits = true
+	params.Safety.AllowedTransports = []string{"REQ-TEST*"}
+
+	client, err := getClient(params)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !client.Safety().AllowTransportableEdits {
+		t.Error("resolved safety was not installed on the ADT client")
+	}
+	if !reflect.DeepEqual(client.Safety().AllowedTransports, params.Safety.AllowedTransports) {
+		t.Fatalf("allowed transports = %v, want %v", client.Safety().AllowedTransports, params.Safety.AllowedTransports)
+	}
+}

--- a/cmd/vsp/copy_cmd.go
+++ b/cmd/vsp/copy_cmd.go
@@ -144,7 +144,7 @@ func runCopy(cmd *cobra.Command, args []string) error {
 	// Check if ZADT_VSP is available
 	wsAvailable := checkWebSocketAvailable(client, ctx)
 	if wsAvailable {
-		fmt.Println("Mode: WebSocket (ZADT_VSP available - full object type support)")
+		fmt.Println("Mode: ADT Native (ZADT_VSP detected; WebSocket copy deployment is not implemented)")
 	} else {
 		fmt.Println("Mode: ADT Native (fallback - PROG, CLAS, INTF, DDLS, BDEF, SRVD)")
 	}
@@ -154,21 +154,12 @@ func runCopy(cmd *cobra.Command, args []string) error {
 	fmt.Printf("Deployment Plan (%d objects):\n", len(filteredObjects))
 	fmt.Println(strings.Repeat("-", 60))
 
-	adtSupported := map[string]bool{
-		"PROG": true,
-		"CLAS": true,
-		"INTF": true,
-		"DDLS": true,
-		"BDEF": true,
-		"SRVD": true,
-	}
-
 	var deployable, skipped int
 	for _, obj := range filteredObjects {
-		supported := wsAvailable || adtSupported[obj.Type]
+		supported, reason := copyObjectSupported(obj)
 		status := "✓"
 		if !supported {
-			status = "⊘ (requires ZADT_VSP)"
+			status = fmt.Sprintf("⊘ (%s)", reason)
 			skipped++
 		} else {
 			deployable++
@@ -201,17 +192,12 @@ func runCopy(cmd *cobra.Command, args []string) error {
 
 	// Ensure package exists
 	fmt.Printf("Checking package %s...\n", copyToPackage)
-	_, err = client.GetPackage(ctx, copyToPackage)
+	created, err := ensureCopyTargetPackage(ctx, client, copyToPackage, sourceName)
 	if err != nil {
-		fmt.Printf("Creating package %s...\n", copyToPackage)
-		err = client.CreateObject(ctx, adt.CreateObjectOptions{
-			ObjectType:  adt.ObjectTypePackage,
-			Name:        copyToPackage,
-			Description: fmt.Sprintf("Deployed from %s", sourceName),
-		})
-		if err != nil {
-			return fmt.Errorf("failed to create package: %w", err)
-		}
+		return err
+	}
+	if created {
+		fmt.Printf("Created package %s\n", copyToPackage)
 	}
 
 	// Deploy objects
@@ -219,14 +205,14 @@ func runCopy(cmd *cobra.Command, args []string) error {
 	var success, failed int
 
 	for _, obj := range filteredObjects {
-		supported := wsAvailable || adtSupported[obj.Type]
+		supported, _ := copyObjectSupported(obj)
 		if !supported {
 			continue
 		}
 
 		fmt.Printf("  Deploying %s %s... ", obj.Type, obj.Name)
 
-		err := deployObject(ctx, client, obj, copyToPackage, wsAvailable)
+		err := deployObject(ctx, client, obj, copyToPackage)
 		if err != nil {
 			fmt.Printf("FAILED: %v\n", err)
 			failed++
@@ -239,13 +225,57 @@ func runCopy(cmd *cobra.Command, args []string) error {
 	fmt.Println()
 	fmt.Printf("Deployment complete: %d success, %d failed\n", success, failed)
 
-	if !wsAvailable && skipped > 0 {
-		fmt.Println("\nNote: Some objects were skipped because ZADT_VSP is not installed.")
-		fmt.Println("Install ZADT_VSP first to enable full object type support:")
-		fmt.Println("  vsp -s <system> copy --embedded zadt-vsp --to $ZADT_VSP")
+	if skipped > 0 {
+		fmt.Println("\nNote: Unsupported or incomplete object types were skipped before deployment.")
 	}
 
-	return nil
+	return deploymentSummaryError(failed)
+}
+
+func deploymentSummaryError(failed int) error {
+	if failed == 0 {
+		return nil
+	}
+	return fmt.Errorf("deployment completed with %d failed object(s)", failed)
+}
+
+type copyPackageClient interface {
+	PackageExists(context.Context, string) (bool, error)
+	CreateObject(context.Context, adt.CreateObjectOptions) error
+}
+
+func ensureCopyTargetPackage(ctx context.Context, client copyPackageClient, packageName, sourceName string) (bool, error) {
+	exists, err := client.PackageExists(ctx, packageName)
+	if err != nil {
+		return false, fmt.Errorf("failed to verify target package: %w", err)
+	}
+	if exists {
+		return false, nil
+	}
+
+	err = client.CreateObject(ctx, adt.CreateObjectOptions{
+		ObjectType:  adt.ObjectTypePackage,
+		Name:        packageName,
+		Description: fmt.Sprintf("Deployed from %s", sourceName),
+	})
+	if err != nil {
+		return false, fmt.Errorf("failed to create package: %w", err)
+	}
+	return true, nil
+}
+
+func copyObjectSupported(obj deps.DeploymentObject) (bool, string) {
+	switch obj.Type {
+	case "PROG", "INTF", "DDLS", "BDEF", "SRVD":
+		return true, ""
+	case "CLAS": //nolint:misspell // CLAS is the SAP object type.
+		if len(obj.Includes) > 0 {
+			return false, "class include deployment is not implemented"
+		}
+		return true, ""
+	default:
+		return false, "object type is not supported by ADT copy deployment"
+	}
 }
 
 // checkWebSocketAvailable tests if ZADT_VSP WebSocket is available.
@@ -259,12 +289,7 @@ func checkWebSocketAvailable(client *adt.Client, ctx context.Context) bool {
 }
 
 // deployObject deploys a single object using ADT native or WebSocket.
-func deployObject(ctx context.Context, client *adt.Client, obj deps.DeploymentObject, packageName string, useWebSocket bool) error {
-	if useWebSocket {
-		// TODO: Implement WebSocket-based deployment
-		// For now, fall through to ADT native
-	}
-
+func deployObject(ctx context.Context, client *adt.Client, obj deps.DeploymentObject, packageName string) error {
 	// ADT Native deployment
 	switch obj.Type {
 	case "PROG":
@@ -299,33 +324,41 @@ func deployProgram(ctx context.Context, client *adt.Client, obj deps.DeploymentO
 	if err != nil {
 		return err
 	}
-	if !result.Success {
-		return fmt.Errorf("WriteSource failed: %s", result.Message)
+	return validateCopyWriteResult(result)
+}
+
+func validateCopyWriteResult(result *adt.WriteSourceResult) error {
+	if result == nil {
+		return fmt.Errorf("WriteSource returned no result")
 	}
-	return nil
+	if result.Success {
+		return nil
+	}
+	message := strings.TrimSpace(result.Message)
+	if message == "" {
+		message = "operation returned success=false without a diagnostic"
+	}
+	return fmt.Errorf("WriteSource failed: %s", message)
 }
 
 func deployClass(ctx context.Context, client *adt.Client, obj deps.DeploymentObject, packageName string) error {
+	if len(obj.Includes) > 0 {
+		return fmt.Errorf("class include deployment is not implemented; refusing partial deployment")
+	}
 	desc := obj.Description
 	if desc == "" {
 		desc = fmt.Sprintf("Deployed: %s", obj.Name)
 	}
 	// Deploy main class
-	_, err := client.WriteSource(ctx, "CLAS", obj.Name, obj.MainSource, &adt.WriteSourceOptions{
+	result, err := client.WriteSource(ctx, "CLAS", obj.Name, obj.MainSource, &adt.WriteSourceOptions{ //nolint:misspell // CLAS is the SAP object type.
 		Package:     packageName,
 		Description: desc,
 	})
 	if err != nil {
 		return err
 	}
-
-	// Deploy includes (TODO: implement include deployment)
-	if len(obj.Includes) > 0 {
-		var incTypes []string
-		for t := range obj.Includes {
-			incTypes = append(incTypes, t)
-		}
-		fmt.Printf("\n    Note: class includes [%s] not yet deployed (TODO)\n", strings.Join(incTypes, ","))
+	if err := validateCopyWriteResult(result); err != nil {
+		return err
 	}
 
 	return nil
@@ -336,11 +369,14 @@ func deployInterface(ctx context.Context, client *adt.Client, obj deps.Deploymen
 	if desc == "" {
 		desc = fmt.Sprintf("Deployed: %s", obj.Name)
 	}
-	_, err := client.WriteSource(ctx, "INTF", obj.Name, obj.MainSource, &adt.WriteSourceOptions{
+	result, err := client.WriteSource(ctx, "INTF", obj.Name, obj.MainSource, &adt.WriteSourceOptions{
 		Package:     packageName,
 		Description: desc,
 	})
-	return err
+	if err != nil {
+		return err
+	}
+	return validateCopyWriteResult(result)
 }
 
 func deployDDLS(ctx context.Context, client *adt.Client, obj deps.DeploymentObject, packageName string) error {
@@ -348,11 +384,14 @@ func deployDDLS(ctx context.Context, client *adt.Client, obj deps.DeploymentObje
 	if desc == "" {
 		desc = fmt.Sprintf("Deployed: %s", obj.Name)
 	}
-	_, err := client.WriteSource(ctx, "DDLS", obj.Name, obj.MainSource, &adt.WriteSourceOptions{
+	result, err := client.WriteSource(ctx, "DDLS", obj.Name, obj.MainSource, &adt.WriteSourceOptions{
 		Package:     packageName,
 		Description: desc,
 	})
-	return err
+	if err != nil {
+		return err
+	}
+	return validateCopyWriteResult(result)
 }
 
 func deployBDEF(ctx context.Context, client *adt.Client, obj deps.DeploymentObject, packageName string) error {
@@ -360,11 +399,14 @@ func deployBDEF(ctx context.Context, client *adt.Client, obj deps.DeploymentObje
 	if desc == "" {
 		desc = fmt.Sprintf("Deployed: %s", obj.Name)
 	}
-	_, err := client.WriteSource(ctx, "BDEF", obj.Name, obj.MainSource, &adt.WriteSourceOptions{
+	result, err := client.WriteSource(ctx, "BDEF", obj.Name, obj.MainSource, &adt.WriteSourceOptions{
 		Package:     packageName,
 		Description: desc,
 	})
-	return err
+	if err != nil {
+		return err
+	}
+	return validateCopyWriteResult(result)
 }
 
 func deploySRVD(ctx context.Context, client *adt.Client, obj deps.DeploymentObject, packageName string) error {
@@ -372,9 +414,12 @@ func deploySRVD(ctx context.Context, client *adt.Client, obj deps.DeploymentObje
 	if desc == "" {
 		desc = fmt.Sprintf("Deployed: %s", obj.Name)
 	}
-	_, err := client.WriteSource(ctx, "SRVD", obj.Name, obj.MainSource, &adt.WriteSourceOptions{
+	result, err := client.WriteSource(ctx, "SRVD", obj.Name, obj.MainSource, &adt.WriteSourceOptions{
 		Package:     packageName,
 		Description: desc,
 	})
-	return err
+	if err != nil {
+		return err
+	}
+	return validateCopyWriteResult(result)
 }

--- a/cmd/vsp/copy_cmd_test.go
+++ b/cmd/vsp/copy_cmd_test.go
@@ -104,10 +104,10 @@ func TestCopyObjectSupported(t *testing.T) {
 		wantReason string
 	}{
 		{name: "program", object: deps.DeploymentObject{Type: "PROG"}, want: true},
-		{name: "class main", object: deps.DeploymentObject{Type: "CLAS"}, want: true},
+		{name: "class main", object: deps.DeploymentObject{Type: "CLAS"}, want: true}, //nolint:misspell // CLAS is the SAP object type.
 		{
 			name:       "class includes",
-			object:     deps.DeploymentObject{Type: "CLAS", Includes: map[string]string{"testclasses": "synthetic"}},
+			object:     deps.DeploymentObject{Type: "CLAS", Includes: map[string]string{"testclasses": "synthetic"}}, //nolint:misspell // CLAS is the SAP object type.
 			wantReason: "include deployment",
 		},
 		{name: "unsupported type", object: deps.DeploymentObject{Type: "TABL"}, wantReason: "not supported"},

--- a/cmd/vsp/copy_cmd_test.go
+++ b/cmd/vsp/copy_cmd_test.go
@@ -1,0 +1,127 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/oisee/vibing-steampunk/embedded/deps"
+	"github.com/oisee/vibing-steampunk/pkg/adt"
+)
+
+type fakeCopyPackageClient struct {
+	exists      bool
+	existsErr   error
+	createErr   error
+	createCalls int
+}
+
+func (f *fakeCopyPackageClient) PackageExists(context.Context, string) (bool, error) {
+	return f.exists, f.existsErr
+}
+
+func (f *fakeCopyPackageClient) CreateObject(context.Context, adt.CreateObjectOptions) error {
+	f.createCalls++
+	return f.createErr
+}
+
+func TestValidateCopyWriteResult(t *testing.T) {
+	tests := []struct {
+		name    string
+		result  *adt.WriteSourceResult
+		wantErr string
+	}{
+		{name: "success", result: &adt.WriteSourceResult{Success: true}},
+		{name: "nil result", wantErr: "no result"},
+		{name: "diagnostic", result: &adt.WriteSourceResult{Message: "synthetic activation failure"}, wantErr: "synthetic activation failure"},
+		{name: "missing diagnostic", result: &adt.WriteSourceResult{}, wantErr: "without a diagnostic"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateCopyWriteResult(tt.result)
+			if tt.wantErr == "" {
+				if err != nil {
+					t.Fatalf("validateCopyWriteResult() error = %v", err)
+				}
+				return
+			}
+			if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+				t.Fatalf("validateCopyWriteResult() error = %v, want substring %q", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestDeploymentSummaryError(t *testing.T) {
+	if err := deploymentSummaryError(0); err != nil {
+		t.Fatalf("deploymentSummaryError(0) = %v, want nil", err)
+	}
+	if err := deploymentSummaryError(2); err == nil || !strings.Contains(err.Error(), "2 failed") {
+		t.Fatalf("deploymentSummaryError(2) = %v, want failure count", err)
+	}
+}
+
+func TestEnsureCopyTargetPackage(t *testing.T) {
+	tests := []struct {
+		name        string
+		fake        *fakeCopyPackageClient
+		wantCreated bool
+		wantErr     string
+		wantCalls   int
+	}{
+		{name: "existing", fake: &fakeCopyPackageClient{exists: true}},
+		{name: "missing", fake: &fakeCopyPackageClient{}, wantCreated: true, wantCalls: 1},
+		{name: "inconclusive lookup", fake: &fakeCopyPackageClient{existsErr: errors.New("synthetic authentication failure")}, wantErr: "authentication failure"},
+		{name: "create failure", fake: &fakeCopyPackageClient{createErr: errors.New("synthetic create failure")}, wantErr: "create failure", wantCalls: 1},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			created, err := ensureCopyTargetPackage(context.Background(), tt.fake, "$SYNTHETIC", "synthetic.zip")
+			if created != tt.wantCreated {
+				t.Fatalf("created = %v, want %v", created, tt.wantCreated)
+			}
+			if tt.wantErr == "" && err != nil {
+				t.Fatalf("ensureCopyTargetPackage() error = %v", err)
+			}
+			if tt.wantErr != "" && (err == nil || !strings.Contains(err.Error(), tt.wantErr)) {
+				t.Fatalf("ensureCopyTargetPackage() error = %v, want substring %q", err, tt.wantErr)
+			}
+			if tt.fake.createCalls != tt.wantCalls {
+				t.Fatalf("CreateObject calls = %d, want %d", tt.fake.createCalls, tt.wantCalls)
+			}
+		})
+	}
+}
+
+func TestCopyObjectSupported(t *testing.T) {
+	tests := []struct {
+		name       string
+		object     deps.DeploymentObject
+		want       bool
+		wantReason string
+	}{
+		{name: "program", object: deps.DeploymentObject{Type: "PROG"}, want: true},
+		{name: "class main", object: deps.DeploymentObject{Type: "CLAS"}, want: true},
+		{
+			name:       "class includes",
+			object:     deps.DeploymentObject{Type: "CLAS", Includes: map[string]string{"testclasses": "synthetic"}},
+			wantReason: "include deployment",
+		},
+		{name: "unsupported type", object: deps.DeploymentObject{Type: "TABL"}, wantReason: "not supported"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, reason := copyObjectSupported(tt.object)
+			if got != tt.want {
+				t.Fatalf("copyObjectSupported() = %v, want %v", got, tt.want)
+			}
+			if tt.wantReason != "" && !strings.Contains(reason, tt.wantReason) {
+				t.Fatalf("reason = %q, want substring %q", reason, tt.wantReason)
+			}
+		})
+	}
+}

--- a/cmd/vsp/devops.go
+++ b/cmd/vsp/devops.go
@@ -12,6 +12,7 @@ import (
 
 	embedded "github.com/oisee/vibing-steampunk/embedded/abap"
 	"github.com/oisee/vibing-steampunk/embedded/deps"
+	installer "github.com/oisee/vibing-steampunk/internal/install"
 	"github.com/oisee/vibing-steampunk/pkg/adt"
 	"github.com/oisee/vibing-steampunk/pkg/ctxcomp"
 	"github.com/oisee/vibing-steampunk/pkg/graph"
@@ -3059,10 +3060,11 @@ func runInstallZadtVsp(cmd *cobra.Command, args []string) error {
 	fmt.Fprintf(os.Stderr, "Checking prerequisites...\n")
 
 	// Check if package exists
-	packageExists := false
-	pkg, err := client.GetPackage(ctx, packageName)
-	if err == nil && pkg.URI != "" {
-		packageExists = true
+	packageExists, err := client.PackageExists(ctx, packageName)
+	if err != nil {
+		return fmt.Errorf("failed to check package %s: %w", packageName, err)
+	}
+	if packageExists {
 		fmt.Fprintf(os.Stderr, "  Package %s exists\n", packageName)
 	} else {
 		fmt.Fprintf(os.Stderr, "  Package %s will be created\n", packageName)
@@ -3125,16 +3127,12 @@ func runInstallZadtVsp(cmd *cobra.Command, args []string) error {
 	}
 
 	// Phase 2: Create package if needed
-	if !packageExists {
+	created, err := installer.EnsurePackage(ctx, client, packageName, "VSP WebSocket Handler")
+	if err != nil {
+		return fmt.Errorf("failed to ensure package %s: %w", packageName, err)
+	}
+	if created {
 		fmt.Fprintf(os.Stderr, "Creating package %s...\n", packageName)
-		err := client.CreateObject(ctx, adt.CreateObjectOptions{
-			ObjectType:  adt.ObjectTypePackage,
-			Name:        packageName,
-			Description: "VSP WebSocket Handler",
-		})
-		if err != nil {
-			return fmt.Errorf("failed to create package %s: %w", packageName, err)
-		}
 		fmt.Fprintf(os.Stderr, "  Package created\n\n")
 	} else {
 		fmt.Fprintf(os.Stderr, "Using existing package %s\n\n", packageName)
@@ -3158,10 +3156,11 @@ func runInstallZadtVsp(cmd *cobra.Command, args []string) error {
 		fmt.Fprintf(os.Stderr, "  [%d/%d] %s ... ", i+1, len(objects), obj.Name)
 
 		opts := &adt.WriteSourceOptions{
-			Package: packageName,
-			Mode:    adt.WriteModeUpsert,
+			Package:     packageName,
+			Description: obj.Description,
+			Mode:        adt.WriteModeUpsert,
 		}
-		_, err := client.WriteSource(ctx, obj.Type, obj.Name, obj.Source, opts)
+		_, err := installer.DeploySource(ctx, client, obj.Type, obj.Name, obj.Source, opts)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "FAILED: %v\n", err)
 			failed++
@@ -3181,6 +3180,9 @@ func runInstallZadtVsp(cmd *cobra.Command, args []string) error {
 		fmt.Fprintf(os.Stderr, "DEPLOYMENT COMPLETE\n")
 		fmt.Fprintf(os.Stderr, "Deployed: %d, Skipped: %d\n\n", deployed, skipped)
 	}
+	if failed > 0 {
+		return fmt.Errorf("%d object(s) failed to deploy; post-deployment features were not declared ready", failed)
+	}
 
 	// Post-deployment instructions
 	fmt.Fprint(os.Stderr, embedded.PostDeploymentInstructions())
@@ -3196,9 +3198,6 @@ func runInstallZadtVsp(cmd *cobra.Command, args []string) error {
 		fmt.Fprintf(os.Stderr, "  abapGit export NOT available (install abapGit first)\n")
 	}
 
-	if failed > 0 {
-		return fmt.Errorf("%d object(s) failed to deploy", failed)
-	}
 	return nil
 }
 
@@ -3303,17 +3302,12 @@ func runInstallAbapGit(cmd *cobra.Command, args []string) error {
 
 	// Ensure package exists
 	fmt.Fprintf(os.Stderr, "Checking package %s...\n", packageName)
-	pkg, pkgErr := client.GetPackage(ctx, packageName)
-	if pkgErr != nil || pkg.URI == "" {
+	created, err := installer.EnsurePackage(ctx, client, packageName, fmt.Sprintf("abapGit %s edition", edition))
+	if err != nil {
+		return fmt.Errorf("failed to ensure package: %w", err)
+	}
+	if created {
 		fmt.Fprintf(os.Stderr, "Creating package %s...\n", packageName)
-		err = client.CreateObject(ctx, adt.CreateObjectOptions{
-			ObjectType:  adt.ObjectTypePackage,
-			Name:        packageName,
-			Description: fmt.Sprintf("abapGit %s edition", edition),
-		})
-		if err != nil {
-			return fmt.Errorf("failed to create package: %w", err)
-		}
 		fmt.Fprintf(os.Stderr, "  Package created\n")
 	} else {
 		fmt.Fprintf(os.Stderr, "  Package exists\n")
@@ -3341,7 +3335,7 @@ func runInstallAbapGit(cmd *cobra.Command, args []string) error {
 			Description: desc,
 			Mode:        adt.WriteModeUpsert,
 		}
-		_, err := client.WriteSource(ctx, obj.Type, obj.Name, obj.MainSource, wopts)
+		_, err := installer.DeploySource(ctx, client, obj.Type, obj.Name, obj.MainSource, wopts)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "FAILED: %v\n", err)
 			failCount++

--- a/cmd/vsp/devops.go
+++ b/cmd/vsp/devops.go
@@ -1703,12 +1703,12 @@ type cliHealthSignal struct {
 }
 
 type cliHealthResult struct {
-	Scope            cliHealthScope              `json:"scope"`
-	Summary          cliHealthSummary            `json:"summary"`
-	Signals          map[string]cliHealthSignal  `json:"signals"`
-	TestDetails      *adt.UnitTestResult         `json:"testDetails,omitempty"`
-	ATCDetails       *adt.ATCWorklist            `json:"atcDetails,omitempty"`
-	CrossingDetails  *graph.CrossingReport       `json:"crossingDetails,omitempty"`
+	Scope           cliHealthScope             `json:"scope"`
+	Summary         cliHealthSummary           `json:"summary"`
+	Signals         map[string]cliHealthSignal `json:"signals"`
+	TestDetails     *adt.UnitTestResult        `json:"testDetails,omitempty"`
+	ATCDetails      *adt.ATCWorklist           `json:"atcDetails,omitempty"`
+	CrossingDetails *graph.CrossingReport      `json:"crossingDetails,omitempty"`
 }
 
 func runHealth(cmd *cobra.Command, args []string) error {

--- a/cmd/vsp/main.go
+++ b/cmd/vsp/main.go
@@ -71,11 +71,10 @@ Configuration priority: CLI flags > env vars > .env file > defaults
 Ready-to-use configs for 8 AI agents: docs/cli-agents/`,
 	Version: fmt.Sprintf("%s (commit: %s, built: %s)", Version, Commit, BuildDate),
 	PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
-		// Also check SAP_VERBOSE env var (viper reads it, but resolveConfig
-		// is only called for the MCP server mode, so we check it here too)
-		if !cfg.Verbose {
-			cfg.Verbose = viper.GetBool("VERBOSE")
-		}
+		// Resolve shared flags and SAP_* environment variables for both the MCP
+		// server and CLI subcommands. In particular, safety policy must be
+		// established before a CLI command creates its ADT client.
+		resolveConfig(cmd)
 		if cfg.Verbose {
 			adt.SetLogOutput(os.Stderr)
 		}
@@ -123,15 +122,15 @@ func init() {
 	rootCmd.Flags().Duration("keepalive", 5*time.Minute, "Session keep-alive interval (e.g., 60s, 5m). Prevents session timeout during idle periods. 0 = disabled")
 
 	// Safety options
-	rootCmd.Flags().BoolVar(&cfg.ReadOnly, "read-only", false, "Block all write operations (create, update, delete, activate)")
-	rootCmd.Flags().BoolVar(&cfg.BlockFreeSQL, "block-free-sql", false, "Block execution of arbitrary SQL queries via RunQuery")
-	rootCmd.Flags().StringVar(&cfg.AllowedOps, "allowed-ops", "", "Whitelist of allowed operation types (e.g., \"RSQ\" for Read, Search, Query only)")
-	rootCmd.Flags().StringVar(&cfg.DisallowedOps, "disallowed-ops", "", "Blacklist of operation types to block (e.g., \"CDUA\" for Create, Delete, Update, Activate)")
-	rootCmd.Flags().StringSliceVar(&cfg.AllowedPackages, "allowed-packages", nil, "Restrict operations to specific packages (comma-separated, supports wildcards like Z*)")
-	rootCmd.Flags().BoolVar(&cfg.EnableTransports, "enable-transports", false, "Enable transport management operations (disabled by default for safety)")
-	rootCmd.Flags().BoolVar(&cfg.TransportReadOnly, "transport-read-only", false, "Only allow read operations on transports (list, get)")
-	rootCmd.Flags().StringSliceVar(&cfg.AllowedTransports, "allowed-transports", nil, "Restrict transport operations to specific transports (comma-separated, supports wildcards like A4HK*)")
-	rootCmd.Flags().BoolVar(&cfg.AllowTransportableEdits, "allow-transportable-edits", false, "Allow editing objects in transportable packages (requires transport parameter)")
+	rootCmd.PersistentFlags().BoolVar(&cfg.ReadOnly, "read-only", false, "Block all write operations (create, update, delete, activate)")
+	rootCmd.PersistentFlags().BoolVar(&cfg.BlockFreeSQL, "block-free-sql", false, "Block execution of arbitrary SQL queries via RunQuery")
+	rootCmd.PersistentFlags().StringVar(&cfg.AllowedOps, "allowed-ops", "", "Whitelist of allowed operation types (e.g., \"RSQ\" for Read, Search, Query only)")
+	rootCmd.PersistentFlags().StringVar(&cfg.DisallowedOps, "disallowed-ops", "", "Blacklist of operation types to block (e.g., \"CDUA\" for Create, Delete, Update, Activate)")
+	rootCmd.PersistentFlags().StringSliceVar(&cfg.AllowedPackages, "allowed-packages", nil, "Restrict operations to specific packages (comma-separated, supports wildcards like Z*)")
+	rootCmd.PersistentFlags().BoolVar(&cfg.EnableTransports, "enable-transports", false, "Enable transport management operations (disabled by default for safety)")
+	rootCmd.PersistentFlags().BoolVar(&cfg.TransportReadOnly, "transport-read-only", false, "Only allow read operations on transports (list, get)")
+	rootCmd.PersistentFlags().StringSliceVar(&cfg.AllowedTransports, "allowed-transports", nil, "Restrict transport operations to specific transports (comma-separated, supports wildcards like A4HK*)")
+	rootCmd.PersistentFlags().BoolVar(&cfg.AllowTransportableEdits, "allow-transportable-edits", false, "Allow editing objects in transportable packages (requires transport parameter)")
 
 	// Mode options
 	rootCmd.Flags().StringVar(&cfg.Mode, "mode", "hyperfocused", "Tool mode: hyperfocused (single universal SAP tool), focused (100 tools), or expert (147 tools)")
@@ -174,15 +173,15 @@ func init() {
 	viper.BindPFlag("browser-exec", rootCmd.Flags().Lookup("browser-exec"))
 	viper.BindPFlag("cookie-save", rootCmd.Flags().Lookup("cookie-save"))
 	viper.BindPFlag("keepalive", rootCmd.Flags().Lookup("keepalive"))
-	viper.BindPFlag("read-only", rootCmd.Flags().Lookup("read-only"))
-	viper.BindPFlag("block-free-sql", rootCmd.Flags().Lookup("block-free-sql"))
-	viper.BindPFlag("allowed-ops", rootCmd.Flags().Lookup("allowed-ops"))
-	viper.BindPFlag("disallowed-ops", rootCmd.Flags().Lookup("disallowed-ops"))
-	viper.BindPFlag("allowed-packages", rootCmd.Flags().Lookup("allowed-packages"))
-	viper.BindPFlag("enable-transports", rootCmd.Flags().Lookup("enable-transports"))
-	viper.BindPFlag("transport-read-only", rootCmd.Flags().Lookup("transport-read-only"))
-	viper.BindPFlag("allowed-transports", rootCmd.Flags().Lookup("allowed-transports"))
-	viper.BindPFlag("allow-transportable-edits", rootCmd.Flags().Lookup("allow-transportable-edits"))
+	viper.BindPFlag("read-only", rootCmd.PersistentFlags().Lookup("read-only"))
+	viper.BindPFlag("block-free-sql", rootCmd.PersistentFlags().Lookup("block-free-sql"))
+	viper.BindPFlag("allowed-ops", rootCmd.PersistentFlags().Lookup("allowed-ops"))
+	viper.BindPFlag("disallowed-ops", rootCmd.PersistentFlags().Lookup("disallowed-ops"))
+	viper.BindPFlag("allowed-packages", rootCmd.PersistentFlags().Lookup("allowed-packages"))
+	viper.BindPFlag("enable-transports", rootCmd.PersistentFlags().Lookup("enable-transports"))
+	viper.BindPFlag("transport-read-only", rootCmd.PersistentFlags().Lookup("transport-read-only"))
+	viper.BindPFlag("allowed-transports", rootCmd.PersistentFlags().Lookup("allowed-transports"))
+	viper.BindPFlag("allow-transportable-edits", rootCmd.PersistentFlags().Lookup("allow-transportable-edits"))
 	viper.BindPFlag("mode", rootCmd.Flags().Lookup("mode"))
 	viper.BindPFlag("disabled-groups", rootCmd.Flags().Lookup("disabled-groups"))
 	viper.BindPFlag("verbose", rootCmd.PersistentFlags().Lookup("verbose"))
@@ -205,9 +204,6 @@ func init() {
 }
 
 func runServer(cmd *cobra.Command, args []string) error {
-	// Resolve configuration with priority: flags > env vars > defaults
-	resolveConfig(cmd)
-
 	// Validate configuration
 	if err := validateConfig(); err != nil {
 		return err

--- a/cmd/vsp/main.go
+++ b/cmd/vsp/main.go
@@ -117,7 +117,6 @@ func init() {
 	rootCmd.Flags().String("saml-password", "", "SAML/IAS password")
 	rootCmd.Flags().String("credential-cmd", "", "External command returning JSON {\"username\":...,\"password\":...} (space-separated argv, no shell quoting — use a wrapper script for paths with spaces)")
 
-
 	// Session keep-alive
 	rootCmd.Flags().Duration("keepalive", 5*time.Minute, "Session keep-alive interval (e.g., 60s, 5m). Prevents session timeout during idle periods. 0 = disabled")
 
@@ -173,15 +172,15 @@ func init() {
 	viper.BindPFlag("browser-exec", rootCmd.Flags().Lookup("browser-exec"))
 	viper.BindPFlag("cookie-save", rootCmd.Flags().Lookup("cookie-save"))
 	viper.BindPFlag("keepalive", rootCmd.Flags().Lookup("keepalive"))
-	viper.BindPFlag("read-only", rootCmd.PersistentFlags().Lookup("read-only"))
-	viper.BindPFlag("block-free-sql", rootCmd.PersistentFlags().Lookup("block-free-sql"))
-	viper.BindPFlag("allowed-ops", rootCmd.PersistentFlags().Lookup("allowed-ops"))
-	viper.BindPFlag("disallowed-ops", rootCmd.PersistentFlags().Lookup("disallowed-ops"))
-	viper.BindPFlag("allowed-packages", rootCmd.PersistentFlags().Lookup("allowed-packages"))
-	viper.BindPFlag("enable-transports", rootCmd.PersistentFlags().Lookup("enable-transports"))
-	viper.BindPFlag("transport-read-only", rootCmd.PersistentFlags().Lookup("transport-read-only"))
-	viper.BindPFlag("allowed-transports", rootCmd.PersistentFlags().Lookup("allowed-transports"))
-	viper.BindPFlag("allow-transportable-edits", rootCmd.PersistentFlags().Lookup("allow-transportable-edits"))
+	_ = viper.BindPFlag("read-only", rootCmd.PersistentFlags().Lookup("read-only"))
+	_ = viper.BindPFlag("block-free-sql", rootCmd.PersistentFlags().Lookup("block-free-sql"))
+	_ = viper.BindPFlag("allowed-ops", rootCmd.PersistentFlags().Lookup("allowed-ops"))
+	_ = viper.BindPFlag("disallowed-ops", rootCmd.PersistentFlags().Lookup("disallowed-ops"))
+	_ = viper.BindPFlag("allowed-packages", rootCmd.PersistentFlags().Lookup("allowed-packages"))
+	_ = viper.BindPFlag("enable-transports", rootCmd.PersistentFlags().Lookup("enable-transports"))
+	_ = viper.BindPFlag("transport-read-only", rootCmd.PersistentFlags().Lookup("transport-read-only"))
+	_ = viper.BindPFlag("allowed-transports", rootCmd.PersistentFlags().Lookup("allowed-transports"))
+	_ = viper.BindPFlag("allow-transportable-edits", rootCmd.PersistentFlags().Lookup("allow-transportable-edits"))
 	viper.BindPFlag("mode", rootCmd.Flags().Lookup("mode"))
 	viper.BindPFlag("disabled-groups", rootCmd.Flags().Lookup("disabled-groups"))
 	viper.BindPFlag("verbose", rootCmd.PersistentFlags().Lookup("verbose"))

--- a/internal/install/install.go
+++ b/internal/install/install.go
@@ -1,0 +1,92 @@
+// Package install contains the fail-closed primitives shared by CLI and MCP
+// installers. It performs no SAP-specific discovery beyond the supplied ADT
+// client and is designed to be testable with an in-memory fake.
+package install
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/oisee/vibing-steampunk/pkg/adt"
+)
+
+// Client is the subset of the ADT client required by installers.
+type Client interface {
+	PackageExists(context.Context, string) (bool, error)
+	CreateObject(context.Context, adt.CreateObjectOptions) error
+	WriteSource(context.Context, string, string, string, *adt.WriteSourceOptions) (*adt.WriteSourceResult, error)
+	GetSource(context.Context, string, string, *adt.GetSourceOptions) (string, error)
+}
+
+// EnsurePackage proves that a package exists, creating and re-probing it only
+// after a definite missing result. A create error is tolerated only if a fresh
+// probe proves that the package now exists (for example, a concurrent create).
+func EnsurePackage(ctx context.Context, client Client, name, description string) (created bool, err error) {
+	exists, err := client.PackageExists(ctx, name)
+	if err != nil {
+		return false, fmt.Errorf("package existence check was inconclusive: %w", err)
+	}
+	if exists {
+		return false, nil
+	}
+
+	createErr := client.CreateObject(ctx, adt.CreateObjectOptions{
+		ObjectType:  adt.ObjectTypePackage,
+		Name:        name,
+		Description: description,
+	})
+	exists, verifyErr := client.PackageExists(ctx, name)
+	if verifyErr != nil {
+		if createErr != nil {
+			return false, fmt.Errorf("package create failed (%v) and verification was inconclusive: %w", createErr, verifyErr)
+		}
+		return false, fmt.Errorf("package creation could not be verified: %w", verifyErr)
+	}
+	if !exists {
+		if createErr != nil {
+			return false, fmt.Errorf("package create failed and package is still absent: %w", createErr)
+		}
+		return false, fmt.Errorf("package creation returned success but package is still absent")
+	}
+	if createErr != nil {
+		return false, nil
+	}
+	return true, nil
+}
+
+// DeploySource writes one object, validates the structured workflow result,
+// and proves the object can be read back before reporting success.
+func DeploySource(ctx context.Context, client Client, objectType, name, source string, opts *adt.WriteSourceOptions) (*adt.WriteSourceResult, error) {
+	result, err := client.WriteSource(ctx, objectType, name, source, opts)
+	if err != nil {
+		return result, err
+	}
+	if result == nil {
+		return nil, fmt.Errorf("WriteSource returned no result")
+	}
+	if !result.Success {
+		message := strings.TrimSpace(result.Message)
+		if message == "" {
+			message = "WriteSource returned success=false without a diagnostic"
+		}
+		return result, fmt.Errorf("WriteSource failed: %s", message)
+	}
+	for _, syntax := range result.SyntaxErrors {
+		severity := strings.ToUpper(strings.TrimSpace(syntax.Severity))
+		if severity == "E" || severity == "A" || severity == "X" {
+			return result, fmt.Errorf("WriteSource reported a syntax error")
+		}
+	}
+	if result.Activation != nil && !result.Activation.Success {
+		return result, fmt.Errorf("WriteSource reported activation failure")
+	}
+	readBack, err := client.GetSource(ctx, objectType, name, nil)
+	if err != nil {
+		return result, fmt.Errorf("source read-back failed: %w", err)
+	}
+	if strings.TrimSpace(readBack) == "" {
+		return result, fmt.Errorf("source read-back was empty")
+	}
+	return result, nil
+}

--- a/internal/install/install_test.go
+++ b/internal/install/install_test.go
@@ -81,6 +81,7 @@ func TestEnsurePackage(t *testing.T) {
 	}
 }
 
+//nolint:misspell // CLAS is the SAP ADT object type.
 func TestDeploySource(t *testing.T) {
 	tests := []struct {
 		name    string

--- a/internal/install/install_test.go
+++ b/internal/install/install_test.go
@@ -1,0 +1,115 @@
+package install
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/oisee/vibing-steampunk/pkg/adt"
+)
+
+type fakeClient struct {
+	packageProbes []packageProbe
+	probeIndex    int
+	createErr     error
+	createCalls   int
+	writeResult   *adt.WriteSourceResult
+	writeErr      error
+	writeOpts     *adt.WriteSourceOptions
+	readBack      string
+	readBackErr   error
+}
+
+type packageProbe struct {
+	exists bool
+	err    error
+}
+
+func (f *fakeClient) PackageExists(context.Context, string) (bool, error) {
+	if f.probeIndex >= len(f.packageProbes) {
+		return false, errors.New("unexpected package probe")
+	}
+	probe := f.packageProbes[f.probeIndex]
+	f.probeIndex++
+	return probe.exists, probe.err
+}
+
+func (f *fakeClient) CreateObject(context.Context, adt.CreateObjectOptions) error {
+	f.createCalls++
+	return f.createErr
+}
+
+func (f *fakeClient) WriteSource(_ context.Context, _, _, _ string, opts *adt.WriteSourceOptions) (*adt.WriteSourceResult, error) {
+	f.writeOpts = opts
+	return f.writeResult, f.writeErr
+}
+
+func (f *fakeClient) GetSource(context.Context, string, string, *adt.GetSourceOptions) (string, error) {
+	return f.readBack, f.readBackErr
+}
+
+func TestEnsurePackage(t *testing.T) {
+	tests := []struct {
+		name        string
+		fake        *fakeClient
+		wantCreated bool
+		wantErr     bool
+		wantCreates int
+	}{
+		{name: "existing", fake: &fakeClient{packageProbes: []packageProbe{{exists: true}}}, wantCreates: 0},
+		{name: "created and verified", fake: &fakeClient{packageProbes: []packageProbe{{}, {exists: true}}}, wantCreated: true, wantCreates: 1},
+		{name: "concurrent create verified", fake: &fakeClient{packageProbes: []packageProbe{{}, {exists: true}}, createErr: errors.New("already exists")}, wantCreates: 1},
+		{name: "initial probe inconclusive", fake: &fakeClient{packageProbes: []packageProbe{{err: errors.New("synthetic auth failure")}}}, wantErr: true},
+		{name: "success but absent", fake: &fakeClient{packageProbes: []packageProbe{{}, {}}}, wantErr: true, wantCreates: 1},
+		{name: "create failed and absent", fake: &fakeClient{packageProbes: []packageProbe{{}, {}}, createErr: errors.New("synthetic create failure")}, wantErr: true, wantCreates: 1},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			created, err := EnsurePackage(context.Background(), tt.fake, "$SYNTHETIC", "Synthetic package")
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("error = %v, wantErr=%t", err, tt.wantErr)
+			}
+			if created != tt.wantCreated {
+				t.Fatalf("created = %t, want %t", created, tt.wantCreated)
+			}
+			if tt.fake.createCalls != tt.wantCreates {
+				t.Fatalf("create calls = %d, want %d", tt.fake.createCalls, tt.wantCreates)
+			}
+		})
+	}
+}
+
+func TestDeploySource(t *testing.T) {
+	tests := []struct {
+		name    string
+		fake    *fakeClient
+		wantErr string
+	}{
+		{name: "verified", fake: &fakeClient{writeResult: &adt.WriteSourceResult{Success: true, Activation: &adt.ActivationResult{Success: true}}, readBack: "synthetic source"}},
+		{name: "transport error", fake: &fakeClient{writeErr: errors.New("synthetic request failure")}, wantErr: "synthetic request failure"},
+		{name: "nil result", fake: &fakeClient{}, wantErr: "no result"},
+		{name: "logical failure", fake: &fakeClient{writeResult: &adt.WriteSourceResult{Message: "synthetic workflow failure"}}, wantErr: "synthetic workflow failure"},
+		{name: "syntax failure", fake: &fakeClient{writeResult: &adt.WriteSourceResult{Success: true, SyntaxErrors: []adt.SyntaxCheckResult{{Severity: "E"}}}}, wantErr: "syntax error"},
+		{name: "activation failure", fake: &fakeClient{writeResult: &adt.WriteSourceResult{Success: true, Activation: &adt.ActivationResult{Success: false}}}, wantErr: "activation failure"},
+		{name: "read-back failure", fake: &fakeClient{writeResult: &adt.WriteSourceResult{Success: true}, readBackErr: errors.New("synthetic read failure")}, wantErr: "read-back failed"},
+		{name: "empty read-back", fake: &fakeClient{writeResult: &adt.WriteSourceResult{Success: true}, readBack: "  "}, wantErr: "read-back was empty"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			opts := &adt.WriteSourceOptions{Description: "Synthetic object"}
+			_, err := DeploySource(context.Background(), tt.fake, "CLAS", "ZCL_SYNTHETIC", "synthetic source", opts)
+			if tt.wantErr == "" && err != nil {
+				t.Fatal(err)
+			}
+			if tt.wantErr != "" && (err == nil || !strings.Contains(err.Error(), tt.wantErr)) {
+				t.Fatalf("error = %v, want substring %q", err, tt.wantErr)
+			}
+			if tt.fake.writeOpts != opts {
+				t.Fatal("write options were not forwarded")
+			}
+		})
+	}
+}

--- a/internal/mcp/handlers_devtools.go
+++ b/internal/mcp/handlers_devtools.go
@@ -91,6 +91,9 @@ func (s *Server) handleActivate(ctx context.Context, request mcp.CallToolRequest
 	if err != nil {
 		return newToolResultError(fmt.Sprintf("Activation failed: %v", err)), nil
 	}
+	if err := adt.ActivationResultError(result); err != nil {
+		return newToolResultError(err.Error()), nil
+	}
 
 	output, _ := json.MarshalIndent(result, "", "  ")
 	return mcp.NewToolResultText(string(output)), nil

--- a/internal/mcp/handlers_help.go
+++ b/internal/mcp/handlers_help.go
@@ -232,6 +232,8 @@ Transport analysis:
 
 Execute ABAP:
   SAP(action="analyze", params={"type": "execute_abap", "code": "WRITE 'Hello'."})
+  Runs under ABAP Unit transaction semantics; normal database changes are rolled back.
+  Do not use execute_abap as an API for persistent writes.
 
 Runtime errors:
   SAP(action="analyze", params={"type": "list_dumps"})

--- a/internal/mcp/handlers_install.go
+++ b/internal/mcp/handlers_install.go
@@ -10,6 +10,7 @@ import (
 	"github.com/mark3labs/mcp-go/mcp"
 	embedded "github.com/oisee/vibing-steampunk/embedded/abap"
 	"github.com/oisee/vibing-steampunk/embedded/deps"
+	installer "github.com/oisee/vibing-steampunk/internal/install"
 	"github.com/oisee/vibing-steampunk/pkg/adt"
 )
 
@@ -85,24 +86,22 @@ func (s *Server) handleInstallDummyTest(ctx context.Context, request mcp.CallToo
 
 	// Step 1: Check/Create package (upsert strategy)
 	step("Package Check/Create")
-	pkg, err := s.adtClient.GetPackage(ctx, testPackage)
-	packageExists := err == nil && pkg.URI != "" // URI empty = package doesn't really exist
+	packageExists, err := s.adtClient.PackageExists(ctx, testPackage)
+	if err != nil {
+		return newToolResultError(fmt.Sprintf("PackageExists failed: %v", err)), nil
+	}
 	if !packageExists {
 		info("Package doesn't exist, creating...")
 		if checkOnly {
 			info("SKIP (check_only mode)")
 		} else {
-			err = s.adtClient.CreateObject(ctx, adt.CreateObjectOptions{
-				ObjectType:  adt.ObjectTypePackage,
-				Name:        testPackage,
-				Description: "Install Tools Test Package",
-			})
+			_, err = installer.EnsurePackage(ctx, s.adtClient, testPackage, "Install Tools Test Package")
 			if err != nil {
-				fail(fmt.Sprintf("CreateObject(package) failed: %v", err))
+				fail(fmt.Sprintf("EnsurePackage failed: %v", err))
 			} else {
 				// Verify
-				pkg, err = s.adtClient.GetPackage(ctx, testPackage)
-				if err != nil || pkg.URI == "" {
+				packageExists, err = s.adtClient.PackageExists(ctx, testPackage)
+				if err != nil || !packageExists {
 					fail("Verification failed: package not found after create")
 				} else {
 					pass("Package created and verified")
@@ -331,11 +330,13 @@ func (s *Server) handleInstallZADTVSP(ctx context.Context, request mcp.CallToolR
 	// Phase 1: Check prerequisites
 	sb.WriteString("Checking prerequisites...\n")
 
-	// Check if package exists (verify URI is populated - empty URI means package doesn't really exist)
-	packageExists := false
-	pkg, err := s.adtClient.GetPackage(ctx, packageName)
-	if err == nil && pkg.URI != "" {
-		packageExists = true
+	// Check package identity using the direct resource, which distinguishes an
+	// empty existing package from a missing one.
+	packageExists, err := s.adtClient.PackageExists(ctx, packageName)
+	if err != nil {
+		return newToolResultError(fmt.Sprintf("Failed to check package %s: %v", packageName, err)), nil
+	}
+	if packageExists {
 		fmt.Fprintf(&sb, "  ✓ Package %s exists\n", packageName)
 	} else {
 		fmt.Fprintf(&sb, "  → Package %s will be created\n", packageName)
@@ -387,23 +388,13 @@ func (s *Server) handleInstallZADTVSP(ctx context.Context, request mcp.CallToolR
 	defer cleanupPkgSafety()
 
 	// Phase 2: Create package if needed
-	if !packageExists {
+	created, err := installer.EnsurePackage(ctx, s.adtClient, packageName, "VSP WebSocket Handler")
+	if err != nil {
+		return newToolResultError(fmt.Sprintf("Failed to ensure package %s: %v", packageName, err)), nil
+	}
+	if created {
 		fmt.Fprintf(&sb, "Creating package %s...\n", packageName)
-		createOpts := adt.CreateObjectOptions{
-			ObjectType:  adt.ObjectTypePackage,
-			Name:        packageName,
-			Description: "VSP WebSocket Handler",
-		}
-		err := s.adtClient.CreateObject(ctx, createOpts)
-		if err != nil {
-			// On older SAP releases (e.g. 7.40), /sap/bc/adt/packages may not exist.
-			// Don't abort — the package may have been pre-created via SE21/SE80,
-			// and WriteSource will fail with a clear error if it truly doesn't exist.
-			fmt.Fprintf(&sb, "  ⚠ Package creation failed: %v\n", err)
-			fmt.Fprintf(&sb, "  → Continuing anyway (package may already exist via SE21/SE80)\n\n")
-		} else {
-			fmt.Fprintf(&sb, "  ✓ Package %s created\n\n", packageName)
-		}
+		fmt.Fprintf(&sb, "  ✓ Package %s created and verified\n\n", packageName)
 	} else {
 		fmt.Fprintf(&sb, "Using existing package %s\n\n", packageName)
 	}
@@ -427,10 +418,11 @@ func (s *Server) handleInstallZADTVSP(ctx context.Context, request mcp.CallToolR
 
 		// Use WriteSource to create/update
 		opts := &adt.WriteSourceOptions{
-			Package: packageName,
-			Mode:    adt.WriteModeUpsert,
+			Package:     packageName,
+			Description: obj.Description,
+			Mode:        adt.WriteModeUpsert,
 		}
-		_, err := s.adtClient.WriteSource(ctx, obj.Type, obj.Name, obj.Source, opts)
+		_, err := installer.DeploySource(ctx, s.adtClient, obj.Type, obj.Name, obj.Source, opts)
 		if err != nil {
 			fmt.Fprintf(&sb, "✗ Failed: %v\n", err)
 			failed = append(failed, obj.Name+": "+err.Error())
@@ -457,6 +449,9 @@ func (s *Server) handleInstallZADTVSP(ctx context.Context, request mcp.CallToolR
 	}
 
 	fmt.Fprintf(&sb, "\nDeployed: %d, Skipped: %d, Failed: %d\n\n", len(deployed), len(skipped), len(failed))
+	if len(failed) > 0 {
+		return newToolResultError(sb.String()), nil
+	}
 
 	// Post-deployment instructions
 	sb.WriteString(embedded.PostDeploymentInstructions())

--- a/internal/mcp/handlers_source.go
+++ b/internal/mcp/handlers_source.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strings"
 
 	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/oisee/vibing-steampunk/pkg/adt"
@@ -243,9 +244,26 @@ func (s *Server) handleWriteSource(ctx context.Context, request mcp.CallToolRequ
 	if err != nil {
 		return newToolResultError(fmt.Sprintf("WriteSource failed: %v", err)), nil
 	}
+	if err := validateWriteSourceResult(result); err != nil {
+		return newToolResultError(err.Error()), nil
+	}
 
 	output, _ := json.MarshalIndent(result, "", "  ")
 	return mcp.NewToolResultText(string(output)), nil
+}
+
+func validateWriteSourceResult(result *adt.WriteSourceResult) error {
+	if result == nil {
+		return fmt.Errorf("WriteSource failed: no result returned")
+	}
+	if result.Success {
+		return nil
+	}
+	message := strings.TrimSpace(result.Message)
+	if message == "" {
+		message = "operation returned success=false without a diagnostic"
+	}
+	return fmt.Errorf("WriteSource failed: %s", message)
 }
 
 // registerGrepObjects registers the unified GrepObjects tool

--- a/internal/mcp/handlers_source_test.go
+++ b/internal/mcp/handlers_source_test.go
@@ -1,0 +1,36 @@
+package mcp
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/oisee/vibing-steampunk/pkg/adt"
+)
+
+func TestValidateWriteSourceResult(t *testing.T) {
+	tests := []struct {
+		name    string
+		result  *adt.WriteSourceResult
+		wantErr string
+	}{
+		{name: "success", result: &adt.WriteSourceResult{Success: true}},
+		{name: "nil result", wantErr: "no result"},
+		{name: "diagnostic", result: &adt.WriteSourceResult{Message: "synthetic syntax failure"}, wantErr: "synthetic syntax failure"},
+		{name: "missing diagnostic", result: &adt.WriteSourceResult{}, wantErr: "without a diagnostic"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateWriteSourceResult(tt.result)
+			if tt.wantErr == "" {
+				if err != nil {
+					t.Fatalf("validateWriteSourceResult() error = %v", err)
+				}
+				return
+			}
+			if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+				t.Fatalf("validateWriteSourceResult() error = %v, want substring %q", err, tt.wantErr)
+			}
+		})
+	}
+}

--- a/internal/mcp/handlers_transport.go
+++ b/internal/mcp/handlers_transport.go
@@ -167,6 +167,12 @@ func (s *Server) handleExecuteABAP(ctx context.Context, request mcp.CallToolRequ
 	if err != nil {
 		return newToolResultError(fmt.Sprintf("ExecuteABAP failed: %v", err)), nil
 	}
+	if result == nil {
+		return newToolResultError("ExecuteABAP failed: no result returned"), nil
+	}
+	if !result.Success {
+		return newToolResultError(fmt.Sprintf("ExecuteABAP failed: %s", result.Message)), nil
+	}
 
 	var sb strings.Builder
 	fmt.Fprintf(&sb, "Program: %s\n", result.ProgramName)

--- a/internal/mcp/tools_register.go
+++ b/internal/mcp/tools_register.go
@@ -863,7 +863,7 @@ func (s *Server) registerDevTools(shouldRegister func(string) bool) {
 	// ExecuteABAP - execute arbitrary ABAP code via unit test wrapper (Expert mode only)
 	if shouldRegister("ExecuteABAP") {
 		s.mcpServer.AddTool(mcp.NewTool("ExecuteABAP",
-			mcp.WithDescription("Execute arbitrary ABAP code via unit test wrapper. Creates temp program, injects code into test method, runs via RunUnitTests, extracts results from assertion messages, cleans up. Use lv_result variable to return output. WARNING: Powerful tool - use responsibly."),
+			mcp.WithDescription("Execute ABAP code via a temporary ABAP Unit wrapper. Normal database changes are rolled back under test transactional semantics; this is not an API for persistent writes. Extracts lv_result from a completion assertion and fails on real test exceptions/assertions. WARNING: external side effects may not be reversible."),
 			mcp.WithString("code",
 				mcp.Required(),
 				mcp.Description("ABAP code to execute. Set lv_result variable to return output via assertion message."),

--- a/pkg/adt/client.go
+++ b/pkg/adt/client.go
@@ -24,6 +24,10 @@ type Client struct {
 	keepAliveCancel context.CancelFunc
 	keepAliveDone   chan struct{}
 	keepAliveMu     sync.Mutex
+
+	// Lock handles are session-bound and may carry the transport selected by
+	// SAP in the LOCK response. sync.Map keeps concurrent workflows isolated.
+	lockTransports sync.Map // map[lockHandle]corrNr
 }
 
 // NewClient creates a new ADT client with the given configuration.

--- a/pkg/adt/client.go
+++ b/pkg/adt/client.go
@@ -811,6 +811,27 @@ func (c *Client) GetMessageClass(ctx context.Context, msgClassName string) (*Mes
 
 // --- Package Operations ---
 
+// PackageExists checks package identity through the direct package resource.
+// Unlike the nodestructure endpoint used by GetPackage, this endpoint can
+// distinguish an empty existing package (200) from a missing package (404).
+// Other responses remain errors so callers do not create on an inconclusive
+// authentication, network, or server failure.
+func (c *Client) PackageExists(ctx context.Context, packageName string) (bool, error) {
+	packageName = strings.ToUpper(packageName)
+	packagePath := fmt.Sprintf("/sap/bc/adt/packages/%s", url.PathEscape(packageName))
+	_, err := c.transport.Request(ctx, packagePath, &RequestOptions{
+		Method: http.MethodGet,
+		Accept: "application/*",
+	})
+	if err == nil {
+		return true, nil
+	}
+	if IsNotFoundError(err) {
+		return false, nil
+	}
+	return false, fmt.Errorf("checking package %s: %w", packageName, err)
+}
+
 // GetPackage retrieves the contents of a package using the nodestructure API.
 func (c *Client) GetPackage(ctx context.Context, packageName string) (*PackageContent, error) {
 	packageName = strings.ToUpper(packageName)

--- a/pkg/adt/crud.go
+++ b/pkg/adt/crud.go
@@ -56,22 +56,8 @@ func (c *Client) LockObject(ctx context.Context, objectURL string, accessMode st
 	if err != nil {
 		return nil, err
 	}
-
-	// BTP / ABAP Cloud systems sometimes return a successful lock with
-	// MODIFICATION_SUPPORT="NoModification" — the lock acquired but the
-	// object is read-only via ADT (typical for SAP-delivered objects in
-	// hyperfocused mode, or systems where the user lacks the edit role).
-	// Without this guard the caller proceeds to PUT/POST and gets a
-	// confusing 423 InvalidLockHandle several seconds later. Surface it
-	// upfront so the user sees a clear, actionable error (issue #91).
-	if accessMode == "MODIFY" && strings.EqualFold(result.ModificationSupport, "NoModification") {
-		return nil, fmt.Errorf(
-			"object %s is not modifiable via ADT on this system "+
-				"(SAP returned modificationSupport=%q during LOCK). "+
-				"Common causes: read-only system class, missing developer/edit role, "+
-				"BTP ABAP Environment object outside the customer namespace, "+
-				"or hyperfocused mode locking the object as read-only",
-			objectURL, result.ModificationSupport)
+	if result.LockHandle != "" && result.CorrNr != "" {
+		c.lockTransports.Store(result.LockHandle, result.CorrNr)
 	}
 
 	return result, nil
@@ -125,8 +111,24 @@ func (c *Client) UnlockObject(ctx context.Context, objectURL string, lockHandle 
 	if err != nil {
 		return fmt.Errorf("unlocking object: %w", err)
 	}
+	c.lockTransports.Delete(lockHandle)
 
 	return nil
+}
+
+// effectiveLockTransport preserves an explicit caller transport and otherwise
+// reuses the correlation number returned by SAP for this lock. The resulting
+// value is fed through the ordinary mutation safety gate before any write.
+func (c *Client) effectiveLockTransport(lockHandle, requested string) string {
+	if requested != "" {
+		return requested
+	}
+	if value, ok := c.lockTransports.Load(lockHandle); ok {
+		if corrNr, ok := value.(string); ok {
+			return corrNr
+		}
+	}
+	return ""
 }
 
 // --- Update Source Operations ---
@@ -136,6 +138,7 @@ func (c *Client) UnlockObject(ctx context.Context, objectURL string, lockHandle 
 // lockHandle is required (from LockObject)
 // transport is optional (for transportable objects)
 func (c *Client) UpdateSource(ctx context.Context, objectSourceURL string, source string, lockHandle string, transport string) error {
+	transport = c.effectiveLockTransport(lockHandle, transport)
 	// Unified mutation policy gate (op type + package + transport)
 	if err := c.checkMutation(ctx, MutationContext{
 		Op:        OpUpdate,
@@ -448,6 +451,26 @@ func (c *Client) cleanupPartialObject(ctx context.Context, objectURL, pkg, trans
 		Package:   pkg,
 		Transport: transport,
 	}
+
+	// Resolve and enforce package scope before opening a stateful lock session.
+	// Once marked, DeleteObject skips only its redundant package lookup; it
+	// still enforces delete-operation and transport policy.
+	if err := c.checkMutation(ctx, MutationContext{
+		Op:        OpDelete,
+		OpName:    "cleanupPartialObject",
+		ObjectURL: objectURL,
+		Package:   pkg,
+		Transport: transport,
+	}); err != nil {
+		pce.CleanupActions = append(pce.CleanupActions,
+			fmt.Sprintf("cleanup blocked by mutation policy: %v", err))
+		pce.ManualSteps = []string{
+			"verify that the target package and transport are permitted by the configured safety policy",
+			"run the explicit recovery workflow only after that policy is corrected",
+		}
+		return pce
+	}
+	ctx = withMutationPackageChecked(ctx)
 
 	// Step 1: orphan lock cleanup (cheap; reuses the existing helper).
 	c.tryCleanupOrphanLock(ctx, objectURL)
@@ -871,6 +894,7 @@ func escapeXML(s string) string {
 // lockHandle is required (from LockObject)
 // transport is optional (for transportable objects)
 func (c *Client) DeleteObject(ctx context.Context, objectURL string, lockHandle string, transport string) error {
+	transport = c.effectiveLockTransport(lockHandle, transport)
 	// Unified mutation policy gate (op type + package + transport)
 	if err := c.checkMutation(ctx, MutationContext{
 		Op:        OpDelete,
@@ -895,6 +919,7 @@ func (c *Client) DeleteObject(ctx context.Context, objectURL string, lockHandle 
 	if err != nil {
 		return fmt.Errorf("deleting object: %w", err)
 	}
+	c.lockTransports.Delete(lockHandle)
 
 	return nil
 }
@@ -991,6 +1016,7 @@ func GetClassIncludeSourceURL(className string, includeType ClassIncludeType) st
 // Supports namespaced classes.
 func (c *Client) CreateTestInclude(ctx context.Context, className string, lockHandle string, transport string) error {
 	className = strings.ToUpper(className)
+	transport = c.effectiveLockTransport(lockHandle, transport)
 
 	// Unified mutation policy gate (op type + parent class package + transport)
 	if err := c.checkMutation(ctx, MutationContext{
@@ -1047,6 +1073,7 @@ func (c *Client) GetClassInclude(ctx context.Context, className string, includeT
 // Requires a lock on the parent class.
 func (c *Client) UpdateClassInclude(ctx context.Context, className string, includeType ClassIncludeType, source string, lockHandle string, transport string) error {
 	sourceURL := GetClassIncludeSourceURL(className, includeType)
+	transport = c.effectiveLockTransport(lockHandle, transport)
 
 	// Unified mutation policy gate (op type + package + transport)
 	if err := c.checkMutation(ctx, MutationContext{
@@ -1157,11 +1184,11 @@ func parsePublishResult(data []byte) (*PublishResult, error) {
 
 // CreateTableOptions defines options for creating a DDIC table.
 type CreateTableOptions struct {
-	Name          string       `json:"name"`          // Table name (uppercase, max 30 chars, must start with Z/Y)
-	Description   string       `json:"description"`   // Short description
-	Package       string       `json:"package"`       // Target package
-	Fields        []TableField `json:"fields"`        // Field definitions
-	Transport     string       `json:"transport,omitempty"` // Transport request (optional for $TMP)
+	Name          string       `json:"name"`                    // Table name (uppercase, max 30 chars, must start with Z/Y)
+	Description   string       `json:"description"`             // Short description
+	Package       string       `json:"package"`                 // Target package
+	Fields        []TableField `json:"fields"`                  // Field definitions
+	Transport     string       `json:"transport,omitempty"`     // Transport request (optional for $TMP)
 	DeliveryClass string       `json:"deliveryClass,omitempty"` // A=Application, C=Customizing, L=Temp, etc. (default: A)
 	TableCategory string       `json:"tableCategory,omitempty"` // TRANSPARENT (default), STRUCTURE, etc.
 }
@@ -1169,9 +1196,15 @@ type CreateTableOptions struct {
 // CreateTable creates a new DDIC transparent table from JSON-like options.
 // This is a high-level tool that handles the full workflow: create → set source → activate.
 func (c *Client) CreateTable(ctx context.Context, opts CreateTableOptions) error {
-	if err := c.checkSafety(OpCreate, "CreateTable"); err != nil {
+	if err := c.checkMutation(ctx, MutationContext{
+		Op:        OpCreate,
+		OpName:    "CreateTable",
+		Package:   strings.ToUpper(opts.Package),
+		Transport: opts.Transport,
+	}); err != nil {
 		return err
 	}
+	ctx = withMutationPackageChecked(ctx)
 
 	// Validate input
 	opts.Name = strings.ToUpper(opts.Name)
@@ -1229,18 +1262,7 @@ func (c *Client) CreateTable(ctx context.Context, opts CreateTableOptions) error
 		return fmt.Errorf("locking table: %w", err)
 	}
 
-	params = url.Values{}
-	params.Set("lockHandle", lock.LockHandle)
-	if opts.Transport != "" {
-		params.Set("corrNr", opts.Transport)
-	}
-
-	_, err = c.transport.Request(ctx, sourceURL, &RequestOptions{
-		Method:      http.MethodPut,
-		Query:       params,
-		Body:        []byte(ddlSource),
-		ContentType: "text/plain",
-	})
+	err = c.UpdateSource(ctx, sourceURL, ddlSource, lock.LockHandle, opts.Transport)
 	if err != nil {
 		c.UnlockObject(ctx, tableURL, lock.LockHandle)
 		return fmt.Errorf("updating table source: %w", err)

--- a/pkg/adt/crud.go
+++ b/pkg/adt/crud.go
@@ -386,6 +386,13 @@ func (c *Client) objectExistsByURL(ctx context.Context, objectURL string) (bool,
 // returned PartialCreateError. Manual recovery hints are only added
 // when our best-effort attempt could not finish.
 func (c *Client) reconcileFailedCreate(ctx context.Context, opts CreateObjectOptions, createErr error) error {
+	// A resource-already-exists response proves the object predates this create
+	// attempt. It is not partial persistence owned by this request, so automatic
+	// cleanup must never lock or delete it.
+	if isAlreadyExistsError(createErr) {
+		return createErr
+	}
+
 	objectURL := GetObjectURL(opts.ObjectType, opts.Name, opts.ParentName)
 	if objectURL == "" {
 		// Object type we cannot URL-encode → no probe possible.
@@ -407,6 +414,20 @@ func (c *Client) reconcileFailedCreate(ctx context.Context, opts CreateObjectOpt
 	pce := c.cleanupPartialObject(ctx, objectURL, opts.PackageName, opts.Transport)
 	pce.OriginalErr = createErr
 	return pce
+}
+
+func isAlreadyExistsError(err error) bool {
+	if err == nil {
+		return false
+	}
+	var apiErr *APIError
+	if !errors.As(err, &apiErr) || (apiErr.StatusCode != http.StatusBadRequest && apiErr.StatusCode != http.StatusConflict) {
+		return false
+	}
+	message := strings.ToLower(apiErr.Message)
+	return strings.Contains(message, "exceptionresourcealreadyexists") ||
+		strings.Contains(message, "already exists") ||
+		strings.Contains(message, "does already exist")
 }
 
 // cleanupPartialObject runs the best-effort compensating cleanup for a

--- a/pkg/adt/crud.go
+++ b/pkg/adt/crud.go
@@ -1269,10 +1269,18 @@ func (c *Client) CreateTable(ctx context.Context, opts CreateTableOptions) error
 	}
 
 	// Unlock BEFORE activation
-	c.UnlockObject(ctx, tableURL, lock.LockHandle)
+	err = c.UnlockObject(ctx, tableURL, lock.LockHandle)
+	if err != nil {
+		return fmt.Errorf("unlocking table before activation: %w", err)
+	}
 
 	// Step 3: Activate
-	if _, err := c.Activate(ctx, tableURL, opts.Name); err != nil {
+	activation, err := c.Activate(ctx, tableURL, opts.Name)
+	if err != nil {
+		return fmt.Errorf("activating table: %w", err)
+	}
+	err = ActivationResultError(activation)
+	if err != nil {
 		return fmt.Errorf("activating table: %w", err)
 	}
 

--- a/pkg/adt/crud_reconcile_test.go
+++ b/pkg/adt/crud_reconcile_test.go
@@ -156,6 +156,59 @@ func TestCreateObject_CleanFailureBeforePersistence(t *testing.T) {
 	}
 }
 
+func TestReconcileFailedCreate_DoesNotDeletePreExistingObject(t *testing.T) {
+	mock := &methodPathMock{}
+	client := newReconcileClient(t, mock)
+	createErr := &APIError{
+		StatusCode: http.StatusBadRequest,
+		Message:    "ExceptionResourceAlreadyExists: synthetic object already exists",
+	}
+
+	err := client.reconcileFailedCreate(context.Background(), CreateObjectOptions{
+		ObjectType:  ObjectTypePackage,
+		Name:        "$SYNTHETIC",
+		PackageName: "$SYNTHETIC",
+	}, createErr)
+	if !errors.Is(err, createErr) {
+		t.Fatalf("error = %v, want original already-exists error", err)
+	}
+	if len(mock.calls) != 0 {
+		t.Fatalf("reconciliation touched a pre-existing object: %#v", mock.calls)
+	}
+}
+
+func TestPackageExistsUsesDirectResource(t *testing.T) {
+	tests := []struct {
+		name       string
+		status     int
+		wantExists bool
+		wantErr    bool
+	}{
+		{name: "existing empty package", status: http.StatusOK, wantExists: true},
+		{name: "missing package", status: http.StatusNotFound},
+		{name: "inconclusive server error", status: http.StatusInternalServerError, wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mock := &methodPathMock{routes: []routedResponse{
+				resp(http.MethodGet, "/packages/$SYNTHETIC", tt.status, "synthetic response"),
+			}}
+			client := newReconcileClient(t, mock)
+			exists, err := client.PackageExists(context.Background(), "$SYNTHETIC")
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("error = %v, wantErr=%t", err, tt.wantErr)
+			}
+			if exists != tt.wantExists {
+				t.Fatalf("exists = %t, want %t", exists, tt.wantExists)
+			}
+			if len(mock.calls) != 1 || mock.calls[0].method != http.MethodGet {
+				t.Fatalf("unexpected calls: %#v", mock.calls)
+			}
+		})
+	}
+}
+
 // TestCreateObject_PartialPersistenceCleanupOK covers the prod-incident
 // scenario: CreateObject POST returns 500 but SAP already persisted the
 // object. The existence probe returns 200, lock acquisition succeeds,

--- a/pkg/adt/crud_reconcile_test.go
+++ b/pkg/adt/crud_reconcile_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"io"
 	"net/http"
+	"net/url"
 	"strings"
 	"testing"
 )
@@ -33,10 +34,11 @@ type routedResponse struct {
 type recordedCall struct {
 	method string
 	path   string
+	query  url.Values
 }
 
 func (m *methodPathMock) Do(req *http.Request) (*http.Response, error) {
-	m.calls = append(m.calls, recordedCall{method: req.Method, path: req.URL.Path})
+	m.calls = append(m.calls, recordedCall{method: req.Method, path: req.URL.Path, query: req.URL.Query()})
 	for _, r := range m.routes {
 		if r.method != "" && r.method != req.Method {
 			continue
@@ -111,6 +113,7 @@ func newReconcileClient(t *testing.T, mock *methodPathMock) *Client {
 	cfg := NewConfig("https://sap.example.com:44300", "user", "pass",
 		WithAllowedPackages("$TMP"),
 		WithEnableTransports(),
+		WithAllowTransportableEdits(),
 	)
 	transport := NewTransportWithClient(cfg, mock)
 	return NewClientWithTransport(cfg, transport)
@@ -375,8 +378,8 @@ func TestDeleteObject_UsesStatefulSession(t *testing.T) {
 // stateful-session regression test — the main methodPathMock already
 // records method+path but throws headers away.
 type headerCaptureMock struct {
-	inner     *methodPathMock
-	captured  []capturedReq
+	inner    *methodPathMock
+	captured []capturedReq
 }
 
 type capturedReq struct {
@@ -603,14 +606,11 @@ func TestCreateTestInclude_UsesStatefulSession(t *testing.T) {
 	}
 }
 
-// TestLockObject_RejectsNoModification covers the BTP / ABAP Cloud
-// case from issue #91: a successful LOCK can return
-// MODIFICATION_SUPPORT=NoModification to signal that the object is
-// read-only via ADT for this user/system. Before the fix the caller
-// proceeded to PUT and got a confusing 423 InvalidLockHandle several
-// seconds later. The expected behaviour is to fail at the LOCK call
-// with a clear, actionable error message.
-func TestLockObject_RejectsNoModification(t *testing.T) {
+// TestLockObject_PreservesModificationSupport covers issue #141:
+// MODIFICATION_SUPPORT is Modification Assistant metadata, not an edit
+// permission. LockObject must preserve the value for callers without
+// converting a successful server lock into a client-side rejection.
+func TestLockObject_PreservesModificationSupport(t *testing.T) {
 	const noModLockXML = `<?xml version="1.0" encoding="UTF-8"?>
 <asx:abap xmlns:asx="http://www.sap.com/abapxml" version="1.0">
   <asx:values>
@@ -635,19 +635,19 @@ func TestLockObject_RejectsNoModification(t *testing.T) {
 	transport := NewTransportWithClient(cfg, mock)
 	client := NewClientWithTransport(cfg, transport)
 
-	_, err := client.LockObject(
+	result, err := client.LockObject(
 		context.Background(),
 		"/sap/bc/adt/oo/classes/ZREADONLY",
 		"MODIFY",
 	)
-	if err == nil {
-		t.Fatal("LockObject should have returned an error for NoModification, got nil")
+	if err != nil {
+		t.Fatalf("LockObject returned an error for valid metadata: %v", err)
 	}
-	if !strings.Contains(err.Error(), "not modifiable") {
-		t.Errorf("error = %q, want to contain \"not modifiable\"", err.Error())
+	if result.LockHandle != "HANDLE-X" {
+		t.Errorf("LockHandle = %q, want HANDLE-X", result.LockHandle)
 	}
-	if !strings.Contains(err.Error(), "NoModification") {
-		t.Errorf("error = %q, want to surface the raw modificationSupport value", err.Error())
+	if result.ModificationSupport != "NoModification" {
+		t.Errorf("ModificationSupport = %q, want NoModification", result.ModificationSupport)
 	}
 }
 
@@ -691,4 +691,206 @@ func TestLockObject_AllowsNoModificationOnReadLock(t *testing.T) {
 	if result.LockHandle != "HANDLE-X" {
 		t.Errorf("LockHandle = %q, want HANDLE-X", result.LockHandle)
 	}
+}
+
+const syntheticTransportLockXML = `<?xml version="1.0" encoding="UTF-8"?>
+<asx:abap xmlns:asx="http://www.sap.com/abapxml" version="1.0">
+  <asx:values><DATA>
+    <LOCK_HANDLE>SYNTHETIC-HANDLE</LOCK_HANDLE>
+    <CORRNR>REQ-SYN-001</CORRNR>
+    <MODIFICATION_SUPPORT>NoModification</MODIFICATION_SUPPORT>
+  </DATA></asx:values>
+</asx:abap>`
+
+const syntheticLocalLockXML = `<?xml version="1.0" encoding="UTF-8"?>
+<asx:abap xmlns:asx="http://www.sap.com/abapxml" version="1.0">
+  <asx:values><DATA>
+    <LOCK_HANDLE>SYNTHETIC-HANDLE</LOCK_HANDLE>
+  </DATA></asx:values>
+</asx:abap>`
+
+func TestUpdateSource_UsesLockCorrelationTransport(t *testing.T) {
+	mock := &methodPathMock{routes: []routedResponse{
+		resp("", "discovery", http.StatusOK, ""),
+		resp(http.MethodPost, "/programs/programs/ZSYNTHETIC", http.StatusOK, syntheticTransportLockXML),
+		resp(http.MethodPut, "/source/main", http.StatusOK, ""),
+	}}
+	cfg := NewConfig("https://sap.example.com:44300", "user", "pass",
+		WithAllowTransportableEdits(),
+		WithAllowedTransports("REQ-SYN-*"),
+	)
+	client := NewClientWithTransport(cfg, NewTransportWithClient(cfg, mock))
+
+	lock, err := client.LockObject(context.Background(), "/sap/bc/adt/programs/programs/ZSYNTHETIC", "MODIFY")
+	if err != nil {
+		t.Fatalf("LockObject failed: %v", err)
+	}
+	if err := client.UpdateSource(context.Background(), "/sap/bc/adt/programs/programs/ZSYNTHETIC/source/main", "REPORT zsynthetic.", lock.LockHandle, ""); err != nil {
+		t.Fatalf("UpdateSource failed: %v", err)
+	}
+
+	for _, call := range mock.calls {
+		if call.method == http.MethodPut {
+			if got := call.query.Get("corrNr"); got != "REQ-SYN-001" {
+				t.Fatalf("PUT corrNr = %q, want REQ-SYN-001", got)
+			}
+			return
+		}
+	}
+	t.Fatal("no PUT request was sent")
+}
+
+func TestUpdateSource_ExplicitTransportOverridesLockCorrelation(t *testing.T) {
+	mock := &methodPathMock{routes: []routedResponse{
+		resp("", "discovery", http.StatusOK, ""),
+		resp(http.MethodPost, "/programs/programs/ZSYNTHETIC", http.StatusOK, syntheticTransportLockXML),
+		resp(http.MethodPut, "/source/main", http.StatusOK, ""),
+	}}
+	cfg := NewConfig("https://sap.example.com:44300", "user", "pass",
+		WithAllowTransportableEdits(),
+		WithAllowedTransports("REQ-EXPLICIT-*"),
+	)
+	client := NewClientWithTransport(cfg, NewTransportWithClient(cfg, mock))
+
+	lock, err := client.LockObject(context.Background(), "/sap/bc/adt/programs/programs/ZSYNTHETIC", "MODIFY")
+	if err != nil {
+		t.Fatalf("LockObject failed: %v", err)
+	}
+	if err := client.UpdateSource(context.Background(), "/sap/bc/adt/programs/programs/ZSYNTHETIC/source/main", "REPORT zsynthetic.", lock.LockHandle, "REQ-EXPLICIT-001"); err != nil {
+		t.Fatalf("UpdateSource failed: %v", err)
+	}
+
+	foundPUT := false
+	for _, call := range mock.calls {
+		if call.method == http.MethodPut {
+			foundPUT = true
+			if call.query.Get("corrNr") != "REQ-EXPLICIT-001" {
+				t.Fatalf("PUT corrNr = %q, want explicit transport", call.query.Get("corrNr"))
+			}
+		}
+	}
+	if !foundPUT {
+		t.Fatal("no PUT request was sent")
+	}
+}
+
+func TestUpdateSource_LockCorrelationStillHonorsSafety(t *testing.T) {
+	tests := []struct {
+		name    string
+		options []Option
+	}{
+		{name: "transportable edits disabled"},
+		{name: "transport not allowed", options: []Option{WithAllowTransportableEdits(), WithAllowedTransports("REQ-OTHER-*")}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mock := &methodPathMock{routes: []routedResponse{
+				resp("", "discovery", http.StatusOK, ""),
+				resp(http.MethodPost, "/programs/programs/ZSYNTHETIC", http.StatusOK, syntheticTransportLockXML),
+			}}
+			cfg := NewConfig("https://sap.example.com:44300", "user", "pass", tt.options...)
+			client := NewClientWithTransport(cfg, NewTransportWithClient(cfg, mock))
+			lock, err := client.LockObject(context.Background(), "/sap/bc/adt/programs/programs/ZSYNTHETIC", "MODIFY")
+			if err != nil {
+				t.Fatalf("LockObject failed: %v", err)
+			}
+			err = client.UpdateSource(context.Background(), "/sap/bc/adt/programs/programs/ZSYNTHETIC/source/main", "REPORT zsynthetic.", lock.LockHandle, "")
+			if err == nil {
+				t.Fatal("UpdateSource should be blocked by transport safety")
+			}
+			for _, call := range mock.calls {
+				if call.method == http.MethodPut {
+					t.Fatal("blocked mutation sent a PUT request")
+				}
+			}
+		})
+	}
+}
+
+func TestUpdateSource_PropagatesWriteFailuresWithoutBlindRetry(t *testing.T) {
+	for _, status := range []int{http.StatusLocked, http.StatusConflict, http.StatusBadRequest} {
+		t.Run(http.StatusText(status), func(t *testing.T) {
+			mock := &methodPathMock{routes: []routedResponse{
+				resp("", "discovery", http.StatusOK, ""),
+				resp(http.MethodPut, "/source/main", status, "synthetic write failure"),
+			}}
+			cfg := NewConfig("https://sap.example.com:44300", "user", "pass")
+			client := NewClientWithTransport(cfg, NewTransportWithClient(cfg, mock))
+			err := client.UpdateSource(context.Background(), "/sap/bc/adt/programs/programs/ZSYNTHETIC/source/main", "REPORT zsynthetic.", "SYNTHETIC-HANDLE", "")
+			var apiErr *APIError
+			if !errors.As(err, &apiErr) || apiErr.StatusCode != status {
+				t.Fatalf("error = %v, want API status %d", err, status)
+			}
+			putCount := 0
+			for _, call := range mock.calls {
+				if call.method == http.MethodPut {
+					putCount++
+				}
+			}
+			if putCount != 1 {
+				t.Fatalf("PUT count = %d, want 1", putCount)
+			}
+		})
+	}
+}
+
+func TestEditSource_NoPackageLookupBetweenLockAndWriteAndUnlocksOnFailure(t *testing.T) {
+	mock := &methodPathMock{routes: []routedResponse{
+		resp(http.MethodGet, "informationsystem/search", http.StatusOK, `<?xml version="1.0"?><adtcore:objectReferences xmlns:adtcore="http://www.sap.com/adt/core"><adtcore:objectReference adtcore:uri="/sap/bc/adt/programs/programs/zsynthetic" adtcore:type="PROG/P" adtcore:name="ZSYNTHETIC" adtcore:packageName="$TMP"/></adtcore:objectReferences>`),
+		resp(http.MethodGet, "/source/main", http.StatusOK, "REPORT zsynthetic."),
+		resp(http.MethodPost, "/programs/programs/ZSYNTHETIC", http.StatusOK, syntheticLocalLockXML),
+		resp(http.MethodPut, "/source/main", http.StatusLocked, "synthetic lock failure"),
+	}}
+	cfg := NewConfig("https://sap.example.com:44300", "user", "pass", WithAllowedPackages("$TMP"))
+	client := NewClientWithTransport(cfg, NewTransportWithClient(cfg, mock))
+	result, err := client.EditSourceWithOptions(
+		context.Background(),
+		"/sap/bc/adt/programs/programs/ZSYNTHETIC",
+		"REPORT zsynthetic.",
+		"REPORT zsynthetic_changed.",
+		&EditSourceOptions{SyntaxCheck: false},
+	)
+	if err != nil {
+		t.Fatalf("EditSourceWithOptions returned error: %v", err)
+	}
+	if result == nil || !strings.Contains(result.Message, "Failed to update source") {
+		t.Fatalf("unexpected result: %#v", result)
+	}
+
+	searches, lockIndex, putIndex, unlockIndex := 0, -1, -1, -1
+	for i, call := range mock.calls {
+		if strings.Contains(call.path, "informationsystem/search") {
+			searches++
+		}
+		if call.method == http.MethodPost && call.query.Get("_action") == "LOCK" {
+			lockIndex = i
+		}
+		if call.method == http.MethodPut {
+			putIndex = i
+		}
+		if call.method == http.MethodPost && call.query.Get("_action") == "UNLOCK" {
+			unlockIndex = i
+		}
+	}
+	if searches != 1 || lockIndex < 0 || putIndex != lockIndex+1 || unlockIndex <= putIndex {
+		t.Fatalf("unsafe request order: %#v", mock.calls)
+	}
+}
+
+func TestMutationPackageMarkerDoesNotBypassOperationOrTransportPolicy(t *testing.T) {
+	ctx := withMutationPackageChecked(context.Background())
+	t.Run("operation", func(t *testing.T) {
+		cfg := NewConfig("https://sap.example.com:44300", "user", "pass", WithSafety(SafetyConfig{DisallowedOps: "U"}))
+		client := NewClientWithTransport(cfg, NewTransportWithClient(cfg, &methodPathMock{}))
+		if err := client.checkMutation(ctx, MutationContext{Op: OpUpdate, OpName: "synthetic update"}); err == nil {
+			t.Fatal("marked context bypassed operation policy")
+		}
+	})
+	t.Run("transport", func(t *testing.T) {
+		cfg := NewConfig("https://sap.example.com:44300", "user", "pass")
+		client := NewClientWithTransport(cfg, NewTransportWithClient(cfg, &methodPathMock{}))
+		if err := client.checkMutation(ctx, MutationContext{Op: OpUpdate, OpName: "synthetic update", Transport: "REQ-SYN-001"}); err == nil {
+			t.Fatal("marked context bypassed transport policy")
+		}
+	})
 }

--- a/pkg/adt/devtools.go
+++ b/pkg/adt/devtools.go
@@ -122,9 +122,9 @@ func parseSyntaxCheckResults(data []byte) ([]SyntaxCheckResult, error) {
 
 // ActivationResult represents the result of an activation.
 type ActivationResult struct {
-	Success  bool                       `json:"success"`
-	Messages []ActivationResultMessage  `json:"messages"`
-	Inactive []InactiveObject           `json:"inactive,omitempty"`
+	Success  bool                      `json:"success"`
+	Messages []ActivationResultMessage `json:"messages"`
+	Inactive []InactiveObject          `json:"inactive,omitempty"`
 }
 
 // ActivationResultMessage represents a message from activation.
@@ -135,6 +135,33 @@ type ActivationResultMessage struct {
 	Href           string `json:"href,omitempty"`
 	ForceSupported bool   `json:"forceSupported,omitempty"`
 	ShortText      string `json:"shortText"`
+}
+
+// ActivationResultError converts a logical activation failure into an error
+// without changing Activate's result-oriented public contract. Callers that
+// must not proceed after a failed activation should use this helper after the
+// HTTP request succeeds.
+func ActivationResultError(result *ActivationResult) error {
+	if result == nil {
+		return fmt.Errorf("activation returned no result")
+	}
+	if result.Success {
+		return nil
+	}
+
+	var diagnostics []string
+	for _, message := range result.Messages {
+		if text := strings.TrimSpace(message.ShortText); text != "" {
+			diagnostics = append(diagnostics, text)
+		}
+	}
+	if len(result.Inactive) > 0 {
+		diagnostics = append(diagnostics, fmt.Sprintf("%d object(s) remain inactive", len(result.Inactive)))
+	}
+	if len(diagnostics) == 0 {
+		return fmt.Errorf("activation returned success=false without a diagnostic")
+	}
+	return fmt.Errorf("activation failed: %s", strings.Join(diagnostics, "; "))
 }
 
 // InactiveObject represents an inactive object.
@@ -295,7 +322,7 @@ func parseInactiveObjects(data []byte) ([]InactiveObjectRecord, error) {
 		ParentURI string `xml:"parentUri,attr"`
 	}
 	type objectElement struct {
-		Deleted bool `xml:"deleted,attr"`
+		Deleted bool   `xml:"deleted,attr"`
 		User    string `xml:"user,attr"`
 		Ref     ref    `xml:"ref"`
 	}
@@ -436,7 +463,10 @@ func (c *Client) ActivatePackage(ctx context.Context, packageName string, maxObj
 			continue
 		}
 		obj := rec.Object
-		_, err := c.Activate(ctx, obj.URI, obj.Name)
+		activation, err := c.Activate(ctx, obj.URI, obj.Name)
+		if err == nil {
+			err = ActivationResultError(activation)
+		}
 		if err != nil {
 			result.Failed = append(result.Failed, ActivationFailed{
 				Name:   obj.Name,
@@ -708,13 +738,13 @@ func parseUnitTestResult(data []byte) (*UnitTestResult, error) {
 		} `xml:"stack"`
 	}
 	type testMethod struct {
-		URI           string `xml:"uri,attr"`
-		Type          string `xml:"type,attr"`
-		Name          string `xml:"name,attr"`
+		URI           string  `xml:"uri,attr"`
+		Type          string  `xml:"type,attr"`
+		Name          string  `xml:"name,attr"`
 		ExecutionTime float64 `xml:"executionTime,attr"`
-		URIType       string `xml:"uriType,attr"`
-		NavigationURI string `xml:"navigationUri,attr"`
-		Unit          string `xml:"unit,attr"`
+		URIType       string  `xml:"uriType,attr"`
+		NavigationURI string  `xml:"navigationUri,attr"`
+		Unit          string  `xml:"unit,attr"`
 		Alerts        struct {
 			Items []alert `xml:"alert"`
 		} `xml:"alerts"`
@@ -735,9 +765,9 @@ func parseUnitTestResult(data []byte) (*UnitTestResult, error) {
 		} `xml:"alerts"`
 	}
 	type program struct {
-		URI  string `xml:"uri,attr"`
-		Type string `xml:"type,attr"`
-		Name string `xml:"name,attr"`
+		URI         string `xml:"uri,attr"`
+		Type        string `xml:"type,attr"`
+		Name        string `xml:"name,attr"`
 		TestClasses struct {
 			Items []testClass `xml:"testClass"`
 		} `xml:"testClasses"`

--- a/pkg/adt/devtools_activation_test.go
+++ b/pkg/adt/devtools_activation_test.go
@@ -1,0 +1,127 @@
+package adt
+
+import (
+	"context"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+func TestActivationResultError(t *testing.T) {
+	tests := []struct {
+		name    string
+		result  *ActivationResult
+		wantErr string
+	}{
+		{name: "success", result: &ActivationResult{Success: true}},
+		{name: "nil result", wantErr: "no result"},
+		{
+			name: "message diagnostic",
+			result: &ActivationResult{Messages: []ActivationResultMessage{
+				{Type: "E", ShortText: "synthetic activation failure"},
+			}},
+			wantErr: "synthetic activation failure",
+		},
+		{
+			name:    "inactive diagnostic",
+			result:  &ActivationResult{Inactive: []InactiveObject{{Name: "ZSYNTHETIC"}}},
+			wantErr: "1 object(s) remain inactive",
+		},
+		{name: "missing diagnostic", result: &ActivationResult{}, wantErr: "without a diagnostic"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ActivationResultError(tt.result)
+			if tt.wantErr == "" {
+				if err != nil {
+					t.Fatalf("ActivationResultError() error = %v", err)
+				}
+				return
+			}
+			if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+				t.Fatalf("ActivationResultError() error = %v, want substring %q", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestRenameUsesSourceEndpoint(t *testing.T) {
+	client := &Client{}
+	got, err := client.buildSourceURL(ObjectTypeProgram, "ZSYNTHETIC")
+	if err != nil {
+		t.Fatalf("buildSourceURL() error = %v", err)
+	}
+	if !strings.HasSuffix(got, "/source/main") {
+		t.Fatalf("buildSourceURL() = %q, want source endpoint", got)
+	}
+}
+
+//nolint:bodyclose // Transport.Request owns and closes every synthetic response body.
+func TestActivatePackageClassifiesLogicalFailure(t *testing.T) {
+	inactiveXML := `<inactiveObjects><entry><object user="SYNTHETIC"><ref uri="/sap/bc/adt/programs/programs/ZSYNTHETIC" type="PROG/P" name="ZSYNTHETIC" parentUri="/sap/bc/adt/packages/$TMP"/></object></entry></inactiveObjects>`
+	activationXML := `<activation><messages><msg type="E"><shortText><txt>synthetic activation failure</txt></shortText></msg></messages></activation>`
+	mock := &mockHTTPClient{responses: []*http.Response{
+		newMockResponse(http.StatusOK, inactiveXML, nil),
+		newMockResponse(http.StatusOK, activationXML, nil),
+	}}
+	cfg := NewConfig("https://sap.example.com:44300", "user", "pass")
+	transport := NewTransportWithClient(cfg, mock)
+	transport.setCSRFToken("synthetic-token")
+	client := NewClientWithTransport(cfg, transport)
+
+	result, err := client.ActivatePackage(context.Background(), "$TMP", 10)
+	if err != nil {
+		t.Fatalf("ActivatePackage() error = %v", err)
+	}
+	if len(result.Activated) != 0 {
+		t.Fatalf("activated = %d, want 0", len(result.Activated))
+	}
+	if len(result.Failed) != 1 || !strings.Contains(result.Failed[0].Reason, "synthetic activation failure") {
+		t.Fatalf("failed = %#v, want one logical activation failure", result.Failed)
+	}
+	if len(mock.requests) != 2 {
+		t.Fatalf("requests = %d, want inactive lookup plus activation", len(mock.requests))
+	}
+}
+
+//nolint:bodyclose // Transport.Request owns and closes every synthetic response body.
+func TestRenameStopsBeforeDeletingOldObjectWhenActivationFails(t *testing.T) {
+	lockXML := `<?xml version="1.0"?><asx:abap xmlns:asx="http://www.sap.com/abapxml"><asx:values><DATA><LOCK_HANDLE>SYNTHETIC-HANDLE</LOCK_HANDLE></DATA></asx:values></asx:abap>`
+	activationXML := `<activation><messages><msg type="E"><shortText><txt>synthetic activation failure</txt></shortText></msg></messages></activation>`
+	mock := &mockHTTPClient{responses: []*http.Response{
+		newMockResponse(http.StatusOK, "REPORT zold.", nil), // Read old source.
+		newMockResponse(http.StatusOK, "", nil),             // Verify package.
+		newMockResponse(http.StatusCreated, "", nil),        // Create new object.
+		newMockResponse(http.StatusOK, lockXML, nil),        // Lock new object.
+		newMockResponse(http.StatusOK, "", nil),             // Write new source.
+		newMockResponse(http.StatusOK, "", nil),             // Unlock new object.
+		newMockResponse(http.StatusOK, activationXML, nil),  // Logical activation failure.
+	}}
+	cfg := NewConfig("https://sap.example.com:44300", "user", "pass")
+	transport := NewTransportWithClient(cfg, mock)
+	transport.setCSRFToken("synthetic-token")
+	client := NewClientWithTransport(cfg, transport)
+
+	result, err := client.RenameObject(context.Background(), ObjectTypeProgram, "ZOLD", "ZNEW", "$TMP", "")
+	if err != nil {
+		t.Fatalf("RenameObject() error = %v", err)
+	}
+	if result.Success {
+		t.Fatal("RenameObject() success = true after logical activation failure")
+	}
+	if len(result.Errors) == 0 || !strings.Contains(result.Errors[0], "synthetic activation failure") {
+		t.Fatalf("errors = %#v, want activation diagnostic", result.Errors)
+	}
+	if len(mock.requests) != 7 {
+		t.Fatalf("requests = %d, want flow to stop immediately after activation", len(mock.requests))
+	}
+	if got := mock.requests[4].URL.Path; !strings.HasSuffix(got, "/znew/source/main") {
+		t.Fatalf("write path = %q, want new object's source endpoint", got)
+	}
+	for _, req := range mock.requests {
+		if strings.Contains(req.URL.Path, "/zold") && req.URL.Query().Get("_action") == "LOCK" {
+			t.Fatalf("old object was locked for deletion after activation failure: %s", req.URL.String())
+		}
+	}
+}

--- a/pkg/adt/http.go
+++ b/pkg/adt/http.go
@@ -131,8 +131,8 @@ func (t *Transport) Request(ctx context.Context, path string, opts *RequestOptio
 		token := t.getCSRFToken()
 		if token == "" {
 			// Fetch CSRF token first
-			if err := t.fetchCSRFToken(ctx, opts.Stateful); err != nil {
-				return nil, fmt.Errorf("fetching CSRF token: %w", err)
+			if fetchErr := t.fetchCSRFToken(ctx, opts.Stateful); fetchErr != nil {
+				return nil, fmt.Errorf("fetching CSRF token: %w", fetchErr)
 			}
 			token = t.getCSRFToken()
 		}
@@ -155,8 +155,8 @@ func (t *Transport) Request(ctx context.Context, path string, opts *RequestOptio
 	// Handle CSRF token refresh on 403
 	if resp.StatusCode == http.StatusForbidden && isModifyingMethod(opts.Method) {
 		// Try to refresh CSRF token and retry once
-		if err := t.fetchCSRFToken(ctx, opts.Stateful); err != nil {
-			return nil, fmt.Errorf("refreshing CSRF token: %w", err)
+		if fetchErr := t.fetchCSRFToken(ctx, opts.Stateful); fetchErr != nil {
+			return nil, fmt.Errorf("refreshing CSRF token: %w", fetchErr)
 		}
 
 		// Retry the request
@@ -187,8 +187,8 @@ func (t *Transport) Request(ctx context.Context, path string, opts *RequestOptio
 			t.setCSRFToken("")
 			t.setSessionID("")
 			// Fetch new CSRF token (this establishes a new session)
-			if err := t.fetchCSRFToken(ctx, opts.Stateful); err != nil {
-				return nil, fmt.Errorf("refreshing session after timeout: %w", err)
+			if fetchErr := t.fetchCSRFToken(ctx, opts.Stateful); fetchErr != nil {
+				return nil, fmt.Errorf("refreshing session after timeout: %w", fetchErr)
 			}
 			// Retry the request
 			return t.retryRequest(ctx, path, opts)
@@ -203,13 +203,13 @@ func (t *Transport) Request(ctx context.Context, path string, opts *RequestOptio
 
 			if !t.config.HasBasicAuth() && t.config.ReauthFunc != nil {
 				// Cookie/SAML auth: re-run full auth dance to get fresh cookies.
-				if err := t.callReauthFunc(ctx, opts.Stateful); err != nil {
-					return nil, fmt.Errorf("re-authenticating after 401 on %s: %w (original error: %v)", path, err, apiErr)
+				if reauthErr := t.callReauthFunc(ctx, opts.Stateful); reauthErr != nil {
+					return nil, fmt.Errorf("re-authenticating after 401 on %s: %w (original error: %v)", path, reauthErr, apiErr)
 				}
 			} else {
 				// Basic auth: just refresh CSRF token.
-				if err := t.fetchCSRFToken(ctx, opts.Stateful); err != nil {
-					return nil, fmt.Errorf("re-authenticating after 401 on %s: %w (original error: %v)", path, err, apiErr)
+				if fetchErr := t.fetchCSRFToken(ctx, opts.Stateful); fetchErr != nil {
+					return nil, fmt.Errorf("re-authenticating after 401 on %s: %w (original error: %v)", path, fetchErr, apiErr)
 				}
 			}
 			return t.retryRequest(ctx, path, opts)

--- a/pkg/adt/http.go
+++ b/pkg/adt/http.go
@@ -131,7 +131,7 @@ func (t *Transport) Request(ctx context.Context, path string, opts *RequestOptio
 		token := t.getCSRFToken()
 		if token == "" {
 			// Fetch CSRF token first
-			if err := t.fetchCSRFToken(ctx); err != nil {
+			if err := t.fetchCSRFToken(ctx, opts.Stateful); err != nil {
 				return nil, fmt.Errorf("fetching CSRF token: %w", err)
 			}
 			token = t.getCSRFToken()
@@ -155,7 +155,7 @@ func (t *Transport) Request(ctx context.Context, path string, opts *RequestOptio
 	// Handle CSRF token refresh on 403
 	if resp.StatusCode == http.StatusForbidden && isModifyingMethod(opts.Method) {
 		// Try to refresh CSRF token and retry once
-		if err := t.fetchCSRFToken(ctx); err != nil {
+		if err := t.fetchCSRFToken(ctx, opts.Stateful); err != nil {
 			return nil, fmt.Errorf("refreshing CSRF token: %w", err)
 		}
 
@@ -187,7 +187,7 @@ func (t *Transport) Request(ctx context.Context, path string, opts *RequestOptio
 			t.setCSRFToken("")
 			t.setSessionID("")
 			// Fetch new CSRF token (this establishes a new session)
-			if err := t.fetchCSRFToken(ctx); err != nil {
+			if err := t.fetchCSRFToken(ctx, opts.Stateful); err != nil {
 				return nil, fmt.Errorf("refreshing session after timeout: %w", err)
 			}
 			// Retry the request
@@ -203,12 +203,12 @@ func (t *Transport) Request(ctx context.Context, path string, opts *RequestOptio
 
 			if !t.config.HasBasicAuth() && t.config.ReauthFunc != nil {
 				// Cookie/SAML auth: re-run full auth dance to get fresh cookies.
-				if err := t.callReauthFunc(ctx); err != nil {
+				if err := t.callReauthFunc(ctx, opts.Stateful); err != nil {
 					return nil, fmt.Errorf("re-authenticating after 401 on %s: %w (original error: %v)", path, err, apiErr)
 				}
 			} else {
 				// Basic auth: just refresh CSRF token.
-				if err := t.fetchCSRFToken(ctx); err != nil {
+				if err := t.fetchCSRFToken(ctx, opts.Stateful); err != nil {
 					return nil, fmt.Errorf("re-authenticating after 401 on %s: %w (original error: %v)", path, err, apiErr)
 				}
 			}
@@ -281,60 +281,58 @@ func (t *Transport) retryRequest(ctx context.Context, path string, opts *Request
 	}, nil
 }
 
-// fetchCSRFToken retrieves a CSRF token from the server.
-// Uses /core/discovery with HEAD for optimal performance (~25ms vs ~56s for GET on /discovery)
-func (t *Transport) fetchCSRFToken(ctx context.Context) error {
+// fetchCSRFToken retrieves a CSRF token from the server. The fetch must use
+// the same session mode as the modifying request that triggered it; otherwise
+// SAP can bind the token/cookie to a stateless context and reject the following
+// stateful lock/write request.
+func (t *Transport) fetchCSRFToken(ctx context.Context, stateful bool) error {
 	reqURL, err := t.buildURL("/sap/bc/adt/core/discovery", nil)
 	if err != nil {
 		return fmt.Errorf("building URL: %w", err)
 	}
 
-	// Use HEAD instead of GET for faster CSRF token fetch (~5s vs ~56s on slow systems)
-	req, err := http.NewRequestWithContext(ctx, http.MethodHead, reqURL, nil)
-	if err != nil {
-		return fmt.Errorf("creating request: %w", err)
-	}
+	// HEAD is faster on most systems. Some proxies and older ADT stacks omit
+	// the token or reject HEAD, so retry once with GET in the same session.
+	for _, method := range []string{http.MethodHead, http.MethodGet} {
+		req, err := http.NewRequestWithContext(ctx, method, reqURL, nil)
+		if err != nil {
+			return fmt.Errorf("creating request: %w", err)
+		}
+		if t.config.HasBasicAuth() {
+			req.SetBasicAuth(t.config.Username, t.config.Password)
+		}
+		t.addCookies(req)
+		req.Header.Set("X-CSRF-Token", "fetch")
+		req.Header.Set("Accept", "*/*")
+		if stateful || t.config.SessionType == SessionStateful {
+			req.Header.Set("X-sap-adt-sessiontype", "stateful")
+		} else {
+			req.Header.Set("X-sap-adt-sessiontype", "stateless")
+		}
 
-	// Set authentication
-	if t.config.HasBasicAuth() {
-		req.SetBasicAuth(t.config.Username, t.config.Password)
-	}
-	t.addCookies(req)
-	req.Header.Set("X-CSRF-Token", "fetch")
-	req.Header.Set("Accept", "*/*")
+		resp, err := t.httpClient.Do(req)
+		if err != nil {
+			return fmt.Errorf("executing request: %w", err)
+		}
+		_, _ = io.Copy(io.Discard, resp.Body)
+		_ = resp.Body.Close()
 
-	// Set session type header for stateful sessions
-	if t.config.SessionType == SessionStateful {
-		req.Header.Set("X-sap-adt-sessiontype", "stateful")
-	}
-
-	resp, err := t.httpClient.Do(req)
-	if err != nil {
-		return fmt.Errorf("executing request: %w", err)
-	}
-	defer resp.Body.Close()
-
-	// Drain body to allow connection reuse
-	_, _ = io.Copy(io.Discard, resp.Body)
-
-	// Note: HEAD may return 400 but still provides CSRF token in headers
-	// But 401/403 indicates auth failure and won't have a valid token
-
-	token := resp.Header.Get("X-CSRF-Token")
-	if token == "" || token == "Required" {
-		// Provide better error message based on status code
+		token := resp.Header.Get("X-CSRF-Token")
+		if token != "" && token != "Required" {
+			t.setCSRFToken(token)
+			return nil
+		}
 		switch resp.StatusCode {
 		case http.StatusUnauthorized:
 			return fmt.Errorf("authentication failed (401): check username/password")
 		case http.StatusForbidden:
 			return fmt.Errorf("access forbidden (403): check user authorizations")
-		default:
-			return fmt.Errorf("no CSRF token in response (HTTP %d)", resp.StatusCode)
+		}
+		if method == http.MethodGet {
+			return fmt.Errorf("no CSRF token in HEAD or GET response (last HTTP %d)", resp.StatusCode)
 		}
 	}
-
-	t.setCSRFToken(token)
-	return nil
+	return fmt.Errorf("no CSRF token returned")
 }
 
 // buildURL constructs the full URL for an API request.
@@ -511,7 +509,7 @@ func IsSessionExpiredError(err error) bool {
 // Ping sends a lightweight HEAD request to /sap/bc/adt/core/discovery to keep the session alive.
 // It refreshes the CSRF token as a side effect.
 func (t *Transport) Ping(ctx context.Context) error {
-	return t.fetchCSRFToken(ctx)
+	return t.fetchCSRFToken(ctx, false)
 }
 
 // reauthCooldown prevents concurrent 401 handlers from triggering simultaneous
@@ -526,7 +524,7 @@ const reauthTimeout = 30 * time.Second
 // callReauthFunc invokes config.ReauthFunc with stampede protection.
 // Multiple goroutines hitting 401 simultaneously will serialize through the mutex;
 // the first one performs the re-auth, subsequent ones within the cooldown window skip it.
-func (t *Transport) callReauthFunc(ctx context.Context) error {
+func (t *Transport) callReauthFunc(ctx context.Context, stateful bool) error {
 	t.reauthMu.Lock()
 	defer t.reauthMu.Unlock()
 
@@ -551,7 +549,7 @@ func (t *Transport) callReauthFunc(ctx context.Context) error {
 	// Fetch CSRF token with the new cookies.
 	// Set lastReauth only after CSRF succeeds — if it fails, the next
 	// goroutine should retry rather than hitting the cooldown skip.
-	if err := t.fetchCSRFToken(reauthCtx); err != nil {
+	if err := t.fetchCSRFToken(reauthCtx, stateful); err != nil {
 		return err
 	}
 	t.lastReauth = time.Now()

--- a/pkg/adt/http_test.go
+++ b/pkg/adt/http_test.go
@@ -153,6 +153,7 @@ func TestTransport_Request_CSRFToken(t *testing.T) {
 	}
 }
 
+//nolint:bodyclose // Transport.Request owns and closes every synthetic response body.
 func TestTransport_Request_StatefulCSRFFetch(t *testing.T) {
 	mock := &mockHTTPClient{responses: []*http.Response{
 		newMockResponse(http.StatusOK, "", map[string]string{"X-CSRF-Token": "synthetic-token"}),
@@ -180,6 +181,7 @@ func TestTransport_Request_StatefulCSRFFetch(t *testing.T) {
 	}
 }
 
+//nolint:bodyclose // Transport.Request owns and closes every synthetic response body.
 func TestTransport_Request_CSRFHeadFallsBackToGET(t *testing.T) {
 	mock := &mockHTTPClient{responses: []*http.Response{
 		newMockResponse(http.StatusMethodNotAllowed, "", nil),

--- a/pkg/adt/http_test.go
+++ b/pkg/adt/http_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/http/httptest"
 	"net/url"
 	"strings"
 	"testing"
@@ -152,6 +153,116 @@ func TestTransport_Request_CSRFToken(t *testing.T) {
 	}
 }
 
+func TestTransport_Request_StatefulCSRFFetch(t *testing.T) {
+	mock := &mockHTTPClient{responses: []*http.Response{
+		newMockResponse(http.StatusOK, "", map[string]string{"X-CSRF-Token": "synthetic-token"}),
+		newMockResponse(http.StatusOK, "", nil),
+	}}
+	transport := NewTransportWithClient(
+		NewConfig("https://sap.example.com:44300", "user", "pass"),
+		mock,
+	)
+
+	_, err := transport.Request(context.Background(), "/sap/bc/adt/synthetic", &RequestOptions{
+		Method:   http.MethodPost,
+		Stateful: true,
+	})
+	if err != nil {
+		t.Fatalf("Request failed: %v", err)
+	}
+	if len(mock.requests) != 2 {
+		t.Fatalf("requests = %d, want 2", len(mock.requests))
+	}
+	for i, req := range mock.requests {
+		if got := req.Header.Get("X-sap-adt-sessiontype"); got != "stateful" {
+			t.Errorf("request %d session type = %q, want stateful", i, got)
+		}
+	}
+}
+
+func TestTransport_Request_CSRFHeadFallsBackToGET(t *testing.T) {
+	mock := &mockHTTPClient{responses: []*http.Response{
+		newMockResponse(http.StatusMethodNotAllowed, "", nil),
+		newMockResponse(http.StatusOK, "", map[string]string{"X-CSRF-Token": "synthetic-token"}),
+		newMockResponse(http.StatusOK, "", nil),
+	}}
+	transport := NewTransportWithClient(
+		NewConfig("https://sap.example.com:44300", "user", "pass"),
+		mock,
+	)
+
+	_, err := transport.Request(context.Background(), "/sap/bc/adt/synthetic", &RequestOptions{
+		Method:   http.MethodPut,
+		Stateful: true,
+	})
+	if err != nil {
+		t.Fatalf("Request failed: %v", err)
+	}
+	wantMethods := []string{http.MethodHead, http.MethodGet, http.MethodPut}
+	if len(mock.requests) != len(wantMethods) {
+		t.Fatalf("requests = %d, want %d", len(mock.requests), len(wantMethods))
+	}
+	for i, want := range wantMethods {
+		if got := mock.requests[i].Method; got != want {
+			t.Errorf("request %d method = %s, want %s", i, got, want)
+		}
+		if got := mock.requests[i].Header.Get("X-sap-adt-sessiontype"); got != "stateful" {
+			t.Errorf("request %d session type = %q, want stateful", i, got)
+		}
+	}
+}
+
+func TestTransport_StatefulSequenceKeepsDiscoveryCookie(t *testing.T) {
+	const sessionCookie = "SYNTHETIC-SESSION"
+	var seen []string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		seen = append(seen, r.Method+" "+r.URL.RequestURI())
+		if got := r.Header.Get("X-sap-adt-sessiontype"); got != "stateful" {
+			t.Errorf("%s session type = %q, want stateful", r.Method, got)
+		}
+
+		if r.URL.Path == "/sap/bc/adt/core/discovery" {
+			http.SetCookie(w, &http.Cookie{Name: "sap-contextid", Value: sessionCookie, Path: "/"})
+			w.Header().Set("X-CSRF-Token", "synthetic-token")
+			return
+		}
+		cookie, err := r.Cookie("sap-contextid")
+		if err != nil || cookie.Value != sessionCookie {
+			t.Errorf("%s missing discovery session cookie", r.Method)
+		}
+
+		switch r.URL.Query().Get("_action") {
+		case "LOCK":
+			_, _ = io.WriteString(w, `<?xml version="1.0"?><asx:abap xmlns:asx="http://www.sap.com/abapxml"><asx:values><DATA><LOCK_HANDLE>SYNTHETIC-HANDLE</LOCK_HANDLE></DATA></asx:values></asx:abap>`)
+		case "UNLOCK":
+			w.WriteHeader(http.StatusOK)
+		default:
+			if r.Method != http.MethodPut {
+				t.Errorf("unexpected request: %s", r.URL.RequestURI())
+			}
+			w.WriteHeader(http.StatusOK)
+		}
+	}))
+	defer server.Close()
+
+	client := NewClient(server.URL, "user", "pass")
+	ctx := context.Background()
+	objectURL := "/sap/bc/adt/programs/programs/ZSYNTHETIC"
+	lock, err := client.LockObject(ctx, objectURL, "MODIFY")
+	if err != nil {
+		t.Fatalf("LockObject failed: %v", err)
+	}
+	if err := client.UpdateSource(ctx, objectURL+"/source/main", "REPORT zsynthetic.", lock.LockHandle, ""); err != nil {
+		t.Fatalf("UpdateSource failed: %v", err)
+	}
+	if err := client.UnlockObject(ctx, objectURL, lock.LockHandle); err != nil {
+		t.Fatalf("UnlockObject failed: %v", err)
+	}
+	if len(seen) != 4 {
+		t.Fatalf("request sequence = %#v, want discovery+lock+write+unlock", seen)
+	}
+}
+
 func TestTransport_Request_CSRFRefreshOn403(t *testing.T) {
 	mock := &mockHTTPClient{
 		responses: []*http.Response{
@@ -170,7 +281,8 @@ func TestTransport_Request_CSRFRefreshOn403(t *testing.T) {
 	transport := NewTransportWithClient(cfg, mock)
 
 	resp, err := transport.Request(context.Background(), "/sap/bc/adt/test", &RequestOptions{
-		Method: http.MethodPost,
+		Method:   http.MethodPost,
+		Stateful: true,
 	})
 	if err != nil {
 		t.Fatalf("Request failed: %v", err)
@@ -183,6 +295,11 @@ func TestTransport_Request_CSRFRefreshOn403(t *testing.T) {
 	// Should have made 4 requests
 	if len(mock.requests) != 4 {
 		t.Fatalf("Expected 4 requests, got %d", len(mock.requests))
+	}
+	for i, req := range mock.requests {
+		if got := req.Header.Get("X-sap-adt-sessiontype"); got != "stateful" {
+			t.Errorf("request %d session type = %q, want stateful during CSRF renewal", i, got)
+		}
 	}
 }
 

--- a/pkg/adt/mutation_gate.go
+++ b/pkg/adt/mutation_gate.go
@@ -5,6 +5,22 @@ import (
 	"fmt"
 )
 
+type mutationPackageCheckedKey struct{}
+
+// withMutationPackageChecked marks that an outer workflow already resolved
+// and checked the target package before acquiring a stateful lock. Inner
+// mutators still enforce operation and transport policy, but skip the redundant
+// package lookup that would otherwise insert a stateless SearchObject request
+// between LOCK and PUT/DELETE.
+func withMutationPackageChecked(ctx context.Context) context.Context {
+	return context.WithValue(ctx, mutationPackageCheckedKey{}, true)
+}
+
+func mutationPackageAlreadyChecked(ctx context.Context) bool {
+	checked, _ := ctx.Value(mutationPackageCheckedKey{}).(bool)
+	return checked
+}
+
 // MutationSurface identifies the object surface a mutation targets. Different
 // surfaces require different metadata resolution strategies (ADT SearchObject,
 // UI5 BSP metadata, etc.). Use SurfaceADT for standard ABAP objects.
@@ -76,9 +92,12 @@ func (c *Client) checkMutation(ctx context.Context, m MutationContext) error {
 		return err
 	}
 
-	// 2. Package ownership check
-	if err := c.checkMutationPackage(ctx, m); err != nil {
-		return err
+	// 2. Package ownership check. Outer workflows may mark only this networked
+	// portion as complete; operation and transport checks are never bypassed.
+	if !mutationPackageAlreadyChecked(ctx) {
+		if err := c.checkMutationPackage(ctx, m); err != nil {
+			return err
+		}
 	}
 
 	// 3. Transportable-edit check

--- a/pkg/adt/recorder.go
+++ b/pkg/adt/recorder.go
@@ -5,6 +5,7 @@ package adt
 import (
 	"encoding/json"
 	"sync"
+	"sync/atomic"
 	"time"
 )
 
@@ -100,10 +101,24 @@ func NewExecutionRecorder(sessionID, program string) *ExecutionRecorder {
 	}
 }
 
-// generateRecordingID creates a unique recording ID.
+var lastRecordingIDNanos atomic.Int64
+
+// generateRecordingID creates a unique, time-sortable recording ID. Some
+// platforms expose a clock resolution coarser than a nanosecond, so formatting
+// time.Now directly can produce duplicate IDs during a fast burst. Advance the
+// timestamp atomically when the wall clock has not moved forward.
 func generateRecordingID() string {
-	// Include nanoseconds for uniqueness in rapid succession
-	return time.Now().Format("20060102-150405.000000000")
+	now := time.Now()
+	candidate := now.UnixNano()
+	for {
+		previous := lastRecordingIDNanos.Load()
+		if candidate <= previous {
+			candidate = previous + 1
+		}
+		if lastRecordingIDNanos.CompareAndSwap(previous, candidate) {
+			return time.Unix(0, candidate).In(now.Location()).Format("20060102-150405.000000000")
+		}
+	}
 }
 
 // RecordFrame adds a new execution frame to the recording.

--- a/pkg/adt/recorder_test.go
+++ b/pkg/adt/recorder_test.go
@@ -2,9 +2,37 @@ package adt
 
 import (
 	"encoding/json"
+	"sync"
 	"testing"
 	"time"
 )
+
+func TestGenerateRecordingIDUniqueUnderBurst(t *testing.T) {
+	const goroutines = 16
+	const idsPerGoroutine = 250
+
+	ids := make(chan string, goroutines*idsPerGoroutine)
+	var wg sync.WaitGroup
+	for range goroutines {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for range idsPerGoroutine {
+				ids <- generateRecordingID()
+			}
+		}()
+	}
+	wg.Wait()
+	close(ids)
+
+	seen := make(map[string]struct{}, goroutines*idsPerGoroutine)
+	for id := range ids {
+		if _, exists := seen[id]; exists {
+			t.Fatalf("duplicate recording ID generated: %s", id)
+		}
+		seen[id] = struct{}{}
+	}
+}
 
 func TestNewExecutionRecorder(t *testing.T) {
 	recorder := NewExecutionRecorder("test-session", "ZTEST_PROGRAM")

--- a/pkg/adt/saml_auth_test.go
+++ b/pkg/adt/saml_auth_test.go
@@ -264,7 +264,7 @@ func TestSAMLLogin_ReauthConcurrent(t *testing.T) {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			_ = transport.callReauthFunc(context.Background())
+			_ = transport.callReauthFunc(context.Background(), false)
 		}()
 	}
 	wg.Wait()

--- a/pkg/adt/workflows.go
+++ b/pkg/adt/workflows.go
@@ -12,12 +12,12 @@ import (
 
 // WriteProgramResult represents the result of writing a program.
 type WriteProgramResult struct {
-	Success      bool                       `json:"success"`
-	ProgramName  string                     `json:"programName"`
-	ObjectURL    string                     `json:"objectUrl"`
-	SyntaxErrors []SyntaxCheckResult        `json:"syntaxErrors,omitempty"`
-	Activation   *ActivationResult          `json:"activation,omitempty"`
-	Message      string                     `json:"message,omitempty"`
+	Success      bool                `json:"success"`
+	ProgramName  string              `json:"programName"`
+	ObjectURL    string              `json:"objectUrl"`
+	SyntaxErrors []SyntaxCheckResult `json:"syntaxErrors,omitempty"`
+	Activation   *ActivationResult   `json:"activation,omitempty"`
+	Message      string              `json:"message,omitempty"`
 }
 
 // WriteProgram performs Lock -> SyntaxCheck -> UpdateSource -> Unlock -> Activate workflow.
@@ -36,6 +36,7 @@ func (c *Client) WriteProgram(ctx context.Context, programName string, source st
 	}); err != nil {
 		return nil, err
 	}
+	ctx = withMutationPackageChecked(ctx)
 
 	result := &WriteProgramResult{
 		ProgramName: programName,
@@ -108,12 +109,12 @@ func (c *Client) WriteProgram(ctx context.Context, programName string, source st
 
 // WriteClassResult represents the result of writing a class.
 type WriteClassResult struct {
-	Success      bool                       `json:"success"`
-	ClassName    string                     `json:"className"`
-	ObjectURL    string                     `json:"objectUrl"`
-	SyntaxErrors []SyntaxCheckResult        `json:"syntaxErrors,omitempty"`
-	Activation   *ActivationResult          `json:"activation,omitempty"`
-	Message      string                     `json:"message,omitempty"`
+	Success      bool                `json:"success"`
+	ClassName    string              `json:"className"`
+	ObjectURL    string              `json:"objectUrl"`
+	SyntaxErrors []SyntaxCheckResult `json:"syntaxErrors,omitempty"`
+	Activation   *ActivationResult   `json:"activation,omitempty"`
+	Message      string              `json:"message,omitempty"`
 }
 
 // WriteClass performs Lock -> SyntaxCheck -> UpdateSource -> Unlock -> Activate workflow for classes.
@@ -131,6 +132,7 @@ func (c *Client) WriteClass(ctx context.Context, className string, source string
 	}); err != nil {
 		return nil, err
 	}
+	ctx = withMutationPackageChecked(ctx)
 
 	result := &WriteClassResult{
 		ClassName: className,
@@ -225,6 +227,7 @@ func (c *Client) CreateAndActivateProgram(ctx context.Context, programName strin
 	}); err != nil {
 		return nil, err
 	}
+	ctx = withMutationPackageChecked(ctx)
 
 	objectURL := fmt.Sprintf("/sap/bc/adt/programs/programs/%s", url.PathEscape(programName))
 	sourceURL := objectURL + "/source/main"
@@ -318,6 +321,7 @@ func (c *Client) CreateClassWithTests(ctx context.Context, className string, des
 	}); err != nil {
 		return nil, err
 	}
+	ctx = withMutationPackageChecked(ctx)
 
 	objectURL := fmt.Sprintf("/sap/bc/adt/oo/classes/%s", url.PathEscape(className))
 	sourceURL := objectURL + "/source/main"

--- a/pkg/adt/workflows_deploy.go
+++ b/pkg/adt/workflows_deploy.go
@@ -12,20 +12,20 @@ import (
 
 // DeployResult contains the result of a file deployment operation.
 type DeployResult struct {
-	ObjectURL     string   `json:"objectUrl"`
-	ObjectName    string   `json:"objectName"`
-	ObjectType    string   `json:"objectType"`
-	FilePath      string   `json:"filePath"`
-	Success       bool     `json:"success"`
-	Created       bool     `json:"created"` // true if created, false if updated
-	SyntaxErrors  []string `json:"syntaxErrors,omitempty"`
-	Errors        []string `json:"errors,omitempty"`
-	Message       string   `json:"message,omitempty"`
+	ObjectURL    string   `json:"objectUrl"`
+	ObjectName   string   `json:"objectName"`
+	ObjectType   string   `json:"objectType"`
+	FilePath     string   `json:"filePath"`
+	Success      bool     `json:"success"`
+	Created      bool     `json:"created"` // true if created, false if updated
+	SyntaxErrors []string `json:"syntaxErrors,omitempty"`
+	Errors       []string `json:"errors,omitempty"`
+	Message      string   `json:"message,omitempty"`
 }
 
 // CreateFromFile creates a new ABAP object from a file and activates it.
 //
-// Workflow: Parse → Create → Lock → SyntaxCheck → Write → Unlock → Activate
+// Workflow: Parse → Create → SyntaxCheck → Lock → Write → Unlock → Activate
 //
 // The function automatically detects the object type and name from the file extension
 // and content. Supported file extensions: .clas.abap, .prog.abap, .intf.abap
@@ -33,10 +33,16 @@ type DeployResult struct {
 // Example:
 //   result, err := client.CreateFromFile(ctx, "/path/to/zcl_test.clas.abap", "$TMP", "")
 func (c *Client) CreateFromFile(ctx context.Context, filePath, packageName, transport string) (*DeployResult, error) {
-	// Safety check
-	if err := c.checkSafety(OpCreate, "CreateFromFile"); err != nil {
+	// Validate the complete mutation policy before opening a stateful lock session.
+	if err := c.checkMutation(ctx, MutationContext{
+		Op:        OpCreate,
+		OpName:    "CreateFromFile",
+		Package:   strings.ToUpper(packageName),
+		Transport: transport,
+	}); err != nil {
 		return nil, err
 	}
+	ctx = withMutationPackageChecked(ctx)
 
 	// 1. Parse file to detect type and name
 	info, err := ParseABAPFile(filePath)
@@ -77,29 +83,8 @@ func (c *Client) CreateFromFile(ctx context.Context, filePath, packageName, tran
 		return nil, err
 	}
 
-	// 5. Lock object
-	lockResult, err := c.LockObject(ctx, objectURL, "MODIFY")
-	if err != nil {
-		return &DeployResult{
-			FilePath:   filePath,
-			ObjectURL:  objectURL,
-			ObjectName: info.ObjectName,
-			ObjectType: string(info.ObjectType),
-			Success:    false,
-			Errors:     []string{fmt.Sprintf("lock failed: %v", err)},
-			Message:    fmt.Sprintf("Object created but failed to lock: %v", err),
-		}, nil
-	}
-
-	// Ensure unlock on any error
-	unlocked := false
-	defer func() {
-		if !unlocked {
-			_ = c.UnlockObject(ctx, objectURL, lockResult.LockHandle)
-		}
-	}()
-
-	// 6. Syntax check (optional pre-check)
+	// 5. Syntax check (optional pre-check). Do this before locking so syntax
+	// failures cannot leave an avoidable stateful session behind.
 	syntaxErrors, err := c.SyntaxCheck(ctx, objectURL, source)
 	if err != nil {
 		return &DeployResult{
@@ -129,6 +114,28 @@ func (c *Client) CreateFromFile(ctx context.Context, filePath, packageName, tran
 			Message:      fmt.Sprintf("Object created but has %d syntax errors", len(syntaxErrors)),
 		}, nil
 	}
+
+	// 6. Lock object
+	lockResult, err := c.LockObject(ctx, objectURL, "MODIFY")
+	if err != nil {
+		return &DeployResult{
+			FilePath:   filePath,
+			ObjectURL:  objectURL,
+			ObjectName: info.ObjectName,
+			ObjectType: string(info.ObjectType),
+			Success:    false,
+			Errors:     []string{fmt.Sprintf("lock failed: %v", err)},
+			Message:    fmt.Sprintf("Object created but failed to lock: %v", err),
+		}, nil
+	}
+
+	// Ensure unlock on any error
+	unlocked := false
+	defer func() {
+		if !unlocked {
+			_ = c.UnlockObject(ctx, objectURL, lockResult.LockHandle)
+		}
+	}()
 
 	// 7. Write source (need source URL, not object URL)
 	sourceURL, err := c.buildSourceURL(info.ObjectType, info.ObjectName)
@@ -190,16 +197,11 @@ func (c *Client) CreateFromFile(ctx context.Context, filePath, packageName, tran
 
 // UpdateFromFile updates an existing ABAP object from a file.
 //
-// Workflow: Parse → Lock → SyntaxCheck → Write → Unlock → Activate
+// Workflow: Parse → SyntaxCheck → Lock → Write → Unlock → Activate
 //
 // Example:
 //   result, err := client.UpdateFromFile(ctx, "/path/to/zcl_test.clas.abap", "")
 func (c *Client) UpdateFromFile(ctx context.Context, filePath, transport string) (*DeployResult, error) {
-	// Safety check
-	if err := c.checkSafety(OpUpdate, "UpdateFromFile"); err != nil {
-		return nil, err
-	}
-
 	// 1. Parse file to detect type and name
 	info, err := ParseABAPFile(filePath)
 	if err != nil {
@@ -224,29 +226,20 @@ func (c *Client) UpdateFromFile(ctx context.Context, filePath, transport string)
 		return nil, err
 	}
 
-	// 4. Lock object
-	lockResult, err := c.LockObject(ctx, objectURL, "MODIFY")
-	if err != nil {
-		return &DeployResult{
-			FilePath:   filePath,
-			ObjectURL:  objectURL,
-			ObjectName: info.ObjectName,
-			ObjectType: string(info.ObjectType),
-			Success:    false,
-			Errors:     []string{fmt.Sprintf("lock failed: %v", err)},
-			Message:    fmt.Sprintf("Failed to lock object: %v", err),
-		}, nil
+	// Validate package scope before locking. The context marker suppresses only
+	// the redundant package lookup in the low-level writer; operation and
+	// transport checks still run there.
+	if err := c.checkMutation(ctx, MutationContext{
+		Op:        OpUpdate,
+		OpName:    "UpdateFromFile",
+		ObjectURL: objectURL,
+		Transport: transport,
+	}); err != nil {
+		return nil, err
 	}
+	ctx = withMutationPackageChecked(ctx)
 
-	// Ensure unlock on any error
-	unlocked := false
-	defer func() {
-		if !unlocked {
-			_ = c.UnlockObject(ctx, objectURL, lockResult.LockHandle)
-		}
-	}()
-
-	// 5. Syntax check (skip for class includes - will check after update)
+	// 4. Syntax check (skip for class includes - will check after update)
 	if !isClassInclude {
 		syntaxErrors, err := c.SyntaxCheck(ctx, objectURL, source)
 		if err != nil {
@@ -278,6 +271,28 @@ func (c *Client) UpdateFromFile(ctx context.Context, filePath, transport string)
 			}, nil
 		}
 	}
+
+	// 5. Lock object
+	lockResult, err := c.LockObject(ctx, objectURL, "MODIFY")
+	if err != nil {
+		return &DeployResult{
+			FilePath:   filePath,
+			ObjectURL:  objectURL,
+			ObjectName: info.ObjectName,
+			ObjectType: string(info.ObjectType),
+			Success:    false,
+			Errors:     []string{fmt.Sprintf("lock failed: %v", err)},
+			Message:    fmt.Sprintf("Failed to lock object: %v", err),
+		}, nil
+	}
+
+	// Ensure unlock on any error
+	unlocked := false
+	defer func() {
+		if !unlocked {
+			_ = c.UnlockObject(ctx, objectURL, lockResult.LockHandle)
+		}
+	}()
 
 	// 6. Write source
 	if isClassInclude {

--- a/pkg/adt/workflows_deploy.go
+++ b/pkg/adt/workflows_deploy.go
@@ -31,7 +31,8 @@ type DeployResult struct {
 // and content. Supported file extensions: .clas.abap, .prog.abap, .intf.abap
 //
 // Example:
-//   result, err := client.CreateFromFile(ctx, "/path/to/zcl_test.clas.abap", "$TMP", "")
+//
+//	result, err := client.CreateFromFile(ctx, "/path/to/zcl_test.clas.abap", "$TMP", "")
 func (c *Client) CreateFromFile(ctx context.Context, filePath, packageName, transport string) (*DeployResult, error) {
 	// Validate the complete mutation policy before opening a stateful lock session.
 	if err := c.checkMutation(ctx, MutationContext{
@@ -200,7 +201,8 @@ func (c *Client) CreateFromFile(ctx context.Context, filePath, packageName, tran
 // Workflow: Parse → SyntaxCheck → Lock → Write → Unlock → Activate
 //
 // Example:
-//   result, err := client.UpdateFromFile(ctx, "/path/to/zcl_test.clas.abap", "")
+//
+//	result, err := client.UpdateFromFile(ctx, "/path/to/zcl_test.clas.abap", "")
 func (c *Client) UpdateFromFile(ctx context.Context, filePath, transport string) (*DeployResult, error) {
 	// 1. Parse file to detect type and name
 	info, err := ParseABAPFile(filePath)
@@ -229,13 +231,13 @@ func (c *Client) UpdateFromFile(ctx context.Context, filePath, transport string)
 	// Validate package scope before locking. The context marker suppresses only
 	// the redundant package lookup in the low-level writer; operation and
 	// transport checks still run there.
-	if err := c.checkMutation(ctx, MutationContext{
+	if gateErr := c.checkMutation(ctx, MutationContext{
 		Op:        OpUpdate,
 		OpName:    "UpdateFromFile",
 		ObjectURL: objectURL,
 		Transport: transport,
-	}); err != nil {
-		return nil, err
+	}); gateErr != nil {
+		return nil, gateErr
 	}
 	ctx = withMutationPackageChecked(ctx)
 
@@ -397,8 +399,9 @@ func (c *Client) UpdateFromFile(ctx context.Context, filePath, transport string)
 // For class includes, the parent class must already exist.
 //
 // Example:
-//   result, err := client.DeployFromFile(ctx, "/path/to/zcl_test.clas.abap", "$TMP", "")
-//   result, err := client.DeployFromFile(ctx, "/path/to/zcl_test.clas.testclasses.abap", "$TMP", "")
+//
+//	result, err := client.DeployFromFile(ctx, "/path/to/zcl_test.clas.abap", "$TMP", "")
+//	result, err := client.DeployFromFile(ctx, "/path/to/zcl_test.clas.testclasses.abap", "$TMP", "")
 func (c *Client) DeployFromFile(ctx context.Context, filePath, packageName, transport string) (*DeployResult, error) {
 	// 1. Parse file
 	info, err := ParseABAPFile(filePath)

--- a/pkg/adt/workflows_deploy.go
+++ b/pkg/adt/workflows_deploy.go
@@ -172,7 +172,10 @@ func (c *Client) CreateFromFile(ctx context.Context, filePath, packageName, tran
 	}
 
 	// 9. Activate
-	_, err = c.Activate(ctx, objectURL, info.ObjectName)
+	activation, err := c.Activate(ctx, objectURL, info.ObjectName)
+	if err == nil {
+		err = ActivationResultError(activation)
+	}
 	if err != nil {
 		return &DeployResult{
 			FilePath:   filePath,
@@ -358,7 +361,10 @@ func (c *Client) UpdateFromFile(ctx context.Context, filePath, transport string)
 	}
 
 	// 8. Activate
-	_, err = c.Activate(ctx, objectURL, info.ObjectName)
+	activation, err := c.Activate(ctx, objectURL, info.ObjectName)
+	if err == nil {
+		err = ActivationResultError(activation)
+	}
 	if err != nil {
 		return &DeployResult{
 			FilePath:   filePath,
@@ -451,8 +457,9 @@ func (c *Client) DeployFromFile(ctx context.Context, filePath, packageName, tran
 			// Regular object - create it
 			return c.CreateFromFile(ctx, filePath, packageName, transport)
 		}
-		// For other errors (session timeout, network issues, etc.), proceed with update
-		// The parent class might still exist - let UpdateFromFile handle it
+		// Authentication, network and server failures are inconclusive. Do not
+		// turn them into an update attempt; fail closed before locking or writing.
+		return nil, fmt.Errorf("checking whether %s %s exists: %w", info.ObjectType, info.ObjectName, err)
 	}
 
 	// Object exists - update it (handles both regular objects and class includes)

--- a/pkg/adt/workflows_deploy_exists_test.go
+++ b/pkg/adt/workflows_deploy_exists_test.go
@@ -1,0 +1,32 @@
+package adt
+
+import (
+	"context"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+//nolint:bodyclose // Transport.Request owns and closes every synthetic response body.
+func TestDeployFromFileStopsOnInconclusiveExistenceCheck(t *testing.T) {
+	filePath := filepath.Join(t.TempDir(), "zsynthetic.prog.abap")
+	if err := os.WriteFile(filePath, []byte("REPORT zsynthetic."), 0o600); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+
+	mock := &mockHTTPClient{responses: []*http.Response{
+		newMockResponse(http.StatusInternalServerError, "synthetic server failure", nil),
+	}}
+	cfg := NewConfig("https://sap.example.com:44300", "user", "pass")
+	client := NewClientWithTransport(cfg, NewTransportWithClient(cfg, mock))
+
+	result, err := client.DeployFromFile(context.Background(), filePath, "$TMP", "")
+	if err == nil || !strings.Contains(err.Error(), "checking whether") {
+		t.Fatalf("DeployFromFile() result = %#v, error = %v, want inconclusive existence error", result, err)
+	}
+	if len(mock.requests) != 1 {
+		t.Fatalf("requests = %d, want only the existence probe", len(mock.requests))
+	}
+}

--- a/pkg/adt/workflows_deploy_order_test.go
+++ b/pkg/adt/workflows_deploy_order_test.go
@@ -1,0 +1,46 @@
+package adt
+
+import (
+	"context"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestUpdateFromFile_SyntaxFailureDoesNotAcquireLock(t *testing.T) {
+	filePath := filepath.Join(t.TempDir(), "zsynthetic.prog.abap")
+	if err := os.WriteFile(filePath, []byte("REPORT zsynthetic.\n"), 0o600); err != nil {
+		t.Fatalf("writing synthetic source fixture: %v", err)
+	}
+
+	const syntaxErrorXML = `<?xml version="1.0" encoding="UTF-8"?>
+<chkrun:checkRunReports xmlns:chkrun="http://www.sap.com/adt/checkrun">
+  <chkrun:checkReport>
+    <chkrun:checkMessageList>
+      <chkrun:checkMessage chkrun:uri="/synthetic#start=1,1" chkrun:type="E" chkrun:shortText="synthetic syntax error"/>
+    </chkrun:checkMessageList>
+  </chkrun:checkReport>
+</chkrun:checkRunReports>`
+	mock := &methodPathMock{routes: []routedResponse{
+		resp("", "discovery", http.StatusOK, ""),
+		resp(http.MethodPost, "/sap/bc/adt/checkruns", http.StatusOK, syntaxErrorXML),
+		resp(http.MethodPost, "/sap/bc/adt/programs/programs/ZSYNTHETIC", http.StatusOK, syntheticLocalLockXML),
+	}}
+	cfg := NewConfig("https://sap.example.com:44300", "user", "pass")
+	client := NewClientWithTransport(cfg, NewTransportWithClient(cfg, mock))
+
+	result, err := client.UpdateFromFile(context.Background(), filePath, "")
+	if err != nil {
+		t.Fatalf("UpdateFromFile returned error: %v", err)
+	}
+	if result == nil || result.Success || len(result.SyntaxErrors) != 1 {
+		t.Fatalf("unexpected result: %#v", result)
+	}
+	for _, call := range mock.calls {
+		if call.query.Get("_action") == "LOCK" || strings.Contains(call.path, "/source/main") {
+			t.Fatalf("syntax failure should stop before lock/write, calls: %#v", mock.calls)
+		}
+	}
+}

--- a/pkg/adt/workflows_edit.go
+++ b/pkg/adt/workflows_edit.go
@@ -135,14 +135,16 @@ func (c *Client) EditSource(ctx context.Context, objectURL, oldString, newString
 //   - opts: Optional parameters (ReplaceAll, SyntaxCheck, CaseInsensitive, Method)
 //
 // Method-level isolation (CLAS only):
-//   When opts.Method is set, the search is constrained to the specified method only.
-//   This prevents accidental edits in other methods when the same pattern exists elsewhere.
+//
+//	When opts.Method is set, the search is constrained to the specified method only.
+//	This prevents accidental edits in other methods when the same pattern exists elsewhere.
 //
 // Example:
-//   EditSourceWithOptions(ctx, "/sap/bc/adt/oo/classes/ZCL_TEST",
-//     "METHOD foo.\n  ENDMETHOD.",
-//     "METHOD foo.\n  rv_result = 42.\n  ENDMETHOD.",
-//     &EditSourceOptions{Method: "FOO"})
+//
+//	EditSourceWithOptions(ctx, "/sap/bc/adt/oo/classes/ZCL_TEST",
+//	  "METHOD foo.\n  ENDMETHOD.",
+//	  "METHOD foo.\n  rv_result = 42.\n  ENDMETHOD.",
+//	  &EditSourceOptions{Method: "FOO"})
 func (c *Client) EditSourceWithOptions(ctx context.Context, objectURL, oldString, newString string, opts *EditSourceOptions) (*EditSourceResult, error) {
 	// Default options
 	if opts == nil {

--- a/pkg/adt/workflows_edit.go
+++ b/pkg/adt/workflows_edit.go
@@ -10,17 +10,17 @@ import (
 
 // EditSourceResult represents the result of editing source code.
 type EditSourceResult struct {
-	Success        bool                `json:"success"`
-	ObjectURL      string              `json:"objectUrl"`
-	ObjectName     string              `json:"objectName"`
-	MatchCount     int                 `json:"matchCount"`
-	OldString      string              `json:"oldString,omitempty"`
-	NewString      string              `json:"newString,omitempty"`
-	SyntaxErrors   []string            `json:"syntaxErrors,omitempty"`
-	SyntaxWarnings []string            `json:"syntaxWarnings,omitempty"`
-	Activation     *ActivationResult   `json:"activation,omitempty"`
-	Message        string              `json:"message,omitempty"`
-	Method         string              `json:"method,omitempty"` // Method name if method-level edit
+	Success        bool              `json:"success"`
+	ObjectURL      string            `json:"objectUrl"`
+	ObjectName     string            `json:"objectName"`
+	MatchCount     int               `json:"matchCount"`
+	OldString      string            `json:"oldString,omitempty"`
+	NewString      string            `json:"newString,omitempty"`
+	SyntaxErrors   []string          `json:"syntaxErrors,omitempty"`
+	SyntaxWarnings []string          `json:"syntaxWarnings,omitempty"`
+	Activation     *ActivationResult `json:"activation,omitempty"`
+	Message        string            `json:"message,omitempty"`
+	Method         string            `json:"method,omitempty"` // Method name if method-level edit
 }
 
 // EditSourceOptions provides optional parameters for EditSource.
@@ -158,6 +158,7 @@ func (c *Client) EditSourceWithOptions(ctx context.Context, objectURL, oldString
 	}); err != nil {
 		return nil, err
 	}
+	ctx = withMutationPackageChecked(ctx)
 	// SyntaxCheck defaults to true if not explicitly set (zero value is false, so we need to handle this)
 	// Note: caller should explicitly set SyntaxCheck=false if they don't want it
 
@@ -418,4 +419,3 @@ func (c *Client) EditSourceWithOptions(ctx context.Context, objectURL, oldString
 	}
 	return result, nil
 }
-

--- a/pkg/adt/workflows_execute.go
+++ b/pkg/adt/workflows_execute.go
@@ -71,10 +71,16 @@ type ExecuteABAPOptions struct {
 //
 // Security: This is gated by OpWorkflow safety check.
 func (c *Client) ExecuteABAP(ctx context.Context, code string, opts *ExecuteABAPOptions) (*ExecuteABAPResult, error) {
-	// Safety check for workflow operations
-	if err := c.checkSafety(OpWorkflow, "ExecuteABAP"); err != nil {
+	// The temporary program is always local. Resolve package policy before the
+	// stateful lock, then let inner mutators skip only that networked lookup.
+	if err := c.checkMutation(ctx, MutationContext{
+		Op:      OpWorkflow,
+		OpName:  "ExecuteABAP",
+		Package: "$TMP",
+	}); err != nil {
 		return nil, err
 	}
+	ctx = withMutationPackageChecked(ctx)
 
 	if opts == nil {
 		opts = &ExecuteABAPOptions{}
@@ -94,7 +100,7 @@ func (c *Client) ExecuteABAP(ctx context.Context, code string, opts *ExecuteABAP
 	}
 
 	// Generate unique program name using timestamp
-	timestamp := fmt.Sprintf("%d", time.Now().UnixNano()/1000000) // milliseconds
+	timestamp := fmt.Sprintf("%d", time.Now().UnixNano()/1000000)                     // milliseconds
 	programName := strings.ToUpper(opts.ProgramPrefix + timestamp[len(timestamp)-8:]) // Last 8 digits
 	result.ProgramName = programName
 	objectURL := fmt.Sprintf("/sap/bc/adt/programs/programs/%s", url.PathEscape(programName))

--- a/pkg/adt/workflows_execute.go
+++ b/pkg/adt/workflows_execute.go
@@ -12,13 +12,13 @@ import (
 
 // ExecuteABAPResult represents the result of executing ABAP code via unit test.
 type ExecuteABAPResult struct {
-	Success       bool     `json:"success"`
-	ProgramName   string   `json:"programName"`
-	Output        []string `json:"output"`        // Values returned via assertion messages
+	Success       bool            `json:"success"`
+	ProgramName   string          `json:"programName"`
+	Output        []string        `json:"output"`              // Values returned via assertion messages
 	RawAlerts     []UnitTestAlert `json:"rawAlerts,omitempty"` // Full alert details for debugging
-	ExecutionTime float64  `json:"executionTime"` // Execution time in seconds
-	Message       string   `json:"message,omitempty"`
-	CleanedUp     bool     `json:"cleanedUp"`
+	ExecutionTime float64         `json:"executionTime"`       // Execution time in seconds
+	Message       string          `json:"message,omitempty"`
+	CleanedUp     bool            `json:"cleanedUp"`
 }
 
 // ExecuteABAPOptions configures ExecuteABAP behavior.
@@ -44,8 +44,11 @@ type ExecuteABAPOptions struct {
 
 // ExecuteABAP executes arbitrary ABAP code via a temporary unit test wrapper.
 //
-// This is a powerful tool that allows executing any ABAP code on the SAP system.
-// The code is wrapped in a test class and executed via RunUnitTests.
+// This is a powerful tool that allows executing ABAP code on the SAP system.
+// The code is wrapped in a test class and executed via RunUnitTests. It runs
+// under ABAP Unit transactional semantics, so normal database changes are
+// rolled back. It is not an API for persistent writes. External side effects
+// may not be reversible and remain subject to the configured risk level.
 // Return values are extracted from assertion messages.
 //
 // Workflow:
@@ -178,9 +181,13 @@ ENDCLASS.
 	}
 
 	// Step 4: Activate
-	_, err = c.Activate(ctx, objectURL, programName)
+	activation, err := c.Activate(ctx, objectURL, programName)
 	if err != nil {
 		result.Message = fmt.Sprintf("Failed to activate: %v", err)
+		return result, nil
+	}
+	if activation == nil || !activation.Success {
+		result.Message = "Failed to activate temp program: activation did not succeed"
 		return result, nil
 	}
 
@@ -200,38 +207,94 @@ ENDCLASS.
 		return result, nil
 	}
 
-	// Step 6: Parse results - extract assertion messages
+	// Step 6: Parse results. The wrapper's failed assertion carrying
+	// EXEC_RESULT is the completion sentinel; every other real assertion or
+	// exception must make the workflow fail.
+	analysis := analyzeExecuteABAPUnitResult(testResult)
+	result.Output = analysis.Output
+	result.RawAlerts = analysis.Alerts
+	result.ExecutionTime = analysis.ExecutionTime
+	result.Success = analysis.Success
+	if !analysis.Success {
+		result.Message = analysis.Message
+		return result, nil
+	}
+	if len(result.Output) > 0 {
+		result.Message = fmt.Sprintf("Executed successfully, %d output(s) returned", len(result.Output))
+	} else {
+		result.Message = "Executed successfully"
+	}
+
+	return result, nil
+}
+
+const executeResultMarker = "EXEC_RESULT:"
+
+type executeABAPAnalysis struct {
+	Success       bool
+	Output        []string
+	Alerts        []UnitTestAlert
+	ExecutionTime float64
+	Message       string
+}
+
+func analyzeExecuteABAPUnitResult(testResult *UnitTestResult) executeABAPAnalysis {
+	analysis := executeABAPAnalysis{Output: []string{}}
+	if testResult == nil {
+		analysis.Message = "Execution failed: ABAP Unit returned no result"
+		return analysis
+	}
+
+	markerFound := false
+	realFailureFound := false
+	consumeAlert := func(alert UnitTestAlert) {
+		analysis.Alerts = append(analysis.Alerts, alert)
+		alertHasMarker := false
+		for _, text := range append([]string{alert.Title}, alert.Details...) {
+			if output, ok := extractExecuteABAPOutput(text); ok {
+				analysis.Output = append(analysis.Output, output)
+				markerFound = true
+				alertHasMarker = true
+			}
+		}
+
+		kind := strings.ToLower(strings.TrimSpace(alert.Kind))
+		severity := strings.ToLower(strings.TrimSpace(alert.Severity))
+		intentionalResultAssertion := kind == "failedassertion" && alertHasMarker
+		if !intentionalResultAssertion && (kind == "failedassertion" || kind == "exception" || severity == "fatal" || severity == "critical") {
+			realFailureFound = true
+		}
+	}
+
 	for _, class := range testResult.Classes {
+		for _, alert := range class.Alerts {
+			consumeAlert(alert)
+		}
 		for _, method := range class.TestMethods {
-			result.ExecutionTime += method.ExecutionTime
+			analysis.ExecutionTime += method.ExecutionTime
 			for _, alert := range method.Alerts {
-				result.RawAlerts = append(result.RawAlerts, alert)
-
-				// Look for our EXEC_RESULT marker in the alert title
-				if strings.HasPrefix(alert.Title, "EXEC_RESULT:") {
-					output := strings.TrimPrefix(alert.Title, "EXEC_RESULT:")
-					result.Output = append(result.Output, output)
-				}
-
-				// Also check details for additional output
-				for _, detail := range alert.Details {
-					if strings.HasPrefix(detail, "EXEC_RESULT:") {
-						output := strings.TrimPrefix(detail, "EXEC_RESULT:")
-						result.Output = append(result.Output, output)
-					}
-				}
+				consumeAlert(alert)
 			}
 		}
 	}
 
-	result.Success = true
-	if len(result.Output) > 0 {
-		result.Message = fmt.Sprintf("Executed successfully, %d output(s) returned", len(result.Output))
-	} else {
-		result.Message = "Executed successfully (no output captured)"
+	switch {
+	case realFailureFound:
+		analysis.Message = "Execution failed: ABAP Unit reported an exception or failed assertion"
+	case !markerFound:
+		analysis.Message = "Execution failed: completion marker was not returned"
+	default:
+		analysis.Success = true
 	}
+	return analysis
+}
 
-	return result, nil
+func extractExecuteABAPOutput(text string) (string, bool) {
+	text = strings.TrimSpace(text)
+	if !strings.HasPrefix(text, executeResultMarker) {
+		return "", false
+	}
+	return strings.TrimPrefix(text, executeResultMarker), true
 }
 
 // ExecuteABAPMultiple executes ABAP code and returns multiple results via chained assertions.

--- a/pkg/adt/workflows_execute_test.go
+++ b/pkg/adt/workflows_execute_test.go
@@ -1,0 +1,88 @@
+package adt
+
+import "testing"
+
+func TestAnalyzeExecuteABAPUnitResult(t *testing.T) {
+	tests := []struct {
+		name       string
+		result     *UnitTestResult
+		wantOK     bool
+		wantOutput []string
+		wantAlerts int
+	}{
+		{
+			name: "intentional result assertion",
+			result: unitResultWithMethodAlerts(UnitTestAlert{
+				Kind: "failedAssertion", Title: "EXEC_RESULT:synthetic value",
+			}),
+			wantOK: true, wantOutput: []string{"synthetic value"}, wantAlerts: 1,
+		},
+		{
+			name: "marker in assertion details",
+			result: unitResultWithMethodAlerts(UnitTestAlert{
+				Kind: "failedAssertion", Title: "Assertion failed", Details: []string{"EXEC_RESULT:detail value"},
+			}),
+			wantOK: true, wantOutput: []string{"detail value"}, wantAlerts: 1,
+		},
+		{
+			name: "real failed assertion is not hidden by marker",
+			result: unitResultWithMethodAlerts(
+				UnitTestAlert{Kind: "failedAssertion", Title: "EXEC_RESULT:synthetic value"},
+				UnitTestAlert{Kind: "failedAssertion", Title: "synthetic assertion failure"},
+			),
+			wantOutput: []string{"synthetic value"}, wantAlerts: 2,
+		},
+		{
+			name: "exception is failure",
+			result: unitResultWithMethodAlerts(
+				UnitTestAlert{Kind: "failedAssertion", Title: "EXEC_RESULT:synthetic value"},
+				UnitTestAlert{Kind: "exception", Title: "synthetic exception"},
+			),
+			wantOutput: []string{"synthetic value"}, wantAlerts: 2,
+		},
+		{
+			name: "class alert is failure",
+			result: &UnitTestResult{Classes: []UnitTestClass{{
+				Alerts:      []UnitTestAlert{{Kind: "exception", Title: "synthetic class exception"}},
+				TestMethods: []UnitTestMethod{{Alerts: []UnitTestAlert{{Kind: "failedAssertion", Title: "EXEC_RESULT:done"}}}},
+			}}},
+			wantOutput: []string{"done"}, wantAlerts: 2,
+		},
+		{
+			name: "missing completion marker",
+			result: &UnitTestResult{Classes: []UnitTestClass{{
+				TestMethods: []UnitTestMethod{{ExecutionTime: 0.25}},
+			}}},
+		},
+		{name: "nil unit result"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := analyzeExecuteABAPUnitResult(tt.result)
+			if got.Success != tt.wantOK {
+				t.Fatalf("Success = %t, want %t; message=%q", got.Success, tt.wantOK, got.Message)
+			}
+			if len(got.Output) != len(tt.wantOutput) {
+				t.Fatalf("Output = %v, want %v", got.Output, tt.wantOutput)
+			}
+			for i := range tt.wantOutput {
+				if got.Output[i] != tt.wantOutput[i] {
+					t.Fatalf("Output = %v, want %v", got.Output, tt.wantOutput)
+				}
+			}
+			if len(got.Alerts) != tt.wantAlerts {
+				t.Fatalf("alerts = %d, want %d", len(got.Alerts), tt.wantAlerts)
+			}
+			if !got.Success && got.Message == "" {
+				t.Fatal("failure did not include a diagnostic message")
+			}
+		})
+	}
+}
+
+func unitResultWithMethodAlerts(alerts ...UnitTestAlert) *UnitTestResult {
+	return &UnitTestResult{Classes: []UnitTestClass{{
+		TestMethods: []UnitTestMethod{{ExecutionTime: 0.125, Alerts: alerts}},
+	}}}
+}

--- a/pkg/adt/workflows_fileio.go
+++ b/pkg/adt/workflows_fileio.go
@@ -12,11 +12,11 @@ import (
 
 // RenameObjectResult contains the result of renaming an object.
 type RenameObjectResult struct {
-	OldName    string `json:"oldName"`
-	NewName    string `json:"newName"`
-	ObjectType string `json:"objectType"`
-	Success    bool   `json:"success"`
-	Message    string `json:"message,omitempty"`
+	OldName    string   `json:"oldName"`
+	NewName    string   `json:"newName"`
+	ObjectType string   `json:"objectType"`
+	Success    bool     `json:"success"`
+	Message    string   `json:"message,omitempty"`
 	Errors     []string `json:"errors,omitempty"`
 }
 
@@ -58,6 +58,7 @@ func (c *Client) RenameObject(ctx context.Context, objType CreatableObjectType, 
 			return nil, err
 		}
 	}
+	ctx = withMutationPackageChecked(ctx)
 
 	// 1. Get old object source
 	resp, err := c.transport.Request(ctx, oldURL+"/source/main", &RequestOptions{

--- a/pkg/adt/workflows_fileio.go
+++ b/pkg/adt/workflows_fileio.go
@@ -89,27 +89,49 @@ func (c *Client) RenameObject(ctx context.Context, objType CreatableObjectType, 
 	}
 
 	// 4. Write source to new object
-	newURL, _ := c.buildObjectURL(objType, newName)
+	newURL, err := c.buildObjectURL(objType, newName)
+	if err != nil {
+		result.Errors = append(result.Errors, fmt.Sprintf("Failed to build new object URL: %v", err))
+		return result, nil
+	}
+	newSourceURL, err := c.buildSourceURL(objType, newName)
+	if err != nil {
+		result.Errors = append(result.Errors, fmt.Sprintf("Failed to build new source URL: %v", err))
+		return result, nil
+	}
 	lockResult, err := c.LockObject(ctx, newURL, "MODIFY")
 	if err != nil {
 		result.Errors = append(result.Errors, fmt.Sprintf("Failed to lock new object: %v", err))
 		return result, nil
 	}
 
+	newUnlocked := false
 	defer func() {
-		_ = c.UnlockObject(ctx, newURL, lockResult.LockHandle)
+		if !newUnlocked {
+			_ = c.UnlockObject(ctx, newURL, lockResult.LockHandle)
+		}
 	}()
 
-	err = c.UpdateSource(ctx, newURL, newSource, lockResult.LockHandle, transport)
+	err = c.UpdateSource(ctx, newSourceURL, newSource, lockResult.LockHandle, transport)
 	if err != nil {
 		result.Errors = append(result.Errors, fmt.Sprintf("Failed to write source: %v", err))
 		return result, nil
 	}
 
-	_ = c.UnlockObject(ctx, newURL, lockResult.LockHandle)
+	err = c.UnlockObject(ctx, newURL, lockResult.LockHandle)
+	if err != nil {
+		result.Errors = append(result.Errors, fmt.Sprintf("Failed to unlock new object: %v", err))
+		return result, nil
+	}
+	newUnlocked = true
 
 	// 5. Activate new object
-	_, err = c.Activate(ctx, newURL, newName)
+	activation, err := c.Activate(ctx, newURL, newName)
+	if err != nil {
+		result.Errors = append(result.Errors, fmt.Sprintf("Failed to activate new object: %v", err))
+		return result, nil
+	}
+	err = ActivationResultError(activation)
 	if err != nil {
 		result.Errors = append(result.Errors, fmt.Sprintf("Failed to activate new object: %v", err))
 		return result, nil
@@ -119,14 +141,14 @@ func (c *Client) RenameObject(ctx context.Context, objType CreatableObjectType, 
 	oldLockResult, err := c.LockObject(ctx, oldURL, "MODIFY")
 	if err != nil {
 		result.Message = fmt.Sprintf("New object %s created successfully, but failed to lock old object %s for deletion: %v. Please delete manually.", newName, oldName, err)
-		result.Success = true
+		result.Errors = append(result.Errors, result.Message)
 		return result, nil
 	}
 
 	err = c.DeleteObject(ctx, oldURL, oldLockResult.LockHandle, transport)
 	if err != nil {
 		result.Message = fmt.Sprintf("New object %s created successfully, but failed to delete old object %s: %v. Please delete manually.", newName, oldName, err)
-		result.Success = true
+		result.Errors = append(result.Errors, result.Message)
 		return result, nil
 	}
 

--- a/pkg/adt/workflows_source.go
+++ b/pkg/adt/workflows_source.go
@@ -215,6 +215,10 @@ func (c *Client) WriteSource(ctx context.Context, objectType, name, source strin
 		ObjectType: objectType,
 		ObjectName: name,
 	}
+	if opts.Mode != WriteModeCreate && opts.Mode != WriteModeUpdate && opts.Mode != WriteModeUpsert {
+		result.Message = fmt.Sprintf("Invalid mode %q (supported: create, update, upsert)", opts.Mode)
+		return result, nil
+	}
 
 	// Validate object type
 	switch objectType {
@@ -225,33 +229,12 @@ func (c *Client) WriteSource(ctx context.Context, objectType, name, source strin
 		return result, nil
 	}
 
-	// Determine if object exists (for upsert mode)
-	objectExists := false
-	if opts.Mode == WriteModeUpsert {
-		// Try to check if object exists
-		switch objectType {
-		case "PROG":
-			_, err := c.GetProgram(ctx, name)
-			objectExists = (err == nil)
-		case "CLAS":
-			_, err := c.GetClass(ctx, name)
-			objectExists = (err == nil)
-		case "INTF":
-			_, err := c.GetInterface(ctx, name)
-			objectExists = (err == nil)
-		case "DDLS":
-			_, err := c.GetDDLS(ctx, name)
-			objectExists = (err == nil)
-		case "BDEF":
-			_, err := c.GetBDEF(ctx, name)
-			objectExists = (err == nil)
-		case "SRVD":
-			_, err := c.GetSRVD(ctx, name)
-			objectExists = (err == nil)
-		case "SRVB":
-			_, err := c.GetSRVB(ctx, name)
-			objectExists = (err == nil)
-		}
+	// All three modes need an authoritative existence check. Treat only a
+	// definite 404 as absence; authentication, network and server failures must
+	// not be misclassified as a reason to create or overwrite an object.
+	objectExists, err := c.writeSourceObjectExists(ctx, objectType, name)
+	if err != nil {
+		return nil, err
 	}
 
 	// Determine actual operation mode
@@ -282,6 +265,17 @@ func (c *Client) WriteSource(ctx context.Context, objectType, name, source strin
 	} else {
 		return c.writeSourceUpdate(ctx, objectType, name, source, opts)
 	}
+}
+
+func (c *Client) writeSourceObjectExists(ctx context.Context, objectType, name string) (bool, error) {
+	_, err := c.GetSource(ctx, objectType, name, nil)
+	if err == nil {
+		return true, nil
+	}
+	if IsNotFoundError(err) {
+		return false, nil
+	}
+	return false, fmt.Errorf("checking whether %s %s exists: %w", objectType, name, err)
 }
 
 // writeSourceCreate handles creation workflow

--- a/pkg/adt/workflows_source.go
+++ b/pkg/adt/workflows_source.go
@@ -165,7 +165,7 @@ type WriteSourceResult struct {
 	Method       string              `json:"method,omitempty"` // Method name if method-level update
 	SyntaxErrors []SyntaxCheckResult `json:"syntaxErrors,omitempty"`
 	Activation   *ActivationResult   `json:"activation,omitempty"`
-	TestResults  *UnitTestResult     `json:"testResults,omitempty"` // For CLAS with TestSource
+	TestResults  *UnitTestResult     `json:"testResults,omitempty"` //nolint:misspell // CLAS is the SAP ADT object type.
 	Message      string              `json:"message,omitempty"`
 }
 
@@ -273,7 +273,7 @@ func writeSourceObjectURL(objectType, name string) string {
 	switch objectType {
 	case "PROG":
 		creatableType = ObjectTypeProgram
-	case "CLAS":
+	case "CLAS": //nolint:misspell // CLAS is the SAP ADT object type.
 		creatableType = ObjectTypeClass
 	case "INTF":
 		creatableType = ObjectTypeInterface

--- a/pkg/adt/workflows_source.go
+++ b/pkg/adt/workflows_source.go
@@ -157,16 +157,16 @@ type WriteSourceOptions struct {
 
 // WriteSourceResult represents the result of WriteSource operation
 type WriteSourceResult struct {
-	Success       bool                       `json:"success"`
-	ObjectType    string                     `json:"objectType"`
-	ObjectName    string                     `json:"objectName"`
-	ObjectURL     string                     `json:"objectUrl"`
-	Mode          string                     `json:"mode"` // "created" or "updated"
-	Method        string                     `json:"method,omitempty"` // Method name if method-level update
-	SyntaxErrors  []SyntaxCheckResult        `json:"syntaxErrors,omitempty"`
-	Activation    *ActivationResult          `json:"activation,omitempty"`
-	TestResults   *UnitTestResult            `json:"testResults,omitempty"` // For CLAS with TestSource
-	Message       string                     `json:"message,omitempty"`
+	Success      bool                `json:"success"`
+	ObjectType   string              `json:"objectType"`
+	ObjectName   string              `json:"objectName"`
+	ObjectURL    string              `json:"objectUrl"`
+	Mode         string              `json:"mode"`             // "created" or "updated"
+	Method       string              `json:"method,omitempty"` // Method name if method-level update
+	SyntaxErrors []SyntaxCheckResult `json:"syntaxErrors,omitempty"`
+	Activation   *ActivationResult   `json:"activation,omitempty"`
+	TestResults  *UnitTestResult     `json:"testResults,omitempty"` // For CLAS with TestSource
+	Message      string              `json:"message,omitempty"`
 }
 
 // WriteSource is a unified tool for writing ABAP source code across different object types.
@@ -192,20 +192,6 @@ func (c *Client) WriteSource(ctx context.Context, objectType, name, source strin
 	}
 	if opts.Mode == "" {
 		opts.Mode = WriteModeUpsert
-	}
-
-	// Top-level mutation gate. The precise package check runs in the
-	// delegated create/update path (CreateAndActivate* / WriteProgram /
-	// WriteClass) because the target package is known there; here we
-	// enforce op-type and transportable-edit policy up front so the caller
-	// gets a clear early rejection.
-	if err := c.checkMutation(ctx, MutationContext{
-		Op:        OpWorkflow,
-		OpName:    "WriteSource",
-		Package:   opts.Package, // empty for update path, present for create
-		Transport: opts.Transport,
-	}); err != nil {
-		return nil, err
 	}
 
 	objectType = strings.ToUpper(objectType)
@@ -259,12 +245,48 @@ func (c *Client) WriteSource(ctx context.Context, objectType, name, source strin
 		return result, nil
 	}
 
+	mutation := MutationContext{
+		Op:        OpWorkflow,
+		OpName:    "WriteSource",
+		Transport: opts.Transport,
+	}
+	if actualMode == WriteModeCreate {
+		mutation.Package = opts.Package
+	} else {
+		mutation.ObjectURL = writeSourceObjectURL(objectType, name)
+	}
+	if err := c.checkMutation(ctx, mutation); err != nil {
+		return nil, err
+	}
+	ctx = withMutationPackageChecked(ctx)
+
 	// Execute create or update workflow
 	if actualMode == WriteModeCreate {
 		return c.writeSourceCreate(ctx, objectType, name, source, opts)
 	} else {
 		return c.writeSourceUpdate(ctx, objectType, name, source, opts)
 	}
+}
+
+func writeSourceObjectURL(objectType, name string) string {
+	var creatableType CreatableObjectType
+	switch objectType {
+	case "PROG":
+		creatableType = ObjectTypeProgram
+	case "CLAS":
+		creatableType = ObjectTypeClass
+	case "INTF":
+		creatableType = ObjectTypeInterface
+	case "DDLS":
+		creatableType = ObjectTypeDDLS
+	case "BDEF":
+		creatableType = ObjectTypeBDEF
+	case "SRVD":
+		creatableType = ObjectTypeSRVD
+	case "SRVB":
+		creatableType = ObjectTypeSRVB
+	}
+	return GetObjectURL(creatableType, name, "")
 }
 
 func (c *Client) writeSourceObjectExists(ctx context.Context, objectType, name string) (bool, error) {
@@ -584,9 +606,9 @@ func (c *Client) writeSourceCreate(ctx context.Context, objectType, name, source
 		// SRVB (Service Binding) - source is JSON configuration
 		// Parse JSON to get binding parameters
 		var srvbConfig struct {
-			ServiceDefName string `json:"serviceDefName"`
-			BindingType    string `json:"bindingType"`    // ODATA
-			BindingVersion string `json:"bindingVersion"` // V2 or V4
+			ServiceDefName  string `json:"serviceDefName"`
+			BindingType     string `json:"bindingType"`     // ODATA
+			BindingVersion  string `json:"bindingVersion"`  // V2 or V4
 			BindingCategory string `json:"bindingCategory"` // 0=WebAPI, 1=UI
 		}
 		if err := json.Unmarshal([]byte(source), &srvbConfig); err != nil {
@@ -652,7 +674,6 @@ func (c *Client) writeSourceCreate(ctx context.Context, objectType, name, source
 		return result, nil
 	}
 }
-
 
 // writeSourceUpdate handles update workflow
 func (c *Client) writeSourceUpdate(ctx context.Context, objectType, name, source string, opts *WriteSourceOptions) (*WriteSourceResult, error) {
@@ -1028,12 +1049,12 @@ func (c *Client) writeClassMethodUpdate(ctx context.Context, className, methodNa
 
 // SourceDiff represents a diff between two sources.
 type SourceDiff struct {
-	Object1     string   `json:"object1"`
-	Object2     string   `json:"object2"`
-	Identical   bool     `json:"identical"`
-	AddedLines  int      `json:"addedLines"`
-	RemovedLines int     `json:"removedLines"`
-	Diff        string   `json:"diff"`
+	Object1      string `json:"object1"`
+	Object2      string `json:"object2"`
+	Identical    bool   `json:"identical"`
+	AddedLines   int    `json:"addedLines"`
+	RemovedLines int    `json:"removedLines"`
+	Diff         string `json:"diff"`
 }
 
 // CompareSource compares source code of two objects and returns a unified diff.
@@ -1178,8 +1199,12 @@ func generateUnifiedDiff(name1, name2 string, lines1, lines2 []string) string {
 				inHunk = true
 				hunkStart1 = line1 - len(contextBefore)
 				hunkStart2 = line2 - len(contextBefore)
-				if hunkStart1 < 1 { hunkStart1 = 1 }
-				if hunkStart2 < 1 { hunkStart2 = 1 }
+				if hunkStart1 < 1 {
+					hunkStart1 = 1
+				}
+				if hunkStart2 < 1 {
+					hunkStart2 = 1
+				}
 				// Add context before
 				for _, ctx := range contextBefore {
 					hunkContent.WriteString(fmt.Sprintf(" %s\n", ctx.text))
@@ -1207,12 +1232,12 @@ func generateUnifiedDiff(name1, name2 string, lines1, lines2 []string) string {
 
 // CloneObjectResult represents the result of cloning an object.
 type CloneObjectResult struct {
-	Success     bool   `json:"success"`
-	SourceName  string `json:"sourceName"`
-	TargetName  string `json:"targetName"`
-	ObjectType  string `json:"objectType"`
-	Package     string `json:"package"`
-	Message     string `json:"message"`
+	Success    bool   `json:"success"`
+	SourceName string `json:"sourceName"`
+	TargetName string `json:"targetName"`
+	ObjectType string `json:"objectType"`
+	Package    string `json:"package"`
+	Message    string `json:"message"`
 }
 
 // CloneObject copies an ABAP object to a new name.
@@ -1288,18 +1313,18 @@ func (c *Client) CloneObject(ctx context.Context, objectType, sourceName, target
 
 // ClassInfo contains metadata about an ABAP class.
 type ClassInfo struct {
-	Name          string   `json:"name"`
-	Description   string   `json:"description,omitempty"`
-	Package       string   `json:"package,omitempty"`
-	Category      string   `json:"category,omitempty"`      // Regular, Abstract, Final
-	Visibility    string   `json:"visibility,omitempty"`    // Public, Protected, Private
-	Superclass    string   `json:"superclass,omitempty"`
-	Interfaces    []string `json:"interfaces,omitempty"`
-	Methods       []string `json:"methods,omitempty"`
-	Attributes    []string `json:"attributes,omitempty"`
-	HasTestClass  bool     `json:"hasTestClass"`
-	IsAbstract    bool     `json:"isAbstract"`
-	IsFinal       bool     `json:"isFinal"`
+	Name         string   `json:"name"`
+	Description  string   `json:"description,omitempty"`
+	Package      string   `json:"package,omitempty"`
+	Category     string   `json:"category,omitempty"`   // Regular, Abstract, Final
+	Visibility   string   `json:"visibility,omitempty"` // Public, Protected, Private
+	Superclass   string   `json:"superclass,omitempty"`
+	Interfaces   []string `json:"interfaces,omitempty"`
+	Methods      []string `json:"methods,omitempty"`
+	Attributes   []string `json:"attributes,omitempty"`
+	HasTestClass bool     `json:"hasTestClass"`
+	IsAbstract   bool     `json:"isAbstract"`
+	IsFinal      bool     `json:"isFinal"`
 }
 
 // GetClassInfo retrieves class metadata without full source code.

--- a/pkg/adt/workflows_test.go
+++ b/pkg/adt/workflows_test.go
@@ -19,6 +19,9 @@ func (m *mockWorkflowTransport) Do(req *http.Request) (*http.Response, error) {
 
 	// Match by path
 	path := req.URL.Path
+	if resp, ok := m.responses[req.Method+" "+path]; ok {
+		return resp, nil
+	}
 	if resp, ok := m.responses[path]; ok {
 		return resp, nil
 	}
@@ -40,6 +43,14 @@ func (m *mockWorkflowTransport) Do(req *http.Request) (*http.Response, error) {
 func newWorkflowTestResponse(body string) *http.Response {
 	return &http.Response{
 		StatusCode: http.StatusOK,
+		Body:       io.NopCloser(strings.NewReader(body)),
+		Header:     http.Header{"X-CSRF-Token": []string{"test-token"}},
+	}
+}
+
+func newWorkflowStatusResponse(status int, body string) *http.Response {
+	return &http.Response{
+		StatusCode: status,
 		Body:       io.NopCloser(strings.NewReader(body)),
 		Header:     http.Header{"X-CSRF-Token": []string{"test-token"}},
 	}
@@ -154,15 +165,11 @@ WRITE: 'Hello, World!'.`
 
 	mock := &mockWorkflowTransport{
 		responses: map[string]*http.Response{
-			"/sap/bc/adt/programs/programs/ZTEST": newWorkflowTestResponse(`<?xml version="1.0"?>
-<program:abapProgram xmlns:program="http://www.sap.com/adt/programs"
-                     adtcore:name="ZTEST"
-                     adtcore:type="PROG/P"
-                     adtcore:responsible="USER"/>`),
-			"/sap/bc/adt/programs/programs/ZTEST/source/main": newWorkflowTestResponse("OK"),
-			"/sap/bc/adt/checkruns": newWorkflowTestResponse("OK"),
-			"/sap/bc/adt/activation": newWorkflowTestResponse("OK"),
-			"discovery": newWorkflowTestResponse("OK"),
+			"GET /sap/bc/adt/programs/programs/ZTEST/source/main": newWorkflowStatusResponse(http.StatusNotFound, "Not found"),
+			"/sap/bc/adt/programs/programs/ZTEST/source/main":     newWorkflowTestResponse("OK"),
+			"/sap/bc/adt/checkruns":                               newWorkflowTestResponse("OK"),
+			"/sap/bc/adt/activation":                              newWorkflowTestResponse("OK"),
+			"discovery":                                           newWorkflowTestResponse("OK"),
 		},
 	}
 
@@ -216,6 +223,50 @@ WRITE: 'Updated!'.`
 	// Verify it's in update mode (even if workflow didn't complete due to mocks)
 	if result.ObjectType != "PROG" {
 		t.Errorf("Expected ObjectType 'PROG', got %q", result.ObjectType)
+	}
+	if result.Mode != "updated" {
+		t.Errorf("Expected update workflow, got mode %q and message %q", result.Mode, result.Message)
+	}
+}
+
+func TestClient_WriteSource_CreateRejectsExistingObject(t *testing.T) {
+	mock := &mockWorkflowTransport{responses: map[string]*http.Response{
+		"GET /sap/bc/adt/programs/programs/ZEXISTS/source/main": newWorkflowTestResponse("REPORT zexists."),
+	}}
+	cfg := NewConfig("https://sap.example.com:44300", "user", "pass")
+	client := NewClientWithTransport(cfg, NewTransportWithClient(cfg, mock))
+
+	result, err := client.WriteSource(context.Background(), "PROG", "ZEXISTS", "REPORT zexists.", &WriteSourceOptions{
+		Mode:        WriteModeCreate,
+		Description: "Synthetic program",
+		Package:     "$TMP",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Success || !strings.Contains(result.Message, "already exists") {
+		t.Fatalf("unexpected result: %#v", result)
+	}
+	for _, req := range mock.requests {
+		if req.Method != http.MethodGet {
+			t.Fatalf("create was attempted after object was found: %s %s", req.Method, req.URL.Path)
+		}
+	}
+}
+
+func TestClient_WriteSourceExistenceCheckFailsClosed(t *testing.T) {
+	mock := &mockWorkflowTransport{responses: map[string]*http.Response{
+		"GET /sap/bc/adt/programs/programs/ZUNKNOWN/source/main": newWorkflowStatusResponse(http.StatusInternalServerError, "synthetic failure"),
+	}}
+	cfg := NewConfig("https://sap.example.com:44300", "user", "pass")
+	client := NewClientWithTransport(cfg, NewTransportWithClient(cfg, mock))
+
+	result, err := client.WriteSource(context.Background(), "PROG", "ZUNKNOWN", "REPORT zunknown.", nil)
+	if err == nil {
+		t.Fatalf("expected inconclusive existence check to fail closed, got %#v", result)
+	}
+	if !strings.Contains(err.Error(), "checking whether PROG ZUNKNOWN exists") {
+		t.Fatalf("unexpected error: %v", err)
 	}
 }
 

--- a/pkg/adt/workflows_test.go
+++ b/pkg/adt/workflows_test.go
@@ -1,3 +1,4 @@
+//nolint:bodyclose // Mock responses are closed by the transport under test.
 package adt
 
 import (
@@ -159,6 +160,8 @@ func TestClient_GetSource_InvalidType(t *testing.T) {
 }
 
 // TestClient_WriteSource_Create tests WriteSource in create mode
+//
+//nolint:bodyclose // The client transport owns and closes all synthetic responses.
 func TestClient_WriteSource_Create(t *testing.T) {
 	sourceCode := `REPORT ztest.
 WRITE: 'Hello, World!'.`
@@ -229,6 +232,7 @@ WRITE: 'Updated!'.`
 	}
 }
 
+//nolint:bodyclose // The client transport owns and closes all synthetic responses.
 func TestClient_WriteSource_CreateRejectsExistingObject(t *testing.T) {
 	mock := &mockWorkflowTransport{responses: map[string]*http.Response{
 		"GET /sap/bc/adt/programs/programs/ZEXISTS/source/main": newWorkflowTestResponse("REPORT zexists."),
@@ -254,6 +258,7 @@ func TestClient_WriteSource_CreateRejectsExistingObject(t *testing.T) {
 	}
 }
 
+//nolint:bodyclose // The client transport owns and closes all synthetic responses.
 func TestClient_WriteSourceExistenceCheckFailsClosed(t *testing.T) {
 	mock := &mockWorkflowTransport{responses: map[string]*http.Response{
 		"GET /sap/bc/adt/programs/programs/ZUNKNOWN/source/main": newWorkflowStatusResponse(http.StatusInternalServerError, "synthetic failure"),
@@ -343,6 +348,8 @@ WRITE: 'Hello, World!'.`
 }
 
 // TestClient_GrepPackages tests GrepPackages with single package
+//
+//nolint:bodyclose // The client transport owns and closes all synthetic responses.
 func TestClient_GrepPackages(t *testing.T) {
 	packageContents := `<?xml version="1.0" encoding="UTF-8"?>
 <package xmlns="http://www.sap.com/adt/packages" name="$TMP">
@@ -356,7 +363,7 @@ func TestClient_GrepPackages(t *testing.T) {
 
 	mock := &mockWorkflowTransport{
 		responses: map[string]*http.Response{
-			"/sap/bc/adt/packages/$TMP": newWorkflowTestResponse(packageContents),
+			"/sap/bc/adt/packages/$TMP":                        newWorkflowTestResponse(packageContents),
 			"/sap/bc/adt/programs/programs/ZTEST1/source/main": newWorkflowTestResponse(sourceCode),
 			"discovery": newWorkflowTestResponse("OK"),
 		},
@@ -403,8 +410,8 @@ func TestClient_GrepPackages_Recursive(t *testing.T) {
 
 	mock := &mockWorkflowTransport{
 		responses: map[string]*http.Response{
-			"/sap/bc/adt/packages/ZMAIN":       newWorkflowTestResponse(mainPackageContents),
-			"/sap/bc/adt/packages/ZSUB1":       newWorkflowTestResponse(subPackageContents),
+			"/sap/bc/adt/packages/ZMAIN":                          newWorkflowTestResponse(mainPackageContents),
+			"/sap/bc/adt/packages/ZSUB1":                          newWorkflowTestResponse(subPackageContents),
 			"/sap/bc/adt/programs/programs/ZTEST_SUB/source/main": newWorkflowTestResponse(sourceCode),
 			"discovery": newWorkflowTestResponse("OK"),
 		},
@@ -440,8 +447,8 @@ func TestClient_GrepPackages_MultiplePackages(t *testing.T) {
 
 	mock := &mockWorkflowTransport{
 		responses: map[string]*http.Response{
-			"/sap/bc/adt/packages/$TMP":  newWorkflowTestResponse(packageContents),
-			"/sap/bc/adt/packages/$LOCAL": newWorkflowTestResponse(packageContents),
+			"/sap/bc/adt/packages/$TMP":                        newWorkflowTestResponse(packageContents),
+			"/sap/bc/adt/packages/$LOCAL":                      newWorkflowTestResponse(packageContents),
 			"/sap/bc/adt/programs/programs/ZTEST1/source/main": newWorkflowTestResponse(sourceCode),
 			"discovery": newWorkflowTestResponse("OK"),
 		},

--- a/pkg/config/systems.go
+++ b/pkg/config/systems.go
@@ -30,8 +30,15 @@ type SystemConfig struct {
 	CookieString string `json:"cookie_string,omitempty"` // Inline cookie string
 
 	// Optional safety settings per system
-	ReadOnly        bool     `json:"read_only,omitempty"`
-	AllowedPackages []string `json:"allowed_packages,omitempty"`
+	ReadOnly                bool     `json:"read_only,omitempty"`
+	BlockFreeSQL            bool     `json:"block_free_sql,omitempty"`
+	AllowedOps              string   `json:"allowed_ops,omitempty"`
+	DisallowedOps           string   `json:"disallowed_ops,omitempty"`
+	AllowedPackages         []string `json:"allowed_packages,omitempty"`
+	EnableTransports        bool     `json:"enable_transports,omitempty"`
+	TransportReadOnly       bool     `json:"transport_read_only,omitempty"`
+	AllowedTransports       []string `json:"allowed_transports,omitempty"`
+	AllowTransportableEdits bool     `json:"allow_transportable_edits,omitempty"`
 }
 
 // SystemsConfig is the root configuration containing all systems.

--- a/pkg/dsl/workflow.go
+++ b/pkg/dsl/workflow.go
@@ -32,11 +32,11 @@ type WorkflowStep struct {
 
 // WorkflowResult represents the result of a workflow execution.
 type WorkflowResult struct {
-	Name        string               `json:"name"`
-	Success     bool                 `json:"success"`
-	StepResults []StepResult         `json:"stepResults"`
+	Name        string                 `json:"name"`
+	Success     bool                   `json:"success"`
+	StepResults []StepResult           `json:"stepResults"`
 	Variables   map[string]interface{} `json:"variables"`
-	Error       string               `json:"error,omitempty"`
+	Error       string                 `json:"error,omitempty"`
 }
 
 // StepResult represents the result of a single step.
@@ -461,9 +461,9 @@ func handleSyntaxCheck(ctx *ExecutionContext, params map[string]interface{}) (in
 		}
 
 		results = append(results, map[string]interface{}{
-			"object":    obj.Name,
-			"success":   !hasErrors,
-			"messages":  checkResults,
+			"object":   obj.Name,
+			"success":  !hasErrors,
+			"messages": checkResults,
 		})
 	}
 
@@ -515,9 +515,12 @@ func handleActivate(ctx *ExecutionContext, params map[string]interface{}) (inter
 		if err != nil {
 			return nil, err
 		}
+		if err := adt.ActivationResultError(result); err != nil {
+			return nil, fmt.Errorf("activating %s: %w", obj.Name, err)
+		}
 		results = append(results, map[string]interface{}{
-			"object":  obj.Name,
-			"success": result.Success,
+			"object":   obj.Name,
+			"success":  result.Success,
 			"messages": result.Messages,
 		})
 	}

--- a/pkg/jseval/oracle_test.go
+++ b/pkg/jseval/oracle_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
 	"testing"
 )
@@ -133,12 +134,12 @@ function lexer(source) {
 }
 `
 
-type tokenResult struct {
-	Type string `json:"type"`
-	Str  string `json:"str"`
-}
-
 func TestOracleComparison(t *testing.T) {
+	nodePath, err := exec.LookPath("node")
+	if err != nil {
+		t.Skip("node executable is required for oracle comparison")
+	}
+
 	// ABAP test corpus
 	abapSamples := []struct {
 		name string
@@ -188,9 +189,11 @@ for (let i = 0; i < result.length; i++) {
 console.log(out);
 `, strings.ReplaceAll(strings.ReplaceAll(strings.ReplaceAll(s.code, "\\", "\\\\"), "\"", "\\\""), "\n", "\\n"))
 
-			tmpFile := fmt.Sprintf("/tmp/oracle_test_%s.js", s.name)
-			os.WriteFile(tmpFile, []byte(nodeCode), 0644)
-			nodeResult, err := exec.Command("node", tmpFile).CombinedOutput()
+			tmpFile := filepath.Join(t.TempDir(), "oracle.js")
+			if writeErr := os.WriteFile(tmpFile, []byte(nodeCode), 0600); writeErr != nil {
+				t.Fatalf("write node oracle fixture: %v", writeErr)
+			}
+			nodeResult, err := exec.CommandContext(t.Context(), nodePath, tmpFile).CombinedOutput()
 			if err != nil {
 				t.Fatalf("node error: %v\n%s", err, nodeResult)
 			}

--- a/pkg/scripting/bindings.go
+++ b/pkg/scripting/bindings.go
@@ -364,8 +364,8 @@ func (e *LuaEngine) luaSetExceptionBreakpoint(L *lua.LState) int {
 
 // setMessageBP(msgClass, msgNumber, [msgType]) - Break on message
 func (e *LuaEngine) luaSetMessageBreakpoint(L *lua.LState) int {
-	msgArea := getString(L, 1)   // Message class e.g. "00", "SY"
-	msgID := getString(L, 2)     // Message number e.g. "001"
+	msgArea := getString(L, 1)        // Message class e.g. "00", "SY"
+	msgID := getString(L, 2)          // Message number e.g. "001"
 	msgType := getOptString(L, 3, "") // Optional: E, W, I, S, A
 
 	req := &adt.BreakpointRequest{

--- a/pkg/scripting/bindings.go
+++ b/pkg/scripting/bindings.go
@@ -203,16 +203,61 @@ func (e *LuaEngine) luaWriteSource(L *lua.LState) int {
 	objType := getString(L, 1)
 	name := getString(L, 2)
 	source := getString(L, 3)
+	var opts *adt.WriteSourceOptions
+	if L.GetTop() >= 4 && L.Get(4) != lua.LNil {
+		table, ok := L.Get(4).(*lua.LTable)
+		if !ok {
+			L.Push(lua.LBool(false))
+			L.Push(lua.LString("writeSource options must be a table"))
+			return 2
+		}
+		opts = &adt.WriteSourceOptions{
+			Mode:        adt.WriteSourceMode(strings.ToLower(luaTableString(table, "mode"))),
+			Description: luaTableString(table, "description"),
+			Package:     luaTableString(table, "package"),
+			TestSource:  luaTableString(table, "test_source"),
+			Transport:   luaTableString(table, "transport"),
+			Method:      luaTableString(table, "method"),
+		}
+	}
 
-	result, err := e.client.WriteSource(e.ctx, objType, name, source, nil)
+	if e.writeSource == nil {
+		L.Push(lua.LBool(false))
+		L.Push(lua.LString("writeSource is unavailable: ADT client is not configured"))
+		return 2
+	}
+
+	result, err := e.writeSource(e.ctx, objType, name, source, opts)
 	if err != nil {
 		L.Push(lua.LBool(false))
 		L.Push(lua.LString(err.Error()))
 		return 2
 	}
+	if result == nil {
+		L.Push(lua.LBool(false))
+		L.Push(lua.LString("writeSource failed: ADT returned no result"))
+		return 2
+	}
+	if !result.Success {
+		message := strings.TrimSpace(result.Message)
+		if message == "" {
+			message = "writeSource failed without a diagnostic message"
+		}
+		L.Push(lua.LBool(false))
+		L.Push(lua.LString(message))
+		return 2
+	}
 
-	L.Push(lua.LBool(result.Success))
+	L.Push(lua.LBool(true))
 	return 1
+}
+
+func luaTableString(table *lua.LTable, key string) string {
+	value := table.RawGetString(key)
+	if value == lua.LNil {
+		return ""
+	}
+	return lua.LVAsString(value)
 }
 
 func (e *LuaEngine) luaEditSource(L *lua.LState) int {

--- a/pkg/scripting/lua.go
+++ b/pkg/scripting/lua.go
@@ -17,10 +17,11 @@ import (
 
 // LuaEngine wraps a Lua VM with vsp bindings.
 type LuaEngine struct {
-	L      *lua.LState
-	client *adt.Client
-	ctx    context.Context
-	output io.Writer
+	L           *lua.LState
+	client      *adt.Client
+	writeSource func(context.Context, string, string, string, *adt.WriteSourceOptions) (*adt.WriteSourceResult, error)
+	ctx         context.Context
+	output      io.Writer
 
 	// Checkpoints (for Force Replay)
 	checkpoints map[string]map[string]interface{}
@@ -46,6 +47,9 @@ func NewLuaEngine(client *adt.Client) *LuaEngine {
 		ctx:         context.Background(),
 		output:      os.Stdout,
 		checkpoints: make(map[string]map[string]interface{}),
+	}
+	if client != nil {
+		engine.writeSource = client.WriteSource
 	}
 
 	engine.registerBuiltins()
@@ -130,7 +134,7 @@ Search & Source:
   searchObject(query, [type])     Search for ABAP objects
   grepObjects(pattern, [type])    Grep in object sources
   getSource(type, name)           Get source code
-  writeSource(type, name, src)    Write source code
+  writeSource(type, name, src, [options]) Write source (mode, transport, package, description)
   editSource(type, name, old, new) Edit source code
 
 Debugging - Breakpoints:

--- a/pkg/scripting/write_source_test.go
+++ b/pkg/scripting/write_source_test.go
@@ -34,6 +34,7 @@ func TestLuaWriteSourceLegacyCallPreservesNilOptions(t *testing.T) {
 	}
 }
 
+//nolint:misspell // CLAS is the SAP ADT object type used by the Lua API.
 func TestLuaWriteSourceForwardsOptions(t *testing.T) {
 	engine := NewLuaEngine(nil)
 	defer engine.Close()

--- a/pkg/scripting/write_source_test.go
+++ b/pkg/scripting/write_source_test.go
@@ -1,0 +1,109 @@
+package scripting
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/oisee/vibing-steampunk/pkg/adt"
+	lua "github.com/yuin/gopher-lua"
+)
+
+func TestLuaWriteSourceLegacyCallPreservesNilOptions(t *testing.T) {
+	engine := NewLuaEngine(nil)
+	defer engine.Close()
+
+	engine.writeSource = func(_ context.Context, objectType, name, source string, opts *adt.WriteSourceOptions) (*adt.WriteSourceResult, error) {
+		if objectType != "PROG" || name != "Z_SYNTHETIC" || source != "REPORT z_synthetic." {
+			t.Fatalf("unexpected arguments: %q %q %q", objectType, name, source)
+		}
+		if opts != nil {
+			t.Fatalf("legacy three-argument call supplied options: %#v", opts)
+		}
+		return &adt.WriteSourceResult{Success: true}, nil
+	}
+
+	if err := engine.Execute(`ok, message = writeSource("PROG", "Z_SYNTHETIC", "REPORT z_synthetic.")`); err != nil {
+		t.Fatal(err)
+	}
+	if engine.L.GetGlobal("ok") != lua.LTrue {
+		t.Fatalf("ok = %v, want true", engine.L.GetGlobal("ok"))
+	}
+	if engine.L.GetGlobal("message") != lua.LNil {
+		t.Fatalf("message = %v, want nil", engine.L.GetGlobal("message"))
+	}
+}
+
+func TestLuaWriteSourceForwardsOptions(t *testing.T) {
+	engine := NewLuaEngine(nil)
+	defer engine.Close()
+
+	engine.writeSource = func(_ context.Context, _, _, _ string, opts *adt.WriteSourceOptions) (*adt.WriteSourceResult, error) {
+		if opts == nil {
+			t.Fatal("options were not forwarded")
+		}
+		want := adt.WriteSourceOptions{
+			Mode:        adt.WriteModeUpdate,
+			Description: "Synthetic description",
+			Package:     "$TMP",
+			TestSource:  "test source",
+			Transport:   "REQ-TEST-001",
+			Method:      "RUN",
+		}
+		if *opts != want {
+			t.Fatalf("options = %#v, want %#v", *opts, want)
+		}
+		return &adt.WriteSourceResult{Success: true}, nil
+	}
+
+	script := `ok, message = writeSource("CLAS", "ZCL_SYNTHETIC", "source", {
+		mode = "UPDATE",
+		description = "Synthetic description",
+		package = "$TMP",
+		test_source = "test source",
+		transport = "REQ-TEST-001",
+		method = "RUN"
+	})`
+	if err := engine.Execute(script); err != nil {
+		t.Fatal(err)
+	}
+	if engine.L.GetGlobal("ok") != lua.LTrue {
+		t.Fatalf("ok = %v, want true", engine.L.GetGlobal("ok"))
+	}
+}
+
+func TestLuaWriteSourceReturnsDiagnosticForUnsuccessfulResult(t *testing.T) {
+	engine := NewLuaEngine(nil)
+	defer engine.Close()
+	engine.writeSource = func(context.Context, string, string, string, *adt.WriteSourceOptions) (*adt.WriteSourceResult, error) {
+		return &adt.WriteSourceResult{Success: false, Message: "synthetic activation failure"}, nil
+	}
+
+	if err := engine.Execute(`ok, message = writeSource("PROG", "Z_SYNTHETIC", "source", {})`); err != nil {
+		t.Fatal(err)
+	}
+	if engine.L.GetGlobal("ok") != lua.LFalse {
+		t.Fatalf("ok = %v, want false", engine.L.GetGlobal("ok"))
+	}
+	if got := lua.LVAsString(engine.L.GetGlobal("message")); got != "synthetic activation failure" {
+		t.Fatalf("message = %q", got)
+	}
+}
+
+func TestLuaWriteSourceReturnsGoError(t *testing.T) {
+	engine := NewLuaEngine(nil)
+	defer engine.Close()
+	engine.writeSource = func(context.Context, string, string, string, *adt.WriteSourceOptions) (*adt.WriteSourceResult, error) {
+		return nil, errors.New("synthetic request error")
+	}
+
+	if err := engine.Execute(`ok, message = writeSource("PROG", "Z_SYNTHETIC", "source")`); err != nil {
+		t.Fatal(err)
+	}
+	if engine.L.GetGlobal("ok") != lua.LFalse {
+		t.Fatalf("ok = %v, want false", engine.L.GetGlobal("ok"))
+	}
+	if got := lua.LVAsString(engine.L.GetGlobal("message")); got != "synthetic request error" {
+		t.Fatalf("message = %q", got)
+	}
+}

--- a/reports/2026-08-15-vsp-bug-audit.md
+++ b/reports/2026-08-15-vsp-bug-audit.md
@@ -21,9 +21,9 @@ Data da auditoria: 2026-08-15
 | Plataforma | Windows/amd64 |
 | Go | `go1.25.0` |
 | CGO | desabilitado no runtime de auditoria |
-| Commit de código auditado | `8bd5c63c470ef6b688880071e4cd8ac9d4362d5e` |
-| Árvore Git do código auditado | `9a9929a42079eda087b494e1b81e1ef661cc0eb2` |
-| Descrição do código auditado | `v2.38.1-82-g8bd5c63` |
+| Commit de código auditado | `596b8cce0a10da847b877f1677e4e1c026cf669a` |
+| Árvore Git do código auditado | `229172f779898e605cc90ed851da65a63fb2680d` |
+| Descrição do código auditado | `v2.38.1-85-g596b8cc` |
 
 ## Matriz de diagnóstico e correção
 
@@ -34,6 +34,8 @@ Data da auditoria: 2026-08-15
 | C. `ExecuteABAP` | Ativação sem sucesso e alertas ABAP Unit reais podiam terminar como sucesso; camadas CLI/MCP não tratavam `Success=false` como erro. | Ativação bem-sucedida passou a ser obrigatória; analisador separa o marcador de resultado de assertions/exceções reais e exige marcador de conclusão; CLI/MCP propagam falha lógica. | Testes puros para sucesso, assertion, exceção, ausência de marcador e falha de ativação. | Corrigido |
 | D. Instaladores | A existência do pacote era inferida por endpoint inadequado, opções não eram integralmente repassadas e o resultado lógico do deploy não era verificado. | Consulta direta do pacote; criação idempotente com verificação; deploy compartilhado valida erro, `Success`, sintaxe, ativação e leitura posterior; objeto preexistente nunca é excluído por reconciliação automática. | Fakes para pacote existente/ausente, falha lógica, sintaxe, ativação, leitura e conflito de existência. | Corrigido |
 | E. Lock, sessão, CSRF e transporte | Descoberta CSRF podia abrir contexto stateless; havia busca de pacote entre lock e escrita; `NoModification` era interpretado como proibição; `corrNr` do lock era descartado. | CSRF usa o mesmo modo stateful, com fallback HEAD→GET; pacote é validado antes do lock; somente a busca redundante é suprimida, mantendo gates de operação/transporte; `NoModification` é preservado como metadado; `corrNr` é reutilizado com whitelist e preferência ao transporte explícito; erros 400/409/423 não recebem retry cego. | Mocks de cookie, renovação 403, ordem LOCK→PUT→UNLOCK, unlock após falha, fallback/override de transporte e bloqueio fail-closed. | Corrigido |
+| F. IDs de gravação | A resolução do relógio no Windows permitia IDs idênticos em gravações criadas em rajada, sobrescrevendo arquivo e índice. | O timestamp usado no ID avança atomicamente quando o relógio não progride, preservando ordenação e formato. | Teste concorrente de 4.000 IDs e 50 repetições da suíte de histórico. | Corrigido |
+| G. Oracle JavaScript no Windows | O teste gravava o script em `/tmp`, caminho não portável, e ignorava erro de escrita. | `t.TempDir`, escrita verificada, `CommandContext` e skip explícito quando Node.js não está disponível. | `pkg/jseval` e `TestOracleComparison` passam no Windows. | Corrigido |
 
 ## Histórico e correlação pública
 
@@ -49,6 +51,8 @@ O histórico da branch principal já continha correções parciais de sessão (`
 4. `057c3c66cbf3a264017f74fc6f5f51f11959f889` — `fix(install): verify package and deployed objects`
 5. `60ec08e86e070fc116d812b30ac9feb110a88fba` — `fix(adt): preserve lock session and transport context`
 6. `8bd5c63c470ef6b688880071e4cd8ac9d4362d5e` — `style(go): format audited files`
+7. `cc9690bdf3c846f98fa7aec0437268b2856178bc` — `fix(adt): guarantee unique recording IDs`
+8. `596b8cce0a10da847b877f1677e4e1c026cf669a` — `test(jseval): use portable oracle temp files`
 
 ## Arquivos modificados
 
@@ -57,6 +61,7 @@ O histórico da branch principal já continha correções parciais de sessão (`
 - Execução: `pkg/adt/workflows_execute.go`, `pkg/adt/workflows_execute_test.go`, `internal/mcp/handlers_help.go`, `internal/mcp/handlers_transport.go`, `internal/mcp/tools_register.go`.
 - Instaladores: `internal/install/install.go`, `internal/install/install_test.go`, `internal/mcp/handlers_install.go`, `pkg/adt/client.go`, `pkg/adt/crud.go`, `pkg/adt/crud_reconcile_test.go`.
 - Sessão e mutações: `pkg/adt/http.go`, `pkg/adt/http_test.go`, `pkg/adt/mutation_gate.go`, `pkg/adt/saml_auth_test.go`, `pkg/adt/workflows.go`, `pkg/adt/workflows_deploy.go`, `pkg/adt/workflows_deploy_order_test.go`, `pkg/adt/workflows_edit.go`, `pkg/adt/workflows_fileio.go`.
+- Portabilidade e histórico: `pkg/adt/recorder.go`, `pkg/adt/recorder_test.go`, `pkg/jseval/oracle_test.go`.
 
 ## Verificação
 
@@ -68,14 +73,14 @@ Passaram:
 - `golangci-lint v1.64.8 run --new-from-rev=origin/main ./...`;
 - `git diff origin/main..HEAD --check`;
 - inspeção do delta para dados de cliente, usando somente fixtures sintéticas.
+- 50 repetições dos testes de histórico que falhavam intermitentemente;
+- teste oracle de `pkg/jseval` com diretório temporário nativo do sistema.
 
-A suíte `go test ./...` não fica integralmente verde no ambiente atual por causas já presentes na base:
+A suíte `go test ./...` agora passa em todos os pacotes que não dependem de SQLite com CGO. No ambiente atual, restam somente falhas já presentes na base:
 
 - testes SQLite de `cmd/vsp` e `pkg/cache` requerem CGO;
-- `pkg/jseval` usa caminhos `/tmp` que não são válidos da mesma forma no Windows;
-- testes de histórico em `pkg/adt` apresentam intermitência no índice de gravações. O pacote passou em uma execução completa e a intermitência foi reproduzida isoladamente.
 
-Essas falhas não interceptam os cenários corrigidos e não foram mascaradas nem alteradas nesta auditoria.
+O problema de `/tmp` em `pkg/jseval` e a intermitência do histórico foram corrigidos, não apenas ignorados. A limitação restante de CGO não intercepta os cenários corrigidos e não foi mascarada.
 
 ## Riscos residuais
 

--- a/reports/2026-08-15-vsp-bug-audit.md
+++ b/reports/2026-08-15-vsp-bug-audit.md
@@ -21,9 +21,9 @@ Data da auditoria: 2026-08-15
 | Plataforma | Windows/amd64 |
 | Go | `go1.25.0` |
 | CGO | desabilitado no runtime de auditoria |
-| Commit de código auditado | `596b8cce0a10da847b877f1677e4e1c026cf669a` |
-| Árvore Git do código auditado | `229172f779898e605cc90ed851da65a63fb2680d` |
-| Descrição do código auditado | `v2.38.1-85-g596b8cc` |
+| Commit de código auditado | `064ad714f5b8c7facae70e5cc691c8acb09f0147` |
+| Árvore Git do código auditado | `dddb6ed63ba1d19e1080b60a04cde2a69796e81e` |
+| Descrição do código auditado | `v2.38.1-90-g064ad71` |
 
 ## Matriz de diagnóstico e correção
 
@@ -36,6 +36,9 @@ Data da auditoria: 2026-08-15
 | E. Lock, sessão, CSRF e transporte | Descoberta CSRF podia abrir contexto stateless; havia busca de pacote entre lock e escrita; `NoModification` era interpretado como proibição; `corrNr` do lock era descartado. | CSRF usa o mesmo modo stateful, com fallback HEAD→GET; pacote é validado antes do lock; somente a busca redundante é suprimida, mantendo gates de operação/transporte; `NoModification` é preservado como metadado; `corrNr` é reutilizado com whitelist e preferência ao transporte explícito; erros 400/409/423 não recebem retry cego. | Mocks de cookie, renovação 403, ordem LOCK→PUT→UNLOCK, unlock após falha, fallback/override de transporte e bloqueio fail-closed. | Corrigido |
 | F. IDs de gravação | A resolução do relógio no Windows permitia IDs idênticos em gravações criadas em rajada, sobrescrevendo arquivo e índice. | O timestamp usado no ID avança atomicamente quando o relógio não progride, preservando ordenação e formato. | Teste concorrente de 4.000 IDs e 50 repetições da suíte de histórico. | Corrigido |
 | G. Oracle JavaScript no Windows | O teste gravava o script em `/tmp`, caminho não portável, e ignorava erro de escrita. | `t.TempDir`, escrita verificada, `CommandContext` e skip explícito quando Node.js não está disponível. | `pkg/jseval` e `TestOracleComparison` passam no Windows. | Corrigido |
+| H. Falsos sucessos em `copy` e MCP | `copy` ignorava `Success=false` em cinco tipos, terminava com código zero após falhas, criava pacote após qualquer erro de consulta e anunciava deploy WebSocket/includes ainda não implementado; o MCP serializava falha lógica de `WriteSource` como resposta normal. | Resultado nulo/lógico agora falha; erro agregado gera saída não zero; pacote só é criado após ausência conclusiva; objetos incompletos são pulados antes da escrita; MCP retorna erro de ferramenta. | Testes de resultado, resumo, pacote existente/ausente/inconclusivo, matriz de suporte e validação MCP. | Corrigido |
+| I. Ativação e rename destrutivo | Vários workflows verificavam apenas erro HTTP de `Activate`; `RenameObject` escrevia no endpoint do objeto, ignorava unlock e podia excluir o objeto antigo após `Success=false`. | Validador comum converte falha lógica em erro; deploy, tabela, lote, DSL e MCP o utilizam; rename escreve em `/source/main`, exige unlock/ativação e não toca no objeto antigo após falha. | Teste sintético confirma diagnóstico, classificação em lote, endpoint correto e interrupção antes do lock/delete antigo, repetido 20 vezes. | Corrigido |
+| J. Existência inconclusiva em deploy de arquivo | `DeployFromFile` tratava somente 404 como ausência, mas seguia para update após erro de autenticação, rede ou servidor. | Falhas inconclusivas encerram o fluxo antes de lock ou escrita. | Teste com erro 500 confirma uma única requisição de leitura e nenhuma mutação. | Corrigido |
 
 ## Histórico e correlação pública
 
@@ -53,6 +56,9 @@ O histórico da branch principal já continha correções parciais de sessão (`
 6. `8bd5c63c470ef6b688880071e4cd8ac9d4362d5e` — `style(go): format audited files`
 7. `cc9690bdf3c846f98fa7aec0437268b2856178bc` — `fix(adt): guarantee unique recording IDs`
 8. `596b8cce0a10da847b877f1677e4e1c026cf669a` — `test(jseval): use portable oracle temp files`
+9. `c2bb35c2fd875e6f8706ff8b78e16ad0738ccbcc` — `fix(copy): reject partial and inconclusive deployments`
+10. `e9fe44d99a37be938c9bc1cd7203994e6879bcf9` — `fix(mcp): surface logical write failures`
+11. `064ad714f5b8c7facae70e5cc691c8acb09f0147` — `fix(adt): stop workflows on activation failure`
 
 ## Arquivos modificados
 
@@ -62,6 +68,7 @@ O histórico da branch principal já continha correções parciais de sessão (`
 - Instaladores: `internal/install/install.go`, `internal/install/install_test.go`, `internal/mcp/handlers_install.go`, `pkg/adt/client.go`, `pkg/adt/crud.go`, `pkg/adt/crud_reconcile_test.go`.
 - Sessão e mutações: `pkg/adt/http.go`, `pkg/adt/http_test.go`, `pkg/adt/mutation_gate.go`, `pkg/adt/saml_auth_test.go`, `pkg/adt/workflows.go`, `pkg/adt/workflows_deploy.go`, `pkg/adt/workflows_deploy_order_test.go`, `pkg/adt/workflows_edit.go`, `pkg/adt/workflows_fileio.go`.
 - Portabilidade e histórico: `pkg/adt/recorder.go`, `pkg/adt/recorder_test.go`, `pkg/jseval/oracle_test.go`.
+- Segunda passada fail-closed: `cmd/vsp/copy_cmd.go`, `cmd/vsp/copy_cmd_test.go`, `internal/mcp/handlers_source.go`, `internal/mcp/handlers_source_test.go`, `internal/mcp/handlers_devtools.go`, `pkg/adt/devtools.go`, `pkg/adt/devtools_activation_test.go`, `pkg/adt/workflows_deploy_exists_test.go`, `pkg/dsl/workflow.go`.
 
 ## Verificação
 
@@ -75,6 +82,7 @@ Passaram:
 - inspeção do delta para dados de cliente, usando somente fixtures sintéticas.
 - 50 repetições dos testes de histórico que falhavam intermitentemente;
 - teste oracle de `pkg/jseval` com diretório temporário nativo do sistema.
+- 20 repetições dos cenários de ativação lógica, rename protegido, existência inconclusiva e contratos de `copy`/MCP.
 
 A suíte `go test ./...` agora passa em todos os pacotes que não dependem de SQLite com CGO. No ambiente atual, restam somente falhas já presentes na base:
 
@@ -89,6 +97,7 @@ O problema de `/tmp` em `pkg/jseval` e a intermitência do histórico foram corr
 - O transporte herdado do lock continua sujeito ao opt-in de edição transportável e à whitelist; por projeto, ele falha fechado.
 - A associação lock→transporte existe somente na memória do processo. Reiniciar o processo invalida essa associação, assim como o próprio contexto de sessão.
 - `ExecuteABAP` continua sendo uma operação sensível e não deve ser usado como executor genérico em ambiente produtivo.
+- O comando `copy` pula classes com includes e tipos fora da implementação ADT atual; o caminho WebSocket permanece explicitamente não implementado, sem anunciar sucesso parcial.
 
 ## Plano manual seguro em SAP
 
@@ -107,7 +116,7 @@ Executar apenas em sandbox descartável e autorizada, nunca com dados de cliente
 
 ## Rascunhos de pull request
 
-Os cinco blocos abaixo foram preservados como unidades lógicas de revisão. Para reduzir conflito e manter as dependências entre os fixes, eles foram publicados juntos no draft PR [#156](https://github.com/oisee/vibing-steampunk/pull/156).
+Os oito blocos abaixo foram preservados como unidades lógicas de revisão. Para reduzir conflito e manter as dependências entre os fixes, eles foram publicados juntos no draft PR [#156](https://github.com/oisee/vibing-steampunk/pull/156).
 
 ### PR 1 — Propagação de segurança na CLI
 
@@ -138,5 +147,23 @@ Os cinco blocos abaixo foram preservados como unidades lógicas de revisão. Par
 **Título:** `fix(adt): preserve lock session and transport context`
 
 **Resumo:** mantém CSRF/cookie stateful, move validações de pacote para antes do lock, preserva gates locais, corrige o uso de `MODIFICATION_SUPPORT` e reutiliza `corrNr` com whitelist. Relaciona-se a #88, #92, #141, #143 e #144 e às PRs #108, #120 e #125.
+
+### PR 6 — `copy` fail-closed
+
+**Título:** `fix(copy): reject partial and inconclusive deployments`
+
+**Resumo:** cria pacote somente após ausência conclusiva, propaga falhas lógicas e agregadas, e não anuncia ou executa parcialmente tipos/includes ainda sem implementação.
+
+### PR 7 — Falhas lógicas no MCP
+
+**Título:** `fix(mcp): surface logical write failures`
+
+**Resumo:** converte resultados nulos ou `Success=false` de `WriteSource` em erro MCP com diagnóstico.
+
+### PR 8 — Ativação e rename verificáveis
+
+**Título:** `fix(adt): stop workflows on activation failure`
+
+**Resumo:** propaga falha lógica de ativação e impede que rename/deploy/tabela/lote avancem após resultado inconclusivo ou sem sucesso.
 
 O PR consolidado permanece em rascunho para revisão dos mantenedores. A branch publicada permite modificações por mantenedores.

--- a/reports/2026-08-15-vsp-bug-audit.md
+++ b/reports/2026-08-15-vsp-bug-audit.md
@@ -1,0 +1,135 @@
+# Auditoria e correção dos bugs do VSP
+
+Data da auditoria: 2026-08-15
+
+## Limites e proteção de dados
+
+- A investigação e os testes foram executados somente no repositório local, com mocks, nomes sintéticos e endpoints de exemplo.
+- Nenhuma chamada foi feita a um sistema SAP, nenhuma credencial foi usada e nenhuma alteração SAP foi executada.
+- Os documentos fornecidos serviram apenas como evidência funcional. Seu conteúdo e quaisquer dados de cliente não foram copiados para código, testes, commits ou este relatório.
+- Não houve push, abertura de pull request nem escrita externa.
+
+## Baseline reproduzível
+
+| Item | Valor |
+|---|---|
+| Repositório | `oisee/vibing-steampunk` |
+| Branch local | `codex/vsp-bug-audit` |
+| Base | `83b9699bbeb42afa35baf0650d055c83c64a8eb0` |
+| Descrição da base | `v2.38.1-76-g83b9699` |
+| Versão reportada pelo binário sem `ldflags` | `dev (commit: unknown, built: unknown)` |
+| Plataforma | Windows/amd64 |
+| Go | `go1.25.0` |
+| CGO | desabilitado no runtime de auditoria |
+| Commit de código auditado | `8bd5c63c470ef6b688880071e4cd8ac9d4362d5e` |
+| Árvore Git do código auditado | `9a9929a42079eda087b494e1b81e1ef661cc0eb2` |
+| Descrição do código auditado | `v2.38.1-82-g8bd5c63` |
+
+## Matriz de diagnóstico e correção
+
+| Frente | Causa confirmada | Correção aplicada | Evidência automatizada | Status |
+|---|---|---|---|---|
+| A. Segurança da CLI | Flags de segurança pertenciam ao comando raiz não persistente e a configuração resolvida não chegava aos clientes criados pelos subcomandos. | Flags tornadas persistentes; resolução central executada antes de CLI/MCP; perfil, ambiente e flags são mesclados; todos os campos de segurança são aceitos no arquivo de sistemas. | Testes de herança, precedência e construção do cliente. | Corrigido |
+| B. `writeSource` em Lua | O binding descartava opções relevantes e reduzia falhas lógicas a retorno insuficiente. | Compatibilidade com três argumentos preservada; tabela opcional encaminha modo, transporte, pacote, descrição, teste e método; falhas retornam `false, mensagem`; erros de existência deixam de converter falhas de rede/autenticação em ausência. | Testes do binding e dos modos create/update/upsert. | Corrigido |
+| C. `ExecuteABAP` | Ativação sem sucesso e alertas ABAP Unit reais podiam terminar como sucesso; camadas CLI/MCP não tratavam `Success=false` como erro. | Ativação bem-sucedida passou a ser obrigatória; analisador separa o marcador de resultado de assertions/exceções reais e exige marcador de conclusão; CLI/MCP propagam falha lógica. | Testes puros para sucesso, assertion, exceção, ausência de marcador e falha de ativação. | Corrigido |
+| D. Instaladores | A existência do pacote era inferida por endpoint inadequado, opções não eram integralmente repassadas e o resultado lógico do deploy não era verificado. | Consulta direta do pacote; criação idempotente com verificação; deploy compartilhado valida erro, `Success`, sintaxe, ativação e leitura posterior; objeto preexistente nunca é excluído por reconciliação automática. | Fakes para pacote existente/ausente, falha lógica, sintaxe, ativação, leitura e conflito de existência. | Corrigido |
+| E. Lock, sessão, CSRF e transporte | Descoberta CSRF podia abrir contexto stateless; havia busca de pacote entre lock e escrita; `NoModification` era interpretado como proibição; `corrNr` do lock era descartado. | CSRF usa o mesmo modo stateful, com fallback HEAD→GET; pacote é validado antes do lock; somente a busca redundante é suprimida, mantendo gates de operação/transporte; `NoModification` é preservado como metadado; `corrNr` é reutilizado com whitelist e preferência ao transporte explícito; erros 400/409/423 não recebem retry cego. | Mocks de cookie, renovação 403, ordem LOCK→PUT→UNLOCK, unlock após falha, fallback/override de transporte e bloqueio fail-closed. | Corrigido |
+
+## Histórico e correlação pública
+
+Em 2026-08-15, as issues [#88](https://github.com/oisee/vibing-steampunk/issues/88), [#92](https://github.com/oisee/vibing-steampunk/issues/92), [#117](https://github.com/oisee/vibing-steampunk/issues/117), [#141](https://github.com/oisee/vibing-steampunk/issues/141), [#143](https://github.com/oisee/vibing-steampunk/issues/143) e [#144](https://github.com/oisee/vibing-steampunk/issues/144) estavam abertas. As PRs [#106](https://github.com/oisee/vibing-steampunk/pull/106) e [#138](https://github.com/oisee/vibing-steampunk/pull/138) cobriam partes do instalador.
+
+O histórico da branch principal já continha correções parciais de sessão (`27f4d7c`, `22517d4`), mas mantinha caminhos incompletos e a interpretação incorreta de `MODIFICATION_SUPPORT`. As PRs abertas [#108](https://github.com/oisee/vibing-steampunk/pull/108), [#120](https://github.com/oisee/vibing-steampunk/pull/120) e [#125](https://github.com/oisee/vibing-steampunk/pull/125) confirmaram os mesmos pontos de ordem, CSRF e busca redundante. A implementação local incorpora esses princípios sem ignorar os gates de operação e transporte.
+
+## Commits locais
+
+1. `41630704550bf16ade46da76644ac7b226b8616e` — `fix(cli): propagate safety policy to subcommands`
+2. `e34ba9e1f25a3ebfd6ea869211800e7375a30138` — `fix(lua): make writeSource failures explicit`
+3. `d30614f4cf52064acdfee299ced9e9e4ced4919e` — `fix(execute): fail on ABAP Unit errors`
+4. `057c3c66cbf3a264017f74fc6f5f51f11959f889` — `fix(install): verify package and deployed objects`
+5. `60ec08e86e070fc116d812b30ac9feb110a88fba` — `fix(adt): preserve lock session and transport context`
+6. `8bd5c63c470ef6b688880071e4cd8ac9d4362d5e` — `style(go): format audited files`
+
+## Arquivos modificados
+
+- CLI e configuração: `cmd/vsp/main.go`, `cmd/vsp/cli.go`, `cmd/vsp/cli_extra.go`, `cmd/vsp/cli_safety_test.go`, `cmd/vsp/devops.go`, `pkg/config/systems.go`.
+- Lua e source workflows: `pkg/scripting/lua.go`, `pkg/scripting/bindings.go`, `pkg/scripting/write_source_test.go`, `pkg/adt/workflows_source.go`, `pkg/adt/workflows_test.go`.
+- Execução: `pkg/adt/workflows_execute.go`, `pkg/adt/workflows_execute_test.go`, `internal/mcp/handlers_help.go`, `internal/mcp/handlers_transport.go`, `internal/mcp/tools_register.go`.
+- Instaladores: `internal/install/install.go`, `internal/install/install_test.go`, `internal/mcp/handlers_install.go`, `pkg/adt/client.go`, `pkg/adt/crud.go`, `pkg/adt/crud_reconcile_test.go`.
+- Sessão e mutações: `pkg/adt/http.go`, `pkg/adt/http_test.go`, `pkg/adt/mutation_gate.go`, `pkg/adt/saml_auth_test.go`, `pkg/adt/workflows.go`, `pkg/adt/workflows_deploy.go`, `pkg/adt/workflows_deploy_order_test.go`, `pkg/adt/workflows_edit.go`, `pkg/adt/workflows_fileio.go`.
+
+## Verificação
+
+Passaram:
+
+- testes focados de `pkg/config`, `pkg/scripting`, `internal/install`, `internal/mcp`, `cmd/vsp` e `pkg/adt`;
+- `go vet ./...`;
+- `gofmt` em todos os arquivos Go do delta;
+- `golangci-lint v1.64.8 run --new-from-rev=origin/main ./...`;
+- `git diff origin/main..HEAD --check`;
+- inspeção do delta para dados de cliente, usando somente fixtures sintéticas.
+
+A suíte `go test ./...` não fica integralmente verde no ambiente atual por causas já presentes na base:
+
+- testes SQLite de `cmd/vsp` e `pkg/cache` requerem CGO;
+- `pkg/jseval` usa caminhos `/tmp` que não são válidos da mesma forma no Windows;
+- testes de histórico em `pkg/adt` apresentam intermitência no índice de gravações. O pacote passou em uma execução completa e a intermitência foi reproduzida isoladamente.
+
+Essas falhas não interceptam os cenários corrigidos e não foram mascaradas nem alteradas nesta auditoria.
+
+## Riscos residuais
+
+- As diferenças entre versões e topologias reais de ADT ainda exigem uma canária manual em sandbox; mocks provam a lógica do cliente, não o comportamento de cada backend.
+- O fallback GET de CSRF adiciona uma requisição apenas quando HEAD falha ou não devolve token.
+- O transporte herdado do lock continua sujeito ao opt-in de edição transportável e à whitelist; por projeto, ele falha fechado.
+- A associação lock→transporte existe somente na memória do processo. Reiniciar o processo invalida essa associação, assim como o próprio contexto de sessão.
+- `ExecuteABAP` continua sendo uma operação sensível e não deve ser usado como executor genérico em ambiente produtivo.
+
+## Plano manual seguro em SAP
+
+Executar apenas em sandbox descartável e autorizada, nunca com dados de cliente:
+
+1. Criar usuário técnico dedicado, sem acesso produtivo, e confirmar logs sem corpo de source, cookies ou credenciais.
+2. Rodar descoberta/autenticação somente leitura e confirmar que o cliente não imprime token nem cookie.
+3. Usar um único objeto local `$TMP`, com nome e source sintéticos, sem leitura de tabelas ou chamadas externas.
+4. Enviar primeiro source deliberadamente inválido e confirmar que não ocorre lock nem escrita.
+5. Enviar source mínimo válido e observar uma única sequência `LOCK → PUT → UNLOCK`; conferir que não há busca stateless no intervalo e que não sobra lock.
+6. Simular falhas 400/409/423 no proxy de teste e confirmar propagação sem segunda escrita.
+7. Validar transporte somente em sistema de desenvolvimento dedicado, com request sintético explicitamente permitido; confirmar que transporte explícito prevalece e que fallback fora da whitelist é bloqueado antes do PUT.
+8. Para `ExecuteABAP`, usar apenas constantes em memória, sem SELECT/UPDATE, exigir resultado e verificar a remoção do programa temporário.
+9. Para o instalador, usar sistema descartável: testar pacote ausente e preexistente, validar ativação e leitura de source, e confirmar que uma falha nunca exclui objeto preexistente.
+10. Encerrar verificando locks e objetos sintéticos e registrar somente metadados técnicos sanitizados.
+
+## Rascunhos de pull request
+
+### PR 1 — Propagação de segurança na CLI
+
+**Título:** `fix(cli): propagate safety policy to subcommands`
+
+**Resumo:** transforma flags de segurança em persistentes, resolve configuração antes de qualquer subcomando e encaminha a política ao cliente ADT. Inclui testes de herança e precedência. Relaciona-se a #117.
+
+### PR 2 — Contrato Lua de `writeSource`
+
+**Título:** `fix(lua): make writeSource failures explicit`
+
+**Resumo:** preserva a chamada legada, aceita opções completas e devolve diagnóstico em falhas lógicas. A existência deixa de tratar erros indeterminados como objeto ausente.
+
+### PR 3 — Resultado confiável de `ExecuteABAP`
+
+**Título:** `fix(execute): fail on ABAP Unit errors`
+
+**Resumo:** exige ativação, marcador de conclusão e ausência de assertions/exceções reais; CLI e MCP passam a falhar quando o workflow reporta `Success=false`.
+
+### PR 4 — Instaladores verificáveis e idempotentes
+
+**Título:** `fix(install): verify package and deployed objects`
+
+**Resumo:** verifica pacote diretamente, preserva descrição/opções, valida resultado, sintaxe, ativação e leitura posterior, e protege objetos preexistentes. Relaciona-se às PRs #106 e #138.
+
+### PR 5 — Sessão stateful e contexto de transporte
+
+**Título:** `fix(adt): preserve lock session and transport context`
+
+**Resumo:** mantém CSRF/cookie stateful, move validações de pacote para antes do lock, preserva gates locais, corrige o uso de `MODIFICATION_SUPPORT` e reutiliza `corrNr` com whitelist. Relaciona-se a #88, #92, #141, #143 e #144 e às PRs #108, #120 e #125.
+
+Nenhuma PR foi criada; estes textos são somente rascunhos para revisão.

--- a/reports/2026-08-15-vsp-bug-audit.md
+++ b/reports/2026-08-15-vsp-bug-audit.md
@@ -7,7 +7,7 @@ Data da auditoria: 2026-08-15
 - A investigação e os testes foram executados somente no repositório local, com mocks, nomes sintéticos e endpoints de exemplo.
 - Nenhuma chamada foi feita a um sistema SAP, nenhuma credencial foi usada e nenhuma alteração SAP foi executada.
 - Os documentos fornecidos serviram apenas como evidência funcional. Seu conteúdo e quaisquer dados de cliente não foram copiados para código, testes, commits ou este relatório.
-- Não houve push, abertura de pull request nem escrita externa.
+- A publicação posterior foi limitada à branch `codex/vsp-bug-audit` no fork `Augusto42/vibing-steampunk` e ao draft PR [#156](https://github.com/oisee/vibing-steampunk/pull/156) contra o projeto original.
 
 ## Baseline reproduzível
 
@@ -107,6 +107,8 @@ Executar apenas em sandbox descartável e autorizada, nunca com dados de cliente
 
 ## Rascunhos de pull request
 
+Os cinco blocos abaixo foram preservados como unidades lógicas de revisão. Para reduzir conflito e manter as dependências entre os fixes, eles foram publicados juntos no draft PR [#156](https://github.com/oisee/vibing-steampunk/pull/156).
+
 ### PR 1 — Propagação de segurança na CLI
 
 **Título:** `fix(cli): propagate safety policy to subcommands`
@@ -137,4 +139,4 @@ Executar apenas em sandbox descartável e autorizada, nunca com dados de cliente
 
 **Resumo:** mantém CSRF/cookie stateful, move validações de pacote para antes do lock, preserva gates locais, corrige o uso de `MODIFICATION_SUPPORT` e reutiliza `corrNr` com whitelist. Relaciona-se a #88, #92, #141, #143 e #144 e às PRs #108, #120 e #125.
 
-Nenhuma PR foi criada; estes textos são somente rascunhos para revisão.
+O PR consolidado permanece em rascunho para revisão dos mantenedores. A branch publicada permite modificações por mantenedores.


### PR DESCRIPTION
## Summary

This PR fixes ten independently reproduced defect groups across CLI safety, source-write result handling, installers, ADT stateful mutation sessions, activation workflows, recording history, and Windows test portability.

### What changed

- propagate persistent safety flags and resolved safety configuration to every CLI/MCP client
- make Lua writeSource forward all supported options and return false with a diagnostic on logical failures
- require successful activation and a valid completion marker in ExecuteABAP; propagate logical failure through CLI/MCP
- verify package creation, deployment result, syntax, activation, and source read-back in installers
- keep CSRF discovery/refresh in the same stateful session as lock/write/unlock
- validate package scope before locking while continuing to enforce operation and transport policy
- preserve MODIFICATION_SUPPORT as metadata and reuse lock corrNr under the normal transport safety whitelist
- guarantee unique, time-sortable recording IDs even when the platform clock does not advance between calls
- use native temporary directories for the JavaScript oracle test on Windows
- make copy exit non-zero on failed objects, create packages only after a conclusive absence check, and skip unsupported or partial deployments before writing
- surface logical WriteSource and Activate failures as MCP tool errors
- stop deploy, table, batch, DSL, and rename workflows when activation reports success=false
- write renamed source to the source endpoint, require unlock and activation, and never delete the old object after an unsuccessful activation
- stop DeployFromFile before locking or writing when the existence probe is inconclusive

### Root causes

The defects combined incomplete configuration propagation, logical failures being treated as transport success, inconclusive existence checks being treated as absence, and loss of session/transport context between ADT mutation requests. Some orchestration paths also advanced after unsuccessful activation or advertised deployment paths that were not implemented. Recording IDs relied on wall-clock resolution alone, causing rapid recordings to overwrite one another on Windows.

### User impact

Write restrictions now apply consistently. Failed or partial writes, installations, executions, activations, copies, and renames are no longer reported as successful. Destructive rename does not touch the old object unless the replacement is written, unlocked, and activated. Stateful ADT edit flows retain their session and transport context without bypassing local safety gates.

### Related issues and PRs

Refs #88, #92, #117, #141, #143, #144.
Overlaps with the intent of #106, #108, #120, #125, and #138 while retaining operation and transport validation after the package lookup is skipped.

### Validation

- focused tests for cmd/vsp, pkg/config, pkg/scripting, pkg/adt, pkg/dsl, internal/install, and internal/mcp
- activation, rename, existence, copy, and MCP regressions passed 20 consecutive runs
- history regression group passed 50 consecutive runs
- pkg/jseval oracle comparison passes on Windows
- go vet ./...
- gofmt on every changed Go file
- golangci-lint v1.64.8 run --new-from-rev=origin/main ./...
- git diff origin/main..HEAD --check

The full go test ./... run passes for every package that does not require SQLite through CGO. The remaining failures are the existing cmd/vsp and pkg/cache SQLite tests under CGO_ENABLED=0.

All SAP-facing behavior is covered with mocks and synthetic fixtures; no live SAP system was contacted.