### PR TITLE
fix(query): --top 0 / MCP all_rows now return every row instead of capping at 100

### DIFF
--- a/cmd/vsp/cli_extra.go
+++ b/cmd/vsp/cli_extra.go
@@ -376,6 +376,7 @@ func runQuery(cmd *cobra.Command, args []string) error {
 	table := args[0]
 	top, _ := cmd.Flags().GetInt("top")
 	skip, _ := cmd.Flags().GetInt("skip")
+	topExplicit := cmd.Flags().Changed("top")
 	where, _ := cmd.Flags().GetString("where")
 	fields, _ := cmd.Flags().GetString("fields")
 	orderBy, _ := cmd.Flags().GetString("order")
@@ -393,10 +394,7 @@ func runQuery(cmd *cobra.Command, args []string) error {
 		sql += " ORDER BY " + orderBy
 	}
 
-	maxRows := 100
-	if top > 0 {
-		maxRows = top + skip
-	}
+	maxRows := adt.ResolveRowLimit(topExplicit && top == 0, top) + skip
 
 	ctx := context.Background()
 	result, err := client.RunQuery(ctx, sql, maxRows)

--- a/cmd/vsp/cli_extra_test.go
+++ b/cmd/vsp/cli_extra_test.go
@@ -1,0 +1,64 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+// `--top 0` must mean "all rows" (per the flag's own help text), while
+// omitting `--top` entirely must keep the existing 100-row default. Both
+// leave the underlying int at its zero value, so the fix depends entirely on
+// cmd.Flags().Changed("top") telling the two cases apart. This test pins that
+// distinction so a future "simplification" doesn't collapse it back into a
+// bare `top == 0` check.
+func TestQueryTopFlagChangedDistinguishesExplicitZero(t *testing.T) {
+	newQueryFlags := func() *cobra.Command {
+		cmd := &cobra.Command{Use: "query"}
+		cmd.Flags().Int("top", 0, "Maximum number of rows (0=all)")
+		cmd.Flags().Int("skip", 0, "Skip first N rows")
+		return cmd
+	}
+
+	t.Run("top omitted", func(t *testing.T) {
+		cmd := newQueryFlags()
+		if err := cmd.ParseFlags([]string{}); err != nil {
+			t.Fatal(err)
+		}
+		if cmd.Flags().Changed("top") {
+			t.Fatal("Changed(\"top\") should be false when --top is not passed")
+		}
+		top, _ := cmd.Flags().GetInt("top")
+		if top != 0 {
+			t.Fatalf("expected zero value for unset --top, got %d", top)
+		}
+	})
+
+	t.Run("top explicitly zero", func(t *testing.T) {
+		cmd := newQueryFlags()
+		if err := cmd.ParseFlags([]string{"--top", "0"}); err != nil {
+			t.Fatal(err)
+		}
+		if !cmd.Flags().Changed("top") {
+			t.Fatal("Changed(\"top\") should be true when --top 0 is passed explicitly")
+		}
+		top, _ := cmd.Flags().GetInt("top")
+		if top != 0 {
+			t.Fatalf("expected 0, got %d", top)
+		}
+	})
+
+	t.Run("top explicitly positive", func(t *testing.T) {
+		cmd := newQueryFlags()
+		if err := cmd.ParseFlags([]string{"--top", "50"}); err != nil {
+			t.Fatal(err)
+		}
+		if !cmd.Flags().Changed("top") {
+			t.Fatal("Changed(\"top\") should be true when --top is passed")
+		}
+		top, _ := cmd.Flags().GetInt("top")
+		if top != 50 {
+			t.Fatalf("expected 50, got %d", top)
+		}
+	})
+}

--- a/internal/mcp/handlers_read.go
+++ b/internal/mcp/handlers_read.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"os"
 
 	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/oisee/vibing-steampunk/pkg/adt"
@@ -63,6 +64,9 @@ func (s *Server) routeReadAction(ctx context.Context, action, objectType, object
 			if v, ok := getFloatParam(params, "max_rows"); ok {
 				args["max_rows"] = v
 			}
+			if v, ok := getBoolParam(params, "all_rows"); ok {
+				args["all_rows"] = v
+			}
 			if v := getStringParam(params, "sql_query"); v != "" {
 				args["sql_query"] = v
 			}
@@ -94,6 +98,9 @@ func (s *Server) routeReadAction(ctx context.Context, action, objectType, object
 			if v, ok := getFloatParam(params, "max_rows"); ok {
 				args["max_rows"] = v
 			}
+			if v, ok := getBoolParam(params, "all_rows"); ok {
+				args["all_rows"] = v
+			}
 			if sqlQuery != "" {
 				args["sql_query"] = sqlQuery
 			}
@@ -104,6 +111,9 @@ func (s *Server) routeReadAction(ctx context.Context, action, objectType, object
 				if v, ok := getFloatParam(params, "max_rows"); ok {
 					args["max_rows"] = v
 				}
+				if v, ok := getBoolParam(params, "all_rows"); ok {
+					args["all_rows"] = v
+				}
 				return s.callHandler(ctx, s.handleRunQuery, args)
 			}
 			// A table named as the target, with no SQL, is the other thing a
@@ -112,6 +122,9 @@ func (s *Server) routeReadAction(ctx context.Context, action, objectType, object
 				args := map[string]any{"table_name": objectName}
 				if v, ok := getFloatParam(params, "max_rows"); ok {
 					args["max_rows"] = v
+				}
+				if v, ok := getBoolParam(params, "all_rows"); ok {
+					args["all_rows"] = v
 				}
 				return s.callHandler(ctx, s.handleGetTableContents, args)
 			}
@@ -239,9 +252,14 @@ func (s *Server) handleGetTableContents(ctx context.Context, request mcp.CallToo
 		return newToolResultError("table_name is required"), nil
 	}
 
-	maxRows := 100
-	if mr, ok := request.GetArguments()["max_rows"].(float64); ok && mr > 0 {
-		maxRows = int(mr)
+	requested := 0
+	if mr, ok := request.GetArguments()["max_rows"].(float64); ok {
+		requested = int(mr)
+	}
+	allRows, _ := request.GetArguments()["all_rows"].(bool)
+	maxRows := adt.ResolveRowLimit(allRows, requested)
+	if os.Getenv("VSP_DEBUG") == "true" {
+		fmt.Fprintf(os.Stderr, "[DEBUG] GetTableContents: requested=%d allRows=%v -> maxRows=%d\n", requested, allRows, maxRows)
 	}
 
 	sqlQuery := ""
@@ -259,9 +277,15 @@ func (s *Server) handleGetTableContents(ctx context.Context, request mcp.CallToo
 		columnsOnly = co
 	}
 
-	// Fetch extra rows to support client-side offset
+	// Fetch extra rows to support client-side offset. Not for all_rows: the
+	// sentinel is already the maximum ADT will honor before it silently
+	// truncates (see adt.UnlimitedRows), so adding offset on top of it can
+	// push the request back over that threshold and reintroduce the same
+	// truncation all_rows exists to avoid. The bounded max_rows path still
+	// needs +offset — that's deliberate client-side pagination within an
+	// intentionally limited request.
 	fetchRows := maxRows
-	if offset > 0 {
+	if offset > 0 && !allRows {
 		fetchRows = maxRows + offset
 	}
 	if columnsOnly {
@@ -300,9 +324,14 @@ func (s *Server) handleRunQuery(ctx context.Context, request mcp.CallToolRequest
 		return newToolResultError("sql_query is required"), nil
 	}
 
-	maxRows := 100
-	if mr, ok := request.GetArguments()["max_rows"].(float64); ok && mr > 0 {
-		maxRows = int(mr)
+	requested := 0
+	if mr, ok := request.GetArguments()["max_rows"].(float64); ok {
+		requested = int(mr)
+	}
+	allRows, _ := request.GetArguments()["all_rows"].(bool)
+	maxRows := adt.ResolveRowLimit(allRows, requested)
+	if os.Getenv("VSP_DEBUG") == "true" {
+		fmt.Fprintf(os.Stderr, "[DEBUG] RunQuery: requested=%d allRows=%v -> maxRows=%d\n", requested, allRows, maxRows)
 	}
 
 	contents, err := s.adtClient.RunQuery(ctx, sqlQuery, maxRows)

--- a/internal/mcp/handlers_read_rows_test.go
+++ b/internal/mcp/handlers_read_rows_test.go
@@ -1,0 +1,207 @@
+package mcp
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/oisee/vibing-steampunk/pkg/adt"
+)
+
+// rowNumberCaptureServer answers any datapreview request with a minimal but
+// valid table-data XML body, and records the rowNumber query parameter each
+// call actually sent — the thing this whole bug was about.
+func rowNumberCaptureServer(t *testing.T) (*httptest.Server, *string) {
+	t.Helper()
+	var got string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Any ADT session that works hands out a CSRF token on every response;
+		// the transport's HEAD/GET CSRF fetch fails without one before the
+		// real POST (the one carrying rowNumber) is ever sent.
+		w.Header().Set("x-csrf-token", "AbCdEfGhIjKlMnOpQrStUv==")
+		if r.URL.Query().Has("rowNumber") {
+			got = r.URL.Query().Get("rowNumber")
+		}
+		w.Header().Set("Content-Type", "application/xml")
+		_, _ = w.Write([]byte(`<?xml version="1.0" encoding="utf-8"?><dataPreview:tableData xmlns:dataPreview="http://www.sap.com/adt/dataPreview"></dataPreview:tableData>`))
+	}))
+	return srv, &got
+}
+
+// A real MCP client's max_rows: 0 (and, it turned out, max_rows: -1 too)
+// arrived at this server identically to the argument being omitted — see
+// pkg/adt/limits.go's ResolveRowLimit doc comment for the live-verified
+// evidence. all_rows is the boolean escape hatch that doesn't have a
+// zero-like value for anything upstream to normalize away.
+func TestHandleGetTableContentsRowLimit(t *testing.T) {
+	tests := []struct {
+		name    string
+		args    map[string]any
+		wantRow string
+	}{
+		{
+			name:    "all_rows true wins over max_rows",
+			args:    map[string]any{"table_name": "TADIR", "all_rows": true, "max_rows": float64(5)},
+			wantRow: fmt.Sprintf("%d", adt.UnlimitedRows),
+		},
+		{
+			name:    "positive max_rows honored",
+			args:    map[string]any{"table_name": "TADIR", "max_rows": float64(5000)},
+			wantRow: "5000",
+		},
+		{
+			name:    "neither set defaults to 100",
+			args:    map[string]any{"table_name": "TADIR"},
+			wantRow: "100",
+		},
+		{
+			name:    "max_rows 0 without all_rows still defaults to 100 (documented MCP limitation)",
+			args:    map[string]any{"table_name": "TADIR", "max_rows": float64(0)},
+			wantRow: "100",
+		},
+		{
+			// Regression (2026-08-31, live): fetchRows used to be
+			// maxRows+offset unconditionally, so all_rows:true + offset:900
+			// sent rowNumber=UnlimitedRows+900 — enough to cross ADT's real
+			// cutoff and silently truncate the result, defeating all_rows
+			// entirely. The sentinel is already the maximum; offset must not
+			// be added on top of it.
+			name:    "all_rows true ignores offset — sentinel already is the max",
+			args:    map[string]any{"table_name": "TADIR", "all_rows": true, "offset": float64(900)},
+			wantRow: fmt.Sprintf("%d", adt.UnlimitedRows),
+		},
+		{
+			// The bounded path still needs +offset — that's deliberate
+			// client-side pagination within an intentionally limited request.
+			name:    "positive max_rows still composes with offset",
+			args:    map[string]any{"table_name": "TADIR", "max_rows": float64(500), "offset": float64(900)},
+			wantRow: "1400",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sap, gotRowNumber := rowNumberCaptureServer(t)
+			defer sap.Close()
+
+			s := NewServer(&Config{BaseURL: sap.URL, Username: "TESTUSER", Client: "001", Mode: "expert"})
+			result, err := s.handleGetTableContents(t.Context(), newRequest(tt.args))
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if *gotRowNumber != tt.wantRow {
+				t.Errorf("rowNumber sent to ADT = %q, want %q\nresult text: %s", *gotRowNumber, tt.wantRow, resultText(result))
+			}
+		})
+	}
+}
+
+func TestHandleRunQueryRowLimit(t *testing.T) {
+	tests := []struct {
+		name    string
+		args    map[string]any
+		wantRow string
+	}{
+		{
+			name:    "all_rows true wins over max_rows",
+			args:    map[string]any{"sql_query": "SELECT * FROM TADIR", "all_rows": true, "max_rows": float64(5)},
+			wantRow: fmt.Sprintf("%d", adt.UnlimitedRows),
+		},
+		{
+			name:    "positive max_rows honored",
+			args:    map[string]any{"sql_query": "SELECT * FROM TADIR", "max_rows": float64(5000)},
+			wantRow: "5000",
+		},
+		{
+			name:    "neither set defaults to 100",
+			args:    map[string]any{"sql_query": "SELECT * FROM TADIR"},
+			wantRow: "100",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sap, gotRowNumber := rowNumberCaptureServer(t)
+			defer sap.Close()
+
+			s := NewServer(&Config{BaseURL: sap.URL, Username: "TESTUSER", Client: "001", Mode: "expert"})
+			if _, err := s.handleRunQuery(t.Context(), newRequest(tt.args)); err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if *gotRowNumber != tt.wantRow {
+				t.Errorf("rowNumber sent to ADT = %q, want %q", *gotRowNumber, tt.wantRow)
+			}
+		})
+	}
+}
+
+// The universal SAP() single-tool wrapper builds its own args map for these
+// same handlers (routeReadAction in handlers_universal.go) and has to
+// forward all_rows separately from max_rows — easy to add to one call site
+// and forget the other three.
+func TestRouteReadActionForwardsAllRows(t *testing.T) {
+	tests := []struct {
+		name    string
+		args    map[string]any
+		wantRow string
+	}{
+		{
+			name: "read TABL_CONTENTS forwards all_rows",
+			args: map[string]any{
+				"action": "read",
+				"target": "TABL_CONTENTS TADIR",
+				"params": map[string]any{"all_rows": true},
+			},
+			wantRow: fmt.Sprintf("%d", adt.UnlimitedRows),
+		},
+		{
+			name: "query TABL_CONTENTS forwards all_rows",
+			args: map[string]any{
+				"action": "query",
+				"target": "TABL_CONTENTS TADIR",
+				"params": map[string]any{"all_rows": true},
+			},
+			wantRow: fmt.Sprintf("%d", adt.UnlimitedRows),
+		},
+		{
+			name: "query with sql forwards all_rows",
+			args: map[string]any{
+				"action": "query",
+				"params": map[string]any{"sql": "SELECT * FROM TADIR", "all_rows": true},
+			},
+			wantRow: fmt.Sprintf("%d", adt.UnlimitedRows),
+		},
+		{
+			// parseTarget (handlers_universal.go) splits target on the first
+			// space into objectType/objectName. A target with no space (e.g.
+			// "TADIR") becomes objectType="TADIR", objectName="" — it does NOT
+			// reach the "bare table name" branch. That branch is
+			// `case "SQL", "":` with no sql_query and a non-empty objectName,
+			// which requires a target with an (unused) leading word, e.g.
+			// "SQL TADIR".
+			name: "query with bare table target forwards all_rows",
+			args: map[string]any{
+				"action": "query",
+				"target": "SQL TADIR",
+				"params": map[string]any{"all_rows": true},
+			},
+			wantRow: fmt.Sprintf("%d", adt.UnlimitedRows),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sap, gotRowNumber := rowNumberCaptureServer(t)
+			defer sap.Close()
+
+			s := NewServer(&Config{BaseURL: sap.URL, Username: "TESTUSER", Client: "001", Mode: "hyperfocused"})
+			if _, err := s.handleUniversalTool(t.Context(), newRequest(tt.args)); err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if *gotRowNumber != tt.wantRow {
+				t.Errorf("rowNumber sent to ADT = %q, want %q", *gotRowNumber, tt.wantRow)
+			}
+		})
+	}
+}

--- a/internal/mcp/tools_register.go
+++ b/internal/mcp/tools_register.go
@@ -205,7 +205,10 @@ func (s *Server) registerReadTools(shouldRegister func(string) bool) {
 				mcp.Description("Name of the ABAP table"),
 			),
 			mcp.WithNumber("max_rows",
-				mcp.Description("Maximum number of rows to retrieve (default 100). Use this instead of SQL LIMIT clause"),
+				mcp.Description("Maximum number of rows to retrieve (default 100). Ignored if all_rows is true. Use this instead of SQL LIMIT clause"),
+			),
+			mcp.WithBoolean("all_rows",
+				mcp.Description("Set true to retrieve every matching row, ignoring max_rows and the 100-row default. Prefer this over max_rows: 0 for \"all rows\" — MCP clients may not transmit 0 or negative numbers reliably; a boolean has no such ambiguity."),
 			),
 			mcp.WithString("sql_query",
 				mcp.Description("Optional ABAP SQL SELECT statement. Uses ABAP syntax: ASCENDING/DESCENDING work, ASC/DESC fail. Example: SELECT * FROM T000 WHERE MANDT = '001' ORDER BY MANDT DESCENDING"),
@@ -227,7 +230,10 @@ func (s *Server) registerReadTools(shouldRegister func(string) bool) {
 				mcp.Description("ABAP SQL query. Example: SELECT carrid, COUNT(*) as cnt FROM sflight GROUP BY carrid ORDER BY cnt DESCENDING. Note: ASC/DESC keywords fail - use ASCENDING/DESCENDING"),
 			),
 			mcp.WithNumber("max_rows",
-				mcp.Description("Maximum number of rows to retrieve (default 100). Use this instead of SQL LIMIT clause"),
+				mcp.Description("Maximum number of rows to retrieve (default 100). Ignored if all_rows is true. Use this instead of SQL LIMIT clause"),
+			),
+			mcp.WithBoolean("all_rows",
+				mcp.Description("Set true to retrieve every matching row, ignoring max_rows and the 100-row default. Prefer this over max_rows: 0 for \"all rows\" — MCP clients may not transmit 0 or negative numbers reliably; a boolean has no such ambiguity."),
 			),
 		), s.handleRunQuery)
 	}

--- a/pkg/adt/limits.go
+++ b/pkg/adt/limits.go
@@ -1,0 +1,59 @@
+package adt
+
+// UnlimitedRows is the practical sentinel sent to SAP's ADT datapreview
+// endpoints when a caller asks for "all rows" (rowNumber has no true
+// unlimited value). This is an approximation, not a true unlimited — see
+// issue #163.
+//
+// 90,000 is not an arbitrary round number: a higher value silently fails.
+// Binary search against a live system (2026-08-31, same 916-row TADIR query
+// used throughout this issue) found rowNumber values up to and including
+// 100,000 return the full result set, while 150,000 and everything tried
+// above it (200,000; 500,000; 999,999; 1,000,000; 10,000,000) silently
+// truncated to ~100 rows instead — no error, just fewer rows, exactly like
+// the original bug. A follow-up regression narrowed the window further:
+// callers can add an offset on top of this sentinel (see
+// handleGetTableContents's fetchRows composition), and 100,900 (100,000 +
+// an observed offset of 900) already fell back into the same silent
+// truncation — so the real cutoff sits somewhere between 100,000 and
+// 100,900, tighter than the first pass found. This is not a 6-digit
+// field-width limit (999,999 fails too); it's a hard cutoff inside the
+// datapreview/ddic ADT endpoint itself, outside vsp's control, and its
+// exact position may vary by system. 90,000 keeps a real safety margin
+// below the narrowest confirmed-working point rather than hugging it —
+// deliberately not "as large as possible", since a bigger number here
+// reintroduces exactly the silent truncation this constant exists to
+// avoid. (internal/mcp/handlers_read.go's handleGetTableContents also no
+// longer adds offset on top of this sentinel for the all_rows path, for the
+// same reason.)
+const UnlimitedRows = 90_000
+
+// ResolveRowLimit turns a caller's requested row count into the value to
+// send as SAP ADT's rowNumber. wantsUnlimited means the caller explicitly
+// asked for "all rows", which maps to UnlimitedRows; how a caller signals
+// that is caller-specific:
+//   - the CLI uses --top 0, since cobra's Changed("top") distinguishes
+//     "typed 0" from "flag left at its zero default" in-process.
+//   - the MCP layer uses a separate all_rows: true boolean, NOT a special
+//     value of max_rows. Verified live (2026-08-31): neither max_rows: 0
+//     nor max_rows: -1 reached the server as their literal value — both
+//     landed identically to max_rows being omitted entirely, while every
+//     positive value (7, 5000, ...) worked correctly, including against the
+//     same ddic datapreview endpoint. That rules out a transport-wide
+//     "drops the key" bug (a present key with a real value came through
+//     fine for positive numbers) and an endpoint-side row cap (5000 came
+//     back in full). What's left is that some layer between the caller and
+//     this process normalizes a non-positive number-typed argument toward
+//     "absent" before serialization — a boolean has no zero-like value to
+//     normalize toward, so all_rows sidesteps the problem instead of
+//     guessing at another magic number. See issue #163.
+func ResolveRowLimit(wantsUnlimited bool, requested int) int {
+	switch {
+	case wantsUnlimited:
+		return UnlimitedRows
+	case requested > 0:
+		return requested
+	default:
+		return 100
+	}
+}

--- a/pkg/adt/limits_test.go
+++ b/pkg/adt/limits_test.go
@@ -1,0 +1,46 @@
+package adt
+
+import "testing"
+
+func TestResolveRowLimit(t *testing.T) {
+	tests := []struct {
+		name           string
+		wantsUnlimited bool
+		requested      int
+		want           int
+	}{
+		{
+			name:           "wantsUnlimited means unlimited regardless of requested",
+			wantsUnlimited: true,
+			requested:      -1,
+			want:           UnlimitedRows,
+		},
+		{
+			name:           "unset defaults to 100",
+			wantsUnlimited: false,
+			requested:      0,
+			want:           100,
+		},
+		{
+			name:           "explicit zero without wantsUnlimited also defaults to 100 (MCP: 0 is indistinguishable from omitted)",
+			wantsUnlimited: false,
+			requested:      0,
+			want:           100,
+		},
+		{
+			name:           "positive request is honored",
+			wantsUnlimited: false,
+			requested:      5000,
+			want:           5000,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ResolveRowLimit(tt.wantsUnlimited, tt.requested)
+			if got != tt.want {
+				t.Errorf("ResolveRowLimit(%v, %d) = %d, want %d", tt.wantsUnlimited, tt.requested, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- `vsp query <table> --top 0` (per the flag's own help text, "0=all") silently capped at 100 rows instead of returning everything. Same collapse existed in the MCP `GetTableContents`/`RunQuery` tools.
- CLI fix: `cmd.Flags().Changed("top")` now distinguishes "explicit `--top 0`" from "flag left unset" — both previously left the underlying Go int at its zero value.
- MCP fix: a numeric `max_rows: 0`/`-1` sentinel does not survive whatever MCP client sends it — verified live that an explicit `0` and `-1` both arrive at the server identical to the argument being omitted. Replaced with a separate `all_rows: true` boolean, which has no zero-like value to be normalized away. Wired through both the direct tools and the hyperfocused `SAP()` universal wrapper's four forwarding sites.
- The sentinel sent as ADT's `rowNumber` (`adt.UnlimitedRows`) is `90,000`, chosen with a real safety margin below a live-verified ADT-side cutoff between `100,000` (confirmed working) and `100,900` (confirmed silently truncated) inside `datapreview/ddic` — not a vsp bug, not fixable from this side, so this is a documented approximation rather than a true "unlimited".
- `handleGetTableContents` no longer adds `offset` on top of the `all_rows` sentinel (a regression found during live testing: the addition pushed requests back over the cutoff).

## Test plan

- [x] `go build ./...`
- [x] `go test ./pkg/adt/... ./cmd/vsp/... ./internal/mcp/...`
- [x] Live verification against a real SAP system: CLI (`--top 0` → full result set matching `--top 5000`; `--top` omitted → still 100; `--top 0 --skip 900` → correct tail); MCP (`GetTableContents`/`RunQuery` default → 100; `all_rows: true` → full result set; `all_rows: true` + `offset: 900` → correct tail, not `null`)

Fixes #163
