### PR TITLE
fix(adt): a lock handle dies of the request nobody flagged (#91)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,11 +27,30 @@ This section understated the package for four months; corrected 2026-08-24.
 Plan: MCP debug sessions → DAP → Web UI. ADT REST API mapped from `CL_TPDA_ADT_RES_APP`. Design: [001](reports/2026-04-05-001-gui-debugger-design.md)
 
 ### 3. Open Issues
-- ~~**#88** Lock handle bug~~ — closed 2026-04-15 by `22517d4` (Stateful +
-  ModificationSupport guard), together with #91, #92, #98. Left here in struck
-  form because this list said "open" for four months after the fix.
-- **#55** RunReport in APC — architectural limit
-- **#46, #45** Sync script — low effort
+- **#91** The 423 lock-handle class — the live one, and this entry was wrong
+  twice. `22517d4` did not close it: a third-party release bisect names that
+  commit as the start of a regression, and its `ModificationSupport` guard was
+  itself removed by `9b98997`. #88, #92, #98, #110 are closed as duplicates of
+  #91 (2026-09-01); #132 stays open for its transport-reuse leg.
+  Cause: `SessionType` defaults to stateless (`config.go:198`, `d84db03`) and
+  `http.go:502` stamps every unflagged request `stateless`, so any hop between
+  LOCK and the write retires the ICM context and kills the handle. The fix on
+  `fix/91-session-affinity` closes the package-lookup hop, the CSRF probe, and
+  two mutations that were themselves stateless. Still open after it: the
+  keep-alive ticker (on by default, 5m) and the MCP cross-tool-call window.
+- **#166** A failed mutation strands the SAP-side ENQUEUE — split out of #92
+  so it survives that closure. Users clear these by hand in SM12.
+- **#55** RunReport in APC — *not* an architectural limit, which this line
+  claimed for months. `34eb727` ("$ZADT_VSP sync", 2026-02-06) replaced a
+  working XBP background-job + spool implementation in
+  `src/zcl_vsp_report_service.clas.abap` with a bare `SUBMIT ... AND RETURN`,
+  deleting the `getJobStatus`/`getSpoolOutput` actions the Go client still
+  speaks. It is a regression with a known good parent commit. #113 was the
+  same defect and is closed against this one.
+- ~~**#46, #45** Sync script~~ — closed 2026-09-01. `scripts/sync-upstream.sh`
+  has never existed here (`git log --all --diff-filter=A` finds it in none of
+  the 913 commits); both issues were filed from a downstream fork's workflow.
+  This line advertised work that was not ours to do.
 
 ---
 

--- a/internal/mcp/handlers_deploy.go
+++ b/internal/mcp/handlers_deploy.go
@@ -227,8 +227,21 @@ func (s *Server) handleDeployZip(ctx context.Context, request mcp.CallToolReques
 
 		fmt.Fprintf(&sb, "  [%d/%d] Upload %s %s... ", i+1, len(deployable), obj.Type, obj.Name)
 
+		// Run UpdateSource's own gate here, before the lock. Called from
+		// inside the lock window it resolves the object's package over the
+		// wire — a stateless request that retires the session the lock handle
+		// belongs to, so the upload comes back 423 (issue #91). The returned
+		// context carries the result of that check for this object only.
+		objCtx, err := s.adtClient.PrepareSourceUpdate(ctx, objectURL, "")
+		if err != nil {
+			fmt.Fprintf(&sb, "BLOCKED: %v\n", err)
+			uploadFailed++
+			uploadFailures = append(uploadFailures, fmt.Sprintf("%s %s: %v", obj.Type, obj.Name, err))
+			continue
+		}
+
 		// Lock
-		lockResult, err := s.adtClient.LockObject(ctx, objectURL, "MODIFY")
+		lockResult, err := s.adtClient.LockObject(objCtx, objectURL, "MODIFY")
 		if err != nil {
 			fmt.Fprintf(&sb, "LOCK FAIL: %v\n", err)
 			uploadFailed++
@@ -237,21 +250,29 @@ func (s *Server) handleDeployZip(ctx context.Context, request mcp.CallToolReques
 		}
 
 		// Upload source (no syntax check!)
-		err = s.adtClient.UpdateSource(ctx, sourceURL, obj.MainSource, lockResult.LockHandle, "")
+		err = s.adtClient.UpdateSource(objCtx, sourceURL, obj.MainSource, lockResult.LockHandle, "")
 		if err != nil {
 			// Always try to unlock even if upload fails
-			_ = s.adtClient.UnlockObject(ctx, objectURL, lockResult.LockHandle)
+			unlockErr := s.adtClient.UnlockObject(objCtx, objectURL, lockResult.LockHandle)
 			fmt.Fprintf(&sb, "UPLOAD FAIL: %v\n", err)
 			uploadFailed++
 			uploadFailures = append(uploadFailures, fmt.Sprintf("%s %s: upload failed: %v", obj.Type, obj.Name, err))
+			if unlockErr != nil {
+				uploadFailures = append(uploadFailures,
+					fmt.Sprintf("%s %s: LEFT LOCKED — unlock also failed: %v (clear it in SM12, or wait for the ADT session timeout)", obj.Type, obj.Name, unlockErr))
+			}
 			continue
 		}
 
 		// Unlock
-		err = s.adtClient.UnlockObject(ctx, objectURL, lockResult.LockHandle)
+		err = s.adtClient.UnlockObject(objCtx, objectURL, lockResult.LockHandle)
 		if err != nil {
+			// Not fatal for the source, which is written — but the object is
+			// left locked, so it is fatal for the next person to touch it and
+			// must not be swallowed into the summary as a success.
 			fmt.Fprintf(&sb, "UNLOCK FAIL: %v\n", err)
-			// Source was uploaded, just couldn't unlock - not fatal
+			uploadFailures = append(uploadFailures,
+				fmt.Sprintf("%s %s: source uploaded but LEFT LOCKED: %v (clear it in SM12, or wait for the ADT session timeout)", obj.Type, obj.Name, err))
 		}
 
 		fmt.Fprintf(&sb, "ok\n")

--- a/pkg/adt/crud.go
+++ b/pkg/adt/crud.go
@@ -1213,11 +1213,8 @@ type CreateTableOptions struct {
 // CreateTable creates a new DDIC transparent table from JSON-like options.
 // This is a high-level tool that handles the full workflow: create → set source → activate.
 func (c *Client) CreateTable(ctx context.Context, opts CreateTableOptions) error {
-	if err := c.checkSafety(OpCreate, "CreateTable"); err != nil {
-		return err
-	}
-
-	// Validate input
+	// Validate input first: the package default below is part of what the gate
+	// has to see.
 	opts.Name = strings.ToUpper(opts.Name)
 	if opts.Name == "" || len(opts.Name) > 30 {
 		return fmt.Errorf("table name must be 1-30 characters")
@@ -1233,6 +1230,19 @@ func (c *Client) CreateTable(ctx context.Context, opts CreateTableOptions) error
 	}
 	if opts.TableCategory == "" {
 		opts.TableCategory = "TRANSPARENT"
+	}
+
+	// Full mutation gate, not just the op-type half. CreateTable used to run
+	// checkSafety alone, so it created tables in any package the user could
+	// reach — SAP_ALLOWED_PACKAGES did not apply to it at all, and the source
+	// PUT below carried no gate either.
+	if err := c.checkMutation(ctx, MutationContext{
+		Op:        OpCreate,
+		OpName:    "CreateTable",
+		Package:   opts.Package,
+		Transport: opts.Transport,
+	}); err != nil {
+		return err
 	}
 
 	// Generate DDL source
@@ -1268,30 +1278,33 @@ func (c *Client) CreateTable(ctx context.Context, opts CreateTableOptions) error
 	tableURL := fmt.Sprintf("/sap/bc/adt/ddic/tables/%s", strings.ToLower(opts.Name))
 	sourceURL := tableURL + "/source/main"
 
+	// The table was just created in opts.Package, which the gate above
+	// accepted, so UpdateSource does not have to resolve it again from inside
+	// the lock (issue #91).
+	ctx = withMutationPackageChecked(ctx, tableURL)
+
 	lock, err := c.LockObject(ctx, tableURL, "MODIFY")
 	if err != nil {
 		return fmt.Errorf("locking table: %w", err)
 	}
 
-	params = url.Values{}
-	params.Set("lockHandle", lock.LockHandle)
-	if opts.Transport != "" {
-		params.Set("corrNr", opts.Transport)
-	}
-
-	_, err = c.transport.Request(ctx, sourceURL, &RequestOptions{
-		Method:      http.MethodPut,
-		Query:       params,
-		Body:        []byte(ddlSource),
-		ContentType: "text/plain",
-	})
-	if err != nil {
-		c.UnlockObject(ctx, tableURL, lock.LockHandle)
+	// This used to be a hand-rolled transport.Request with no Stateful field,
+	// which meant the PUT that consumes the lock handle went out explicitly
+	// stateless — it retired the very session the handle was issued in, and
+	// creating a table failed with 423 InvalidLockHandle on every attempt, on
+	// any configuration. UpdateSource is the same request with Stateful: true
+	// and the mutation gate attached.
+	if err := c.UpdateSource(ctx, sourceURL, ddlSource, lock.LockHandle, opts.Transport); err != nil {
+		if unlockErr := c.releaseLockAfterFailure(ctx, tableURL, lock.LockHandle); unlockErr != nil {
+			return fmt.Errorf("updating table source: %w — %s", err, strandedLockAdvice(tableURL, unlockErr))
+		}
 		return fmt.Errorf("updating table source: %w", err)
 	}
 
 	// Unlock BEFORE activation
-	c.UnlockObject(ctx, tableURL, lock.LockHandle)
+	if err := c.UnlockObject(ctx, tableURL, lock.LockHandle); err != nil {
+		return fmt.Errorf("unlocking table before activation: %w — %s", err, strandedLockAdvice(tableURL, err))
+	}
 
 	// Step 3: Activate
 	activation, err := c.Activate(ctx, tableURL, opts.Name)

--- a/pkg/adt/functions_write.go
+++ b/pkg/adt/functions_write.go
@@ -92,12 +92,15 @@ func (c *Client) WriteFunctionModule(ctx context.Context, groupName, functionNam
 	}
 	objectURL := GetObjectURL(ObjectTypeFunctionMod, functionName, group)
 
-	if err := c.checkMutation(ctx, MutationContext{
+	// Marking here means writeFunctionModule's own gate — which sits above its
+	// lock — resolves nothing a second time (issue #91).
+	ctx, err = c.gateAndMark(ctx, MutationContext{
 		Op:        OpWorkflow,
 		OpName:    "WriteFunctionModule",
 		ObjectURL: objectURL,
 		Transport: transport,
-	}); err != nil {
+	})
+	if err != nil {
 		return nil, err
 	}
 

--- a/pkg/adt/http.go
+++ b/pkg/adt/http.go
@@ -129,8 +129,9 @@ func (t *Transport) Request(ctx context.Context, path string, opts *RequestOptio
 	if isModifyingMethod(opts.Method) {
 		token := t.getCSRFToken()
 		if token == "" {
-			// Fetch CSRF token first
-			if err := t.fetchCSRFToken(ctx); err != nil {
+			// Fetch CSRF token first, on the same kind of session the request
+			// itself will use (issue #91).
+			if err := t.fetchCSRFTokenFor(ctx, opts.Stateful); err != nil {
 				return nil, fmt.Errorf("fetching CSRF token: %w", err)
 			}
 			token = t.getCSRFToken()
@@ -172,8 +173,11 @@ func (t *Transport) Request(ctx context.Context, path string, opts *RequestOptio
 
 	// Handle CSRF token refresh on 403
 	if resp.StatusCode == http.StatusForbidden && isModifyingMethod(opts.Method) {
-		// Try to refresh CSRF token and retry once
-		if err := t.fetchCSRFToken(ctx); err != nil {
+		// Try to refresh CSRF token and retry once. The refresh has to stay on
+		// the request's own session kind: for a stateful write it lands between
+		// the failed attempt and the retry, and an unmarked probe there retires
+		// the session the lock handle belongs to (issue #91).
+		if err := t.fetchCSRFTokenFor(ctx, opts.Stateful); err != nil {
 			return nil, fmt.Errorf("refreshing CSRF token: %w", err)
 		}
 
@@ -205,7 +209,7 @@ func (t *Transport) Request(ctx context.Context, path string, opts *RequestOptio
 			t.setCSRFToken("")
 			t.setSessionID("")
 			// Fetch new CSRF token (this establishes a new session)
-			if err := t.fetchCSRFToken(ctx); err != nil {
+			if err := t.fetchCSRFTokenFor(ctx, opts.Stateful); err != nil {
 				return nil, fmt.Errorf("refreshing session after timeout: %w", err)
 			}
 			// Retry the request
@@ -226,7 +230,7 @@ func (t *Transport) Request(ctx context.Context, path string, opts *RequestOptio
 				}
 			} else {
 				// Basic auth: just refresh CSRF token.
-				if err := t.fetchCSRFToken(ctx); err != nil {
+				if err := t.fetchCSRFTokenFor(ctx, opts.Stateful); err != nil {
 					return nil, fmt.Errorf("re-authenticating after 401 on %s: %w (original error: %v)", path, err, apiErr)
 				}
 			}
@@ -312,7 +316,21 @@ func (t *Transport) retryRequest(ctx context.Context, path string, opts *Request
 // exists to prevent. Let GET have its turn; if it is also forbidden, the error
 // below says so.
 func (t *Transport) fetchCSRFToken(ctx context.Context) error {
-	return t.fetchCSRFTokenWithReauth(ctx, true)
+	return t.fetchCSRFTokenFor(ctx, false)
+}
+
+// fetchCSRFTokenFor fetches a token on behalf of a request whose statefulness
+// is known.
+//
+// A token fetch triggered from inside Request — no cached token, a 403 refresh,
+// a session-expiry retry — lands in the middle of whatever that request is
+// doing. If that request is the write that consumes a lock handle, a probe sent
+// without the stateful marker is answered on a different ADT context and the
+// stateful one is retired: the retry then presents a handle whose session has
+// just been thrown away (issue #91). So the probe inherits the in-flight
+// request's statefulness rather than only the client-wide default.
+func (t *Transport) fetchCSRFTokenFor(ctx context.Context, stateful bool) error {
+	return t.fetchCSRFTokenWithReauth(ctx, true, stateful)
 }
 
 // fetchCSRFTokenWithReauth fetches a token, optionally recovering an expired
@@ -320,8 +338,8 @@ func (t *Transport) fetchCSRFToken(ctx context.Context) error {
 //
 // allowReauth exists to break a cycle: re-authenticating ends with a token
 // fetch of its own, and that fetch must not start another re-authentication.
-func (t *Transport) fetchCSRFTokenWithReauth(ctx context.Context, allowReauth bool) error {
-	token, status, redirected, err := t.probeCSRFToken(ctx, http.MethodHead)
+func (t *Transport) fetchCSRFTokenWithReauth(ctx context.Context, allowReauth bool, stateful bool) error {
+	token, status, redirected, err := t.probeCSRFToken(ctx, http.MethodHead, stateful)
 	if err != nil {
 		return err
 	}
@@ -331,7 +349,7 @@ func (t *Transport) fetchCSRFTokenWithReauth(ctx context.Context, allowReauth bo
 		}
 		var getStatus int
 		var getRedirected bool
-		token, getStatus, getRedirected, err = t.probeCSRFToken(ctx, http.MethodGet)
+		token, getStatus, getRedirected, err = t.probeCSRFToken(ctx, http.MethodGet, stateful)
 		if err != nil {
 			return err
 		}
@@ -357,7 +375,7 @@ func (t *Transport) fetchCSRFTokenWithReauth(ctx context.Context, allowReauth bo
 				if isCSRFToken(t.getCSRFToken()) {
 					return nil
 				}
-				return t.fetchCSRFTokenWithReauth(ctx, false)
+				return t.fetchCSRFTokenWithReauth(ctx, false, stateful)
 			}
 			switch getStatus {
 			case http.StatusUnauthorized:
@@ -377,7 +395,7 @@ func (t *Transport) fetchCSRFTokenWithReauth(ctx context.Context, allowReauth bo
 // probeCSRFToken asks /core/discovery for a token with the given method and
 // returns the token (empty when the server did not supply one), the status, and
 // whether the answer came from somewhere other than the SAP host.
-func (t *Transport) probeCSRFToken(ctx context.Context, method string) (token string, status int, redirected bool, err error) {
+func (t *Transport) probeCSRFToken(ctx context.Context, method string, stateful bool) (token string, status int, redirected bool, err error) {
 	reqURL, err := t.buildURL("/sap/bc/adt/core/discovery", nil)
 	if err != nil {
 		return "", 0, false, fmt.Errorf("building URL: %w", err)
@@ -393,7 +411,11 @@ func (t *Transport) probeCSRFToken(ctx context.Context, method string) (token st
 	t.addCookies(req)
 	req.Header.Set("X-CSRF-Token", "fetch")
 	req.Header.Set("Accept", "*/*")
-	if t.config.SessionType == SessionStateful {
+	// Only ever *add* the stateful marker; never stamp an explicit "stateless"
+	// here. The keep-alive ping goes through this same probe (Ping ->
+	// fetchCSRFToken), and an explicitly stateless keep-alive would retire the
+	// session on a timer — the very failure this is guarding against.
+	if stateful || t.config.SessionType == SessionStateful {
 		req.Header.Set("X-sap-adt-sessiontype", "stateful")
 	}
 
@@ -668,7 +690,9 @@ func (t *Transport) callReauthFunc(ctx context.Context) error {
 	// Fetch CSRF token with the new cookies.
 	// Set lastReauth only after CSRF succeeds — if it fails, the next
 	// goroutine should retry rather than hitting the cooldown skip.
-	if err := t.fetchCSRFTokenWithReauth(reauthCtx, false); err != nil {
+	// Re-auth establishes a brand-new session; there is no lock window to
+	// preserve across it, so this stays on the client-wide default.
+	if err := t.fetchCSRFTokenWithReauth(reauthCtx, false, false); err != nil {
 		return err
 	}
 	t.lastReauth = time.Now()

--- a/pkg/adt/i18n.go
+++ b/pkg/adt/i18n.go
@@ -209,6 +209,11 @@ func (c *Client) WriteMessageClassTexts(ctx context.Context, name, lang string, 
 		Body:             body,
 		ContentType:      "application/vnd.sap.adt.mc.messageclass+xml",
 		OverrideLanguage: lang,
+		// The lockHandle in the query above came from a stateful LOCK and is
+		// bound to that session. Without this the PUT that consumes it went out
+		// explicitly stateless and could never match its own lock — the same
+		// defect as CreateTable's source PUT (issue #91).
+		Stateful: true,
 	})
 	if err != nil {
 		return fmt.Errorf("write message class texts: %w", err)

--- a/pkg/adt/lock_release.go
+++ b/pkg/adt/lock_release.go
@@ -1,0 +1,64 @@
+package adt
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+)
+
+// unlockAfterFailureTimeout bounds the compensating UNLOCK. It runs on a
+// context detached from the caller's, so it needs a deadline of its own.
+const unlockAfterFailureTimeout = 30 * time.Second
+
+// releaseLockAfterFailure releases a lock taken for a mutation that has since
+// failed.
+//
+// It differs from UnlockObject in one way that matters: it runs on a context
+// detached from the caller's cancellation. Every compensating unlock in this
+// package used to reuse the enclosing ctx, so when the mutation failed
+// *because* the context was cancelled or hit its deadline — an MCP client
+// timeout, a Ctrl-C, an HTTP deadline — the unlock never left the process. It
+// failed at http.NewRequestWithContext before a byte was sent, and the ENQUEUE
+// it was meant to release stayed on the object. A timeout inside a lock window
+// was a guaranteed leak.
+//
+// The returned error is the caller's only evidence that an object was left
+// locked; do not discard it. strandedLockAdvice turns it into something a user
+// can act on.
+func (c *Client) releaseLockAfterFailure(ctx context.Context, objectURL, lockHandle string) error {
+	if lockHandle == "" {
+		return nil
+	}
+
+	releaseCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), unlockAfterFailureTimeout)
+	defer cancel()
+
+	return c.UnlockObject(releaseCtx, objectURL, lockHandle)
+}
+
+// strandedLockAdvice explains an unlock that failed, in the terms a user needs
+// to act on it.
+//
+// The failure mode this exists for is issue #91: the mutation returned 423
+// because the stateful ADT session that issued the lock handle was retired, and
+// UNLOCK cannot work either, because `_action=UNLOCK` addresses the ENQUEUE
+// only through that handle and that session. The lock is real, it belongs to
+// the user's own session, no vsp command can clear it, and the next edit will
+// fail with SAP's "is currently editing" message naming the user themselves —
+// which reads exactly like a colleague holding the object. Every one of those
+// facts has to be in the message or the user is left where the issue reporters
+// were: at SM12, guessing.
+func strandedLockAdvice(objectURL string, unlockErr error) string {
+	object := strings.TrimPrefix(objectURL, "/sap/bc/adt/")
+
+	return fmt.Sprintf(
+		"%s was left LOCKED: releasing the lock failed (%v). "+
+			"The lock is held by your own user, not a colleague. "+
+			"If the write failed with 423/invalid lock handle, vsp cannot release it — "+
+			"UNLOCK needs both the handle and the ADT session that issued it, and that session is gone. "+
+			"It clears by itself when SAP reaps the abandoned session (ADT session timeout, typically ~60 min), "+
+			"or immediately in SM12: filter on your user and the object, and delete the entry. "+
+			"Until then the next edit will fail with \"is currently editing\" naming you.",
+		object, unlockErr)
+}

--- a/pkg/adt/mutation_gate.go
+++ b/pkg/adt/mutation_gate.go
@@ -76,9 +76,30 @@ func (c *Client) checkMutation(ctx context.Context, m MutationContext) error {
 		return err
 	}
 
-	// 2. Package ownership check
-	if err := c.checkMutationPackage(ctx, m); err != nil {
-		return err
+	// 2. Package ownership check.
+	//
+	// This is the only step that makes a network request, and inside a lock
+	// window that request is fatal: it goes out explicitly stateless, which
+	// retires the ADT session the lock handle is bound to, and the write that
+	// follows returns 423 ExceptionResourceInvalidLockHandle (issue #91).
+	// An outer workflow that already resolved and approved *this* object's
+	// package marks the context so the lookup is not repeated under the lock.
+	//
+	// The skip is deliberately narrow:
+	//   - it never applies when the caller supplied an explicit Package —
+	//     checkPackageSafety is free and stays;
+	//   - it never applies off the ADT surface, so the SurfaceUI5 fail-closed
+	//     cannot be marked away;
+	//   - it covers step 2 only. Steps 1 and 3 issue no request, so skipping
+	//     them would buy nothing and cost --read-only / --disallowed-ops /
+	//     --allow-transportable-edits enforcement on the inner mutator.
+	skipPackageLookup := m.Surface == SurfaceADT &&
+		m.Package == "" &&
+		mutationPackageAlreadyChecked(ctx, m.ObjectURL)
+	if !skipPackageLookup {
+		if err := c.checkMutationPackage(ctx, m); err != nil {
+			return err
+		}
 	}
 
 	// 3. Transportable-edit check

--- a/pkg/adt/mutation_gate_marker.go
+++ b/pkg/adt/mutation_gate_marker.go
@@ -1,0 +1,102 @@
+package adt
+
+import "context"
+
+// --- Per-object package-check marker (issue #91) ---
+//
+// Of the three steps in checkMutation only step 2 — the package ownership
+// check — ever leaves the process: for an existing object it resolves the
+// package through SearchObject, an explicitly *stateless* ADT request.
+//
+// A lock handle from `?_action=LOCK` is bound to the stateful ADT session it
+// was issued in. A stateless request retires that session server-side, so a
+// package lookup performed between the LOCK and the write that consumes the
+// handle kills the handle, and the write comes back
+// 423 ExceptionResourceInvalidLockHandle.
+//
+// Outer workflows that have already resolved and approved the package of a
+// specific object mark the context. checkMutation then skips *only* the
+// networked lookup, and *only* for that object. Steps 1 and 3 (operation type
+// and transportable-edit policy) are pure config predicates that issue no
+// request, so they always run — skipping them, as PR #125 did, would turn a
+// session fix into a --read-only / --disallowed-ops /
+// --allow-transportable-edits bypass.
+
+// mutationPackageCheckedKey is the context key under which the set of
+// already-approved object keys is carried.
+type mutationPackageCheckedKey struct{}
+
+// mutationPackageKey is the canonical identity used to match a marked object
+// against the object an inner mutator is about to touch. It is the same
+// normalisation getObjectPackage resolves against, so a class, its
+// /source/main and its /includes/<part> all collapse to one key — which is
+// correct, because ADT resolves the package of an include from its parent.
+func mutationPackageKey(objectURL string) string {
+	if objectURL == "" {
+		return ""
+	}
+	return canonicalizeObjectURL(objectURL)
+}
+
+// withMutationPackageChecked records that objectURL's package has been
+// resolved and accepted by the configured whitelist in this call. The mark is
+// per-object on purpose: a blanket "the gate ran" flag would let a workflow
+// that checked object A delegate an unchecked mutation of object B.
+func withMutationPackageChecked(ctx context.Context, objectURL string) context.Context {
+	key := mutationPackageKey(objectURL)
+	if key == "" {
+		return ctx
+	}
+
+	prev, _ := ctx.Value(mutationPackageCheckedKey{}).(map[string]struct{})
+	if _, ok := prev[key]; ok {
+		return ctx
+	}
+
+	// Copy rather than mutate: the parent context may be shared with a
+	// sibling goroutine, and a marker must never travel upwards.
+	next := make(map[string]struct{}, len(prev)+1)
+	for k := range prev {
+		next[k] = struct{}{}
+	}
+	next[key] = struct{}{}
+	return context.WithValue(ctx, mutationPackageCheckedKey{}, next)
+}
+
+// mutationPackageAlreadyChecked reports whether this exact object was marked
+// by an outer gate in the same call.
+func mutationPackageAlreadyChecked(ctx context.Context, objectURL string) bool {
+	key := mutationPackageKey(objectURL)
+	if key == "" {
+		return false
+	}
+	marked, _ := ctx.Value(mutationPackageCheckedKey{}).(map[string]struct{})
+	_, ok := marked[key]
+	return ok
+}
+
+// gateAndMark runs the full mutation gate for m and, on success, returns a
+// context in which the networked package lookup for m.ObjectURL will not be
+// repeated. Call it *above* the LOCK; pass the returned context to everything
+// inside the lock window.
+func (c *Client) gateAndMark(ctx context.Context, m MutationContext) (context.Context, error) {
+	if err := c.checkMutation(ctx, m); err != nil {
+		return ctx, err
+	}
+	return withMutationPackageChecked(ctx, m.ObjectURL), nil
+}
+
+// PrepareSourceUpdate is the exported form of gateAndMark, for callers outside
+// this package (the MCP deploy handlers) that drive LOCK -> UpdateSource ->
+// UNLOCK by hand. It runs the same gate UpdateSource itself would run, before
+// the lock is taken, and returns a context that lets the write under the lock
+// skip the redundant — and session-fatal — package lookup. The returned
+// context must be used for the whole lock window.
+func (c *Client) PrepareSourceUpdate(ctx context.Context, objectURL, transport string) (context.Context, error) {
+	return c.gateAndMark(ctx, MutationContext{
+		Op:        OpUpdate,
+		OpName:    "UpdateSource",
+		ObjectURL: objectURL,
+		Transport: transport,
+	})
+}

--- a/pkg/adt/session_affinity_test.go
+++ b/pkg/adt/session_affinity_test.go
@@ -1,0 +1,705 @@
+package adt
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"sync"
+	"testing"
+)
+
+// --- Session-affinity harness (issue #91) ---
+//
+// The existing helpers in crud_reconcile_test.go answer "was this one request
+// stateful?". This bug is about a *window*: every request between the LOCK and
+// the write that consumes the handle has to stay on the same ADT session, and
+// methodPathMock cannot tell a LOCK POST from an UNLOCK POST because it does
+// not look at the query string. So these tests drive a real httptest server and
+// record method, path, query and X-sap-adt-sessiontype in request order.
+
+// wireCall is one outbound request as the server saw it.
+type wireCall struct {
+	method      string
+	path        string
+	query       url.Values
+	sessionType string
+}
+
+func (c wireCall) String() string {
+	return fmt.Sprintf("%-6s %s?%s sessiontype=%q", c.method, c.path, c.query.Encode(), c.sessionType)
+}
+
+// adtRecorder wraps an httptest handler and records what reached it.
+type adtRecorder struct {
+	mu    sync.Mutex
+	calls []wireCall
+}
+
+func (r *adtRecorder) handler(route http.HandlerFunc) http.HandlerFunc {
+	return func(w http.ResponseWriter, req *http.Request) {
+		r.mu.Lock()
+		r.calls = append(r.calls, wireCall{
+			method:      req.Method,
+			path:        req.URL.Path,
+			query:       req.URL.Query(),
+			sessionType: req.Header.Get("X-sap-adt-sessiontype"),
+		})
+		r.mu.Unlock()
+
+		// Every ADT reply carries a token, so the CSRF probe stays out of the
+		// trace unless a test deliberately provokes it.
+		w.Header().Set("X-CSRF-Token", "TOKEN")
+		route(w, req)
+	}
+}
+
+func (r *adtRecorder) snapshot() []wireCall {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	out := make([]wireCall, len(r.calls))
+	copy(out, r.calls)
+	return out
+}
+
+// dump prints the whole trace; every failure in this file wants it.
+func dumpCalls(t *testing.T, calls []wireCall) {
+	t.Helper()
+	for i, c := range calls {
+		t.Logf("  [%d] %s", i, c)
+	}
+}
+
+func indexOfCall(calls []wireCall, pred func(wireCall) bool) int {
+	for i, c := range calls {
+		if pred(c) {
+			return i
+		}
+	}
+	return -1
+}
+
+func isLock(c wireCall) bool {
+	return c.method == http.MethodPost && c.query.Get("_action") == "LOCK"
+}
+
+func isUnlock(c wireCall) bool {
+	return c.method == http.MethodPost && c.query.Get("_action") == "UNLOCK"
+}
+
+func isSourcePut(c wireCall) bool {
+	return c.method == http.MethodPut && strings.HasSuffix(c.path, "/source/main")
+}
+
+// assertWindowStateful is the assertion this whole bug reduces to: nothing
+// between the LOCK and the request that consumes its handle may leave the
+// stateful session.
+//
+// It is written as `!= "stateful"` rather than `== "stateless"` on purpose —
+// probeCSRFToken builds its request by hand and used to send no
+// X-sap-adt-sessiontype at all, which ICM treats as stateless just the same.
+func assertWindowStateful(t *testing.T, calls []wireCall, from, to int) {
+	t.Helper()
+	for _, c := range calls[from+1 : to] {
+		if c.sessionType != "stateful" {
+			t.Errorf("request inside the lock window is not stateful: %s\n"+
+				"  it retires the ADT session the lock handle lives in, so the write returns\n"+
+				"  423 ExceptionResourceInvalidLockHandle (issue #91)", c)
+		}
+	}
+	if t.Failed() {
+		dumpCalls(t, calls)
+	}
+}
+
+const testLockXML = `<?xml version="1.0" encoding="UTF-8"?>
+<asx:abap xmlns:asx="http://www.sap.com/abapxml" version="1.0"><asx:values><DATA>
+<LOCK_HANDLE>HANDLE-1</LOCK_HANDLE><IS_LOCAL>X</IS_LOCAL>
+<MODIFICATION_SUPPORT>NoModification</MODIFICATION_SUPPORT>
+</DATA></asx:values></asx:abap>`
+
+const testEmptyCheckXML = `<?xml version="1.0" encoding="UTF-8"?>` +
+	`<chkl:messages xmlns:chkl="http://www.sap.com/adt/checklist"/>`
+
+// searchXMLFor renders the quickSearch answer that resolves one object to one
+// package. getObjectPackage matches on the canonicalised URI, so this fixture
+// has to name the same object the test is mutating or the gate fails for an
+// unrelated reason and the real assertion never runs.
+func searchXMLFor(uri, name, pkg string) string {
+	return fmt.Sprintf(`<?xml version="1.0" encoding="UTF-8"?>
+<adtcore:objectReferences xmlns:adtcore="http://www.sap.com/adt/core">
+  <adtcore:objectReference adtcore:uri="%s" adtcore:type="PROG/P" adtcore:name="%s" adtcore:packageName="%s"/>
+</adtcore:objectReferences>`, uri, name, pkg)
+}
+
+// newStubbedClient wires a client to a recording httptest server.
+func newStubbedClient(t *testing.T, rec *adtRecorder, route http.HandlerFunc, opts ...Option) *Client {
+	t.Helper()
+	srv := httptest.NewServer(rec.handler(route))
+	t.Cleanup(srv.Close)
+
+	cfg := NewConfig(srv.URL, "TESTUSER", "secret", opts...)
+	return NewClientWithTransport(cfg, NewTransport(cfg))
+}
+
+// --- The primary regression: the package lookup inside the lock window ---
+
+func TestWriteProgram_NoStatelessRequestBetweenLockAndPut(t *testing.T) {
+	rec := &adtRecorder{}
+	client := newStubbedClient(t, rec, func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case strings.Contains(r.URL.Path, "informationsystem/search"):
+			_, _ = io.WriteString(w, searchXMLFor(
+				"/sap/bc/adt/programs/programs/zdemo_probe", "ZDEMO_PROBE", "$TMP"))
+		case strings.Contains(r.URL.Path, "/checkruns"):
+			w.Header().Set("Content-Type", "application/vnd.sap.adt.checkmessages+xml")
+			_, _ = io.WriteString(w, testEmptyCheckXML)
+		case r.Method == http.MethodPost && r.URL.Query().Get("_action") == "LOCK":
+			w.Header().Set("Content-Type", "application/vnd.sap.as+xml")
+			_, _ = io.WriteString(w, testLockXML)
+		default:
+			w.WriteHeader(http.StatusOK)
+		}
+	}, WithAllowedPackages("$TMP"))
+
+	if _, err := client.WriteProgram(context.Background(), "ZDEMO_PROBE",
+		"REPORT zdemo_probe.\n", ""); err != nil {
+		t.Fatalf("WriteProgram: %v", err)
+	}
+
+	calls := rec.snapshot()
+	lockAt := indexOfCall(calls, isLock)
+	putAt := indexOfCall(calls, isSourcePut)
+	if lockAt < 0 || putAt < 0 || putAt < lockAt {
+		t.Fatalf("expected a LOCK followed by a source PUT; trace:\n%v", calls)
+	}
+	assertWindowStateful(t, calls, lockAt, putAt)
+}
+
+func TestEditSource_NoStatelessRequestBetweenLockAndPut(t *testing.T) {
+	const objectURL = "/sap/bc/adt/programs/programs/ZDEMO_EDIT"
+
+	rec := &adtRecorder{}
+	client := newStubbedClient(t, rec, func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case strings.Contains(r.URL.Path, "informationsystem/search"):
+			_, _ = io.WriteString(w, searchXMLFor(
+				"/sap/bc/adt/programs/programs/zdemo_edit", "ZDEMO_EDIT", "$TMP"))
+		case r.Method == http.MethodGet && strings.HasSuffix(r.URL.Path, "/source/main"):
+			_, _ = io.WriteString(w, "REPORT zdemo_edit.\nWRITE 'old'.\n")
+		case strings.Contains(r.URL.Path, "/checkruns"):
+			w.Header().Set("Content-Type", "application/vnd.sap.adt.checkmessages+xml")
+			_, _ = io.WriteString(w, testEmptyCheckXML)
+		case r.Method == http.MethodPost && r.URL.Query().Get("_action") == "LOCK":
+			w.Header().Set("Content-Type", "application/vnd.sap.as+xml")
+			_, _ = io.WriteString(w, testLockXML)
+		default:
+			w.WriteHeader(http.StatusOK)
+		}
+	}, WithAllowedPackages("$TMP"))
+
+	result, err := client.EditSourceWithOptions(context.Background(), objectURL,
+		"WRITE 'old'.", "WRITE 'new'.", &EditSourceOptions{SyntaxCheck: false})
+	if err != nil {
+		t.Fatalf("EditSourceWithOptions: %v", err)
+	}
+	if !result.Success {
+		t.Fatalf("edit did not succeed: %s", result.Message)
+	}
+
+	calls := rec.snapshot()
+	lockAt := indexOfCall(calls, isLock)
+	putAt := indexOfCall(calls, isSourcePut)
+	if lockAt < 0 || putAt < 0 || putAt < lockAt {
+		t.Fatalf("expected a LOCK followed by a source PUT; trace:\n%v", calls)
+	}
+	assertWindowStateful(t, calls, lockAt, putAt)
+
+	// And the package must have been resolved exactly once, above the lock —
+	// the second lookup was pure waste even when it did not kill the session.
+	searches := 0
+	for _, c := range calls {
+		if strings.Contains(c.path, "informationsystem/search") {
+			searches++
+		}
+	}
+	if searches != 1 {
+		t.Errorf("package resolved %d times, want 1 (once, above the lock)", searches)
+		dumpCalls(t, calls)
+	}
+}
+
+// --- CreateTable: the mutation that was itself stateless ---
+
+func TestCreateTable_SourcePutStaysInTheLockSession(t *testing.T) {
+	rec := &adtRecorder{}
+	client := newStubbedClient(t, rec, func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodPost && r.URL.Query().Get("_action") == "LOCK":
+			w.Header().Set("Content-Type", "application/vnd.sap.as+xml")
+			_, _ = io.WriteString(w, testLockXML)
+		default:
+			w.WriteHeader(http.StatusOK)
+		}
+	}, WithAllowedPackages("$TMP"))
+
+	err := client.CreateTable(context.Background(), CreateTableOptions{
+		Name:        "ZDEMO_TAB",
+		Description: "demo",
+		Package:     "$TMP",
+		Fields:      []TableField{{Name: "MANDT", Type: "mandt", IsKey: true}},
+	})
+	if err != nil {
+		t.Fatalf("CreateTable: %v", err)
+	}
+
+	calls := rec.snapshot()
+	putAt := indexOfCall(calls, isSourcePut)
+	if putAt < 0 {
+		t.Fatalf("expected a PUT of the table source; trace:\n%v", calls)
+	}
+	if got := calls[putAt].sessionType; got != "stateful" {
+		t.Errorf("table source PUT X-sap-adt-sessiontype = %q, want \"stateful\" — "+
+			"it carries the lock handle from the stateful LOCK three lines above it "+
+			"and could never match its own lock (issue #91)", got)
+		dumpCalls(t, calls)
+	}
+
+	lockAt := indexOfCall(calls, isLock)
+	if lockAt < 0 || lockAt > putAt {
+		t.Fatalf("expected a LOCK before the source PUT; trace:\n%v", calls)
+	}
+	assertWindowStateful(t, calls, lockAt, putAt)
+}
+
+func TestCreateTable_RefusesPackageOutsideAllowlist(t *testing.T) {
+	rec := &adtRecorder{}
+	client := newStubbedClient(t, rec, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}, WithAllowedPackages("$TMP"))
+
+	err := client.CreateTable(context.Background(), CreateTableOptions{
+		Name:        "ZDEMO_TAB",
+		Description: "demo",
+		Package:     "ZDEMO_PROD",
+		Fields:      []TableField{{Name: "MANDT", Type: "mandt", IsKey: true}},
+	})
+	if err == nil {
+		t.Fatal("CreateTable created a table in ZDEMO_PROD with SAP_ALLOWED_PACKAGES=$TMP — " +
+			"the path only ran the op-type check, so --allowed-packages never applied to it")
+	}
+	if calls := rec.snapshot(); len(calls) != 0 {
+		t.Errorf("a blocked CreateTable still talked to SAP:")
+		dumpCalls(t, calls)
+	}
+}
+
+// --- The other unconditionally-stateless mutation ---
+
+func TestWriteMessageClassTexts_PutStaysInTheLockSession(t *testing.T) {
+	rec := &adtRecorder{}
+	client := newStubbedClient(t, rec, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodPost && r.URL.Query().Get("_action") == "LOCK" {
+			w.Header().Set("Content-Type", "application/vnd.sap.as+xml")
+			_, _ = io.WriteString(w, testLockXML)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	})
+
+	ctx := context.Background()
+	lock, err := client.LockObject(ctx, "/sap/bc/adt/messageclass/zdemo_mc", "MODIFY")
+	if err != nil {
+		t.Fatalf("LockObject: %v", err)
+	}
+	if err := client.WriteMessageClassTexts(ctx, "ZDEMO_MC", "EN",
+		[]MessageClassMessage{{Number: "001", Text: "hello"}}, lock.LockHandle, ""); err != nil {
+		t.Fatalf("WriteMessageClassTexts: %v", err)
+	}
+
+	calls := rec.snapshot()
+	putAt := indexOfCall(calls, func(c wireCall) bool {
+		return c.method == http.MethodPut && strings.Contains(c.path, "/messageclass/")
+	})
+	if putAt < 0 {
+		t.Fatalf("expected a PUT of the message class; trace:\n%v", calls)
+	}
+	if got := calls[putAt].sessionType; got != "stateful" {
+		t.Errorf("message class PUT X-sap-adt-sessiontype = %q, want \"stateful\" — "+
+			"the lockHandle in its query came from a stateful LOCK (issue #91)", got)
+		dumpCalls(t, calls)
+	}
+}
+
+// --- The one hop no config gates: the CSRF refetch mid-write ---
+
+func TestCSRFRefetchDuringStatefulWriteStaysStateful(t *testing.T) {
+	rec := &adtRecorder{}
+	var mu sync.Mutex
+	putSeen := 0
+
+	client := newStubbedClient(t, rec, func(w http.ResponseWriter, r *http.Request) {
+		if isSourcePut(wireCall{method: r.Method, path: r.URL.Path}) {
+			mu.Lock()
+			putSeen++
+			first := putSeen == 1
+			mu.Unlock()
+			if first {
+				// SAP's stock "your token went stale" answer, which sends the
+				// transport back to /core/discovery mid-window.
+				w.Header().Set("X-CSRF-Token", "Required")
+				w.WriteHeader(http.StatusForbidden)
+				return
+			}
+		}
+		w.WriteHeader(http.StatusOK)
+	})
+
+	if err := client.UpdateSource(context.Background(),
+		"/sap/bc/adt/programs/programs/ZDEMO_CSRF/source/main",
+		"REPORT zdemo_csrf.\n", "HANDLE-1", ""); err != nil {
+		t.Fatalf("UpdateSource: %v", err)
+	}
+
+	calls := rec.snapshot()
+	probes := 0
+	for _, c := range calls {
+		if !strings.Contains(c.path, "/core/discovery") {
+			continue
+		}
+		probes++
+		if c.sessionType != "stateful" {
+			t.Errorf("CSRF probe issued for a stateful write is not stateful: %s\n"+
+				"  it lands between the failed write and its retry, and the retry then\n"+
+				"  presents a handle whose session the probe just retired (issue #91)", c)
+		}
+	}
+	if probes == 0 {
+		t.Fatalf("expected a CSRF probe on /core/discovery; trace:\n%v", calls)
+	}
+	if t.Failed() {
+		dumpCalls(t, calls)
+	}
+}
+
+// --- The marker must not become a policy hole ---
+
+func markerTestClient(t *testing.T, safety SafetyConfig) *Client {
+	t.Helper()
+	cfg := NewConfig("https://sap.invalid", "TESTUSER", "secret", WithSafety(safety))
+	return NewClientWithTransport(cfg, NewTransport(cfg))
+}
+
+func TestMutationMarker_StillEnforcesOperationPolicy(t *testing.T) {
+	// The outer workflow passes OpWorkflow ('W'); the inner mutator passes
+	// OpUpdate ('U'). With 'U' disallowed the inner call must still be
+	// refused — this is precisely what PR #125's all-or-nothing early return
+	// would have let through.
+	client := markerTestClient(t, SafetyConfig{
+		AllowedPackages: []string{"$TMP"},
+		DisallowedOps:   "U",
+	})
+
+	const objectURL = "/sap/bc/adt/programs/programs/ZDEMO_MARK"
+	ctx := withMutationPackageChecked(context.Background(), objectURL)
+
+	err := client.checkMutation(ctx, MutationContext{
+		Op:        OpUpdate,
+		OpName:    "UpdateSource",
+		ObjectURL: objectURL + "/source/main",
+	})
+	if err == nil {
+		t.Fatal("a marked context skipped the operation-type check: --disallowed-ops U " +
+			"no longer blocks UpdateSource once an outer OpWorkflow gate has run")
+	}
+	if !strings.Contains(err.Error(), "blocked by safety configuration") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestMutationMarker_StillEnforcesTransportPolicy(t *testing.T) {
+	client := markerTestClient(t, SafetyConfig{
+		AllowedPackages: []string{"$TMP"},
+		// AllowTransportableEdits stays false: a transport-bound edit is refused.
+	})
+
+	const objectURL = "/sap/bc/adt/programs/programs/ZDEMO_MARK"
+	ctx := withMutationPackageChecked(context.Background(), objectURL)
+
+	err := client.checkMutation(ctx, MutationContext{
+		Op:        OpUpdate,
+		OpName:    "UpdateSource",
+		ObjectURL: objectURL + "/source/main",
+		Transport: "TR-EXAMPLE",
+	})
+	if err == nil {
+		t.Fatal("a marked context skipped the transportable-edit check: " +
+			"--allow-transportable-edits is no longer required once an outer gate has run")
+	}
+	if !strings.Contains(err.Error(), "transportable objects is disabled") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestMutationMarker_IsPerObject(t *testing.T) {
+	// Marking ZDEMO_MARKED must do nothing for ZDEMO_OTHER, which lives in a
+	// package the whitelist does not allow. A blanket "the gate ran" flag would
+	// let a workflow that checked one object delegate an unchecked mutation of
+	// another.
+	rec := &adtRecorder{}
+	client := newStubbedClient(t, rec, func(w http.ResponseWriter, r *http.Request) {
+		if strings.Contains(r.URL.Path, "informationsystem/search") {
+			_, _ = io.WriteString(w, searchXMLFor(
+				"/sap/bc/adt/programs/programs/zdemo_other", "ZDEMO_OTHER", "ZDEMO_PROD"))
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}, WithAllowedPackages("$TMP"))
+
+	ctx := withMutationPackageChecked(context.Background(),
+		"/sap/bc/adt/programs/programs/ZDEMO_MARKED")
+
+	err := client.checkMutation(ctx, MutationContext{
+		Op:        OpUpdate,
+		OpName:    "UpdateSource",
+		ObjectURL: "/sap/bc/adt/programs/programs/ZDEMO_OTHER/source/main",
+	})
+	if err == nil {
+		t.Fatal("the mark for ZDEMO_MARKED suppressed the package check for ZDEMO_OTHER, " +
+			"which lives in ZDEMO_PROD — the marker must be per-object")
+	}
+
+	// It must have actually looked ZDEMO_OTHER up rather than guessing.
+	if idx := indexOfCall(rec.snapshot(), func(c wireCall) bool {
+		return strings.Contains(c.path, "informationsystem/search")
+	}); idx < 0 {
+		t.Error("no package lookup was performed for the unmarked object")
+	}
+}
+
+func TestMutationMarker_SkipsOnlyTheLookupForTheMarkedObject(t *testing.T) {
+	// The marked object must be accepted without any HTTP traffic at all —
+	// that absence of a request is the whole fix.
+	rec := &adtRecorder{}
+	client := newStubbedClient(t, rec, func(w http.ResponseWriter, r *http.Request) {
+		t.Errorf("unexpected request for a marked object: %s %s", r.Method, r.URL)
+		w.WriteHeader(http.StatusOK)
+	}, WithAllowedPackages("$TMP"))
+
+	const objectURL = "/sap/bc/adt/oo/classes/ZCL_DEMO_MARK"
+	ctx := withMutationPackageChecked(context.Background(), objectURL)
+
+	// /source/main and /includes/testclasses both resolve their package from
+	// the parent class, so both are covered by the class's mark.
+	for _, target := range []string{
+		objectURL,
+		objectURL + "/source/main",
+		objectURL + "/includes/testclasses",
+	} {
+		if err := client.checkMutation(ctx, MutationContext{
+			Op:        OpUpdate,
+			OpName:    "UpdateSource",
+			ObjectURL: target,
+		}); err != nil {
+			t.Errorf("marked object %s was rejected: %v", target, err)
+		}
+	}
+}
+
+// --- The function-module metadata PUT, which had no gate of its own ---
+
+func TestSetFunctionModuleProcessingType_HonoursAllowedPackages(t *testing.T) {
+	// The metadata PUT inside writeFunctionModule is a mutation that ran
+	// behind no package check at all: with source empty it never reaches
+	// UpdateSource, so nothing consulted SAP_ALLOWED_PACKAGES before flipping a
+	// module to RFC-enabled.
+	rec := &adtRecorder{}
+	client := newStubbedClient(t, rec, func(w http.ResponseWriter, r *http.Request) {
+		if strings.Contains(r.URL.Path, "informationsystem/search") {
+			_, _ = io.WriteString(w, searchXMLFor(
+				"/sap/bc/adt/functions/groups/zdemo_grp/fmodules/zdemo_fm",
+				"ZDEMO_FM", "ZDEMO_PROD"))
+			return
+		}
+		if r.Method == http.MethodPost && r.URL.Query().Get("_action") == "LOCK" {
+			w.Header().Set("Content-Type", "application/vnd.sap.as+xml")
+			_, _ = io.WriteString(w, testLockXML)
+			return
+		}
+		if r.Method == http.MethodGet && strings.Contains(r.URL.Path, "/fmodules/") {
+			// GetFunctionModule must succeed, or the call fails for an
+			// unrelated reason and the policy assertion proves nothing.
+			_, _ = io.WriteString(w, `<?xml version="1.0" encoding="UTF-8"?>
+<fmodule:abapFunctionModule xmlns:fmodule="http://www.sap.com/adt/functions/fmodules"
+  xmlns:adtcore="http://www.sap.com/adt/core"
+  adtcore:name="ZDEMO_FM" adtcore:description="demo" fmodule:processingType="normal">
+  <adtcore:containerRef adtcore:name="ZDEMO_GRP" adtcore:type="FUGR/F"/>
+</fmodule:abapFunctionModule>`)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}, WithAllowedPackages("$TMP"))
+
+	err := client.SetFunctionModuleProcessingType(context.Background(),
+		"ZDEMO_GRP", "ZDEMO_FM", "rfc")
+	if err == nil {
+		t.Fatal("a function module in ZDEMO_PROD was switched to RFC-enabled with " +
+			"SAP_ALLOWED_PACKAGES=$TMP — the metadata PUT had no package check")
+	}
+
+	calls := rec.snapshot()
+	if idx := indexOfCall(calls, isLock); idx >= 0 {
+		t.Errorf("a blocked call still locked the object (and would have to release it):")
+		dumpCalls(t, calls)
+	}
+}
+
+// --- The stranded-ENQUEUE half ---
+
+func TestRenameObject_ReleasesOldLockWhenDeleteFails(t *testing.T) {
+	const oldURL = "/sap/bc/adt/programs/programs/ZDEMO_OLD"
+
+	rec := &adtRecorder{}
+	client := newStubbedClient(t, rec, func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case strings.Contains(r.URL.Path, "informationsystem/search"):
+			_, _ = io.WriteString(w, searchXMLFor(
+				"/sap/bc/adt/programs/programs/zdemo_old", "ZDEMO_OLD", "$TMP"))
+		case strings.Contains(r.URL.Path, "nodestructure"):
+			// packageExists preflight for CreateObject.
+			_, _ = io.WriteString(w, `<?xml version="1.0"?><asx:abap xmlns:asx="http://www.sap.com/abapxml"><asx:values><DATA/></asx:values></asx:abap>`)
+		case r.Method == http.MethodGet && strings.HasSuffix(r.URL.Path, "/source/main"):
+			_, _ = io.WriteString(w, "REPORT zdemo_old.\n")
+		case r.Method == http.MethodPost && r.URL.Query().Get("_action") == "LOCK":
+			w.Header().Set("Content-Type", "application/vnd.sap.as+xml")
+			_, _ = io.WriteString(w, testLockXML)
+		case r.Method == http.MethodDelete:
+			// The failure this test exists for: the old object cannot be
+			// deleted, and until now the lock taken to delete it was simply
+			// abandoned — on the very object the user is then told to delete
+			// by hand.
+			w.WriteHeader(http.StatusConflict)
+			_, _ = io.WriteString(w, "object is in use")
+		default:
+			w.WriteHeader(http.StatusOK)
+		}
+	}, WithAllowedPackages("$TMP"))
+
+	result, err := client.RenameObject(context.Background(), ObjectTypeProgram,
+		"ZDEMO_OLD", "ZDEMO_NEW", "$TMP", "")
+	if err != nil {
+		t.Fatalf("RenameObject: %v", err)
+	}
+	if result == nil {
+		t.Fatal("RenameObject returned no result")
+	}
+
+	calls := rec.snapshot()
+	deleteAt := indexOfCall(calls, func(c wireCall) bool { return c.method == http.MethodDelete })
+	if deleteAt < 0 {
+		t.Fatalf("expected a DELETE of the old object; trace:\n%v", calls)
+	}
+
+	released := false
+	for _, c := range calls[deleteAt+1:] {
+		if isUnlock(c) && strings.EqualFold(c.path, oldURL) {
+			released = true
+		}
+	}
+	if !released {
+		t.Error("the failed delete left the old object locked: no UNLOCK was sent for it " +
+			"after the DELETE failed, so the ENQUEUE outlives the call — on the object the " +
+			"caller is being told to delete manually")
+		dumpCalls(t, calls)
+	}
+}
+
+func TestReleaseLockAfterFailure_RunsOnACancelledContext(t *testing.T) {
+	// A mutation that fails *because* the context was cancelled or timed out
+	// must still release its lock. Reusing the dead context, as every
+	// compensating unlock in the package used to, fails inside
+	// http.NewRequestWithContext and never sends a byte.
+	rec := &adtRecorder{}
+	client := newStubbedClient(t, rec, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	if err := client.releaseLockAfterFailure(ctx, "/sap/bc/adt/programs/programs/ZDEMO_CANCEL", "HANDLE-1"); err != nil {
+		t.Fatalf("releaseLockAfterFailure on a cancelled context: %v", err)
+	}
+
+	calls := rec.snapshot()
+	if idx := indexOfCall(calls, isUnlock); idx < 0 {
+		t.Errorf("no UNLOCK reached the server after the context was cancelled — "+
+			"the lock would be stranded until SAP reaps the session; trace: %v", calls)
+	}
+}
+
+func TestStrandedLockAdvice_SaysWhatTheUserNeeds(t *testing.T) {
+	msg := strandedLockAdvice("/sap/bc/adt/oo/classes/ZCL_DEMO_FOO",
+		fmt.Errorf("unlocking object: 423 invalid lock handle"))
+
+	for _, want := range []string{
+		"ZCL_DEMO_FOO",    // which object
+		"your own user",   // not a colleague
+		"SM12",            // the immediate route
+		"session timeout", // it expires on its own
+		"currently editing",
+	} {
+		if !strings.Contains(msg, want) {
+			t.Errorf("advice does not mention %q:\n%s", want, msg)
+		}
+	}
+}
+
+// --- The exported preflight used by the MCP deploy handlers ---
+
+func TestPrepareSourceUpdate_MarksTheObjectItChecked(t *testing.T) {
+	rec := &adtRecorder{}
+	client := newStubbedClient(t, rec, func(w http.ResponseWriter, r *http.Request) {
+		if strings.Contains(r.URL.Path, "informationsystem/search") {
+			_, _ = io.WriteString(w, searchXMLFor(
+				"/sap/bc/adt/programs/programs/zdemo_prep", "ZDEMO_PREP", "$TMP"))
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}, WithAllowedPackages("$TMP"))
+
+	const objectURL = "/sap/bc/adt/programs/programs/ZDEMO_PREP"
+
+	ctx, err := client.PrepareSourceUpdate(context.Background(), objectURL, "")
+	if err != nil {
+		t.Fatalf("PrepareSourceUpdate: %v", err)
+	}
+	before := len(rec.snapshot())
+
+	if err := client.checkMutation(ctx, MutationContext{
+		Op:        OpUpdate,
+		OpName:    "UpdateSource",
+		ObjectURL: objectURL + "/source/main",
+	}); err != nil {
+		t.Fatalf("gate rejected the prepared object: %v", err)
+	}
+	if after := len(rec.snapshot()); after != before {
+		t.Errorf("the write's own gate issued %d more request(s) after PrepareSourceUpdate; "+
+			"inside a lock window each one costs the lock handle", after-before)
+	}
+
+	// A different object gets no free pass: the prepared context must not
+	// suppress the lookup for anything but the object it checked.
+	before = len(rec.snapshot())
+	_ = client.checkMutation(ctx, MutationContext{
+		Op:        OpUpdate,
+		OpName:    "UpdateSource",
+		ObjectURL: "/sap/bc/adt/programs/programs/ZDEMO_ELSEWHERE/source/main",
+	})
+	if after := len(rec.snapshot()); after == before {
+		t.Error("an unmarked object was accepted without resolving its package")
+	}
+}

--- a/pkg/adt/workflows.go
+++ b/pkg/adt/workflows.go
@@ -27,13 +27,16 @@ func (c *Client) WriteProgram(ctx context.Context, programName string, source st
 	objectURL := fmt.Sprintf("/sap/bc/adt/programs/programs/%s", url.PathEscape(programName))
 	sourceURL := objectURL + "/source/main"
 
-	// Unified mutation policy gate (op type + package + transport)
-	if err := c.checkMutation(ctx, MutationContext{
+	// Unified mutation policy gate (op type + package + transport). The
+	// returned context carries the mark that stops UpdateSource resolving the
+	// same package again from inside the lock window (issue #91).
+	ctx, err := c.gateAndMark(ctx, MutationContext{
 		Op:        OpWorkflow,
 		OpName:    "WriteProgram",
 		ObjectURL: objectURL,
 		Transport: transport,
-	}); err != nil {
+	})
+	if err != nil {
 		return nil, err
 	}
 
@@ -122,13 +125,16 @@ func (c *Client) WriteClass(ctx context.Context, className string, source string
 	objectURL := fmt.Sprintf("/sap/bc/adt/oo/classes/%s", url.PathEscape(className))
 	sourceURL := objectURL + "/source/main"
 
-	// Unified mutation policy gate (op type + package + transport)
-	if err := c.checkMutation(ctx, MutationContext{
+	// Unified mutation policy gate (op type + package + transport). The
+	// returned context carries the mark that stops UpdateSource resolving the
+	// same package again from inside the lock window (issue #91).
+	ctx, err := c.gateAndMark(ctx, MutationContext{
 		Op:        OpWorkflow,
 		OpName:    "WriteClass",
 		ObjectURL: objectURL,
 		Transport: transport,
-	}); err != nil {
+	})
+	if err != nil {
 		return nil, err
 	}
 
@@ -247,6 +253,12 @@ func (c *Client) CreateAndActivateProgram(ctx context.Context, programName strin
 		return result, nil
 	}
 
+	// The gate above accepted packageName, and CreateObject gated it a second
+	// time before asking SAP to put the program there — so the program's
+	// package is a package the whitelist allows. Record that for the object,
+	// or UpdateSource resolves it again from inside the lock (issue #91).
+	ctx = withMutationPackageChecked(ctx, objectURL)
+
 	// Step 2: Lock
 	lock, err := c.LockObject(ctx, objectURL, "MODIFY")
 	if err != nil {
@@ -339,6 +351,13 @@ func (c *Client) CreateClassWithTests(ctx context.Context, className string, des
 		result.Message = fmt.Sprintf("Failed to create class: %v", err)
 		return result, nil
 	}
+
+	// Same reasoning as CreateAndActivateProgram: packageName passed the gate
+	// twice and the class was created there, so the three mutators that run
+	// under the single lock below (UpdateSource, CreateTestInclude,
+	// UpdateClassInclude — all of which resolve to this class URL) need not
+	// each resolve the package again mid-window (issue #91).
+	ctx = withMutationPackageChecked(ctx, objectURL)
 
 	// Step 2: Lock
 	lock, err := c.LockObject(ctx, objectURL, "MODIFY")

--- a/pkg/adt/workflows_deploy.go
+++ b/pkg/adt/workflows_deploy.go
@@ -78,6 +78,12 @@ func (c *Client) CreateFromFile(ctx context.Context, filePath, packageName, tran
 		return nil, err
 	}
 
+	// CreateObject accepted packageName against the whitelist and SAP put the
+	// object there, so UpdateSource below need not resolve the same package
+	// again — which it would do from inside the lock, ending the session the
+	// lock handle belongs to (issue #91).
+	ctx = withMutationPackageChecked(ctx, objectURL)
+
 	// 5. Syntax check, before the lock and deliberately so. A syntax check does
 	// not need one, and it is a *stateless* request: sent while a lock is held it
 	// ends the stateful session the lock lives in, and the write that follows
@@ -244,6 +250,23 @@ func (c *Client) UpdateFromFile(ctx context.Context, filePath, transport string)
 	// The parent goes with it: DeployFromFile delegates here whenever the object
 	// already exists, so dropping it made every update of a function module fail.
 	objectURL, err := c.buildObjectURLWithParent(info.ObjectType, info.ObjectName, info.ParentName)
+	if err != nil {
+		return nil, err
+	}
+
+	// The full mutation gate for the object, run here — above the lock — for
+	// the same reason the syntax check moved above it: the package lookup it
+	// performs is a stateless request, and the write under the lock would
+	// otherwise trigger it mid-window and lose the handle (issue #91).
+	// UpdateFromFile previously only ran the op-type check, so this also
+	// closes the path's package check rather than leaving it to the inner
+	// mutator.
+	ctx, err = c.gateAndMark(ctx, MutationContext{
+		Op:        OpUpdate,
+		OpName:    "UpdateFromFile",
+		ObjectURL: objectURL,
+		Transport: transport,
+	})
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/adt/workflows_edit.go
+++ b/pkg/adt/workflows_edit.go
@@ -149,13 +149,19 @@ func (c *Client) EditSourceWithOptions(ctx context.Context, objectURL, oldString
 		opts = &EditSourceOptions{SyntaxCheck: true}
 	}
 
-	// Unified mutation policy gate (op type + package + transport)
-	if err := c.checkMutation(ctx, MutationContext{
+	// Unified mutation policy gate (op type + package + transport). The mark
+	// on the returned context stops the identical package resolve running a
+	// second time from inside the lock window, where it would retire the
+	// session the lock handle lives in (issue #91). A class include marks the
+	// same key as its parent class, which is the object ADT resolves the
+	// package from either way.
+	ctx, err := c.gateAndMark(ctx, MutationContext{
 		Op:        OpUpdate,
 		OpName:    "EditSource",
 		ObjectURL: objectURL,
 		Transport: opts.Transport,
-	}); err != nil {
+	})
+	if err != nil {
 		return nil, err
 	}
 	// SyntaxCheck defaults to true if not explicitly set (zero value is false, so we need to handle this)

--- a/pkg/adt/workflows_execute.go
+++ b/pkg/adt/workflows_execute.go
@@ -174,6 +174,13 @@ func (c *Client) ExecuteABAP(ctx context.Context, code string, opts *ExecuteABAP
 		return result, nil
 	}
 
+	// The temp program lives in $TMP, and CreateObject only got that far
+	// because "$TMP" passed the package whitelist. Record it so neither the
+	// UpdateSource below nor the DeleteObject in the cleanup defer resolves the
+	// package again while holding a lock (issue #91). The defer reads this
+	// variable when it runs, so it sees the marked context too.
+	ctx = withMutationPackageChecked(ctx, objectURL)
+
 	// Ensure cleanup on any error (unless KeepProgram is set)
 	defer func() {
 		if !opts.KeepProgram {

--- a/pkg/adt/workflows_fileio.go
+++ b/pkg/adt/workflows_fileio.go
@@ -52,13 +52,17 @@ func (c *Client) RenameObject(ctx context.Context, objType CreatableObjectType, 
 		return nil, err
 	}
 
-	// Unified mutation policy gate for the old object being deleted.
-	if err := c.checkMutation(ctx, MutationContext{
+	// Unified mutation policy gate for the old object being deleted. The mark
+	// on the returned context covers exactly the object this gate resolved, so
+	// the DeleteObject at the end does not resolve it again while holding the
+	// lock it is about to use (issue #91).
+	ctx, err = c.gateAndMark(ctx, MutationContext{
 		Op:        OpDelete,
 		OpName:    "RenameObject",
 		ObjectURL: oldURL,
 		Transport: transport,
-	}); err != nil {
+	})
+	if err != nil {
 		return nil, err
 	}
 
@@ -109,14 +113,31 @@ func (c *Client) RenameObject(ctx context.Context, objType CreatableObjectType, 
 		result.Errors = append(result.Errors, fmt.Sprintf("Failed to address the new object: %v", urlErr))
 		return result, nil
 	}
+	// The new object was created in packageName, which the create-side gate
+	// above accepted (and CreateObject checked again). Only mark when a
+	// package was actually supplied and therefore actually checked: with
+	// packageName empty there is no approved package to stand behind, and
+	// leaving the mark off makes UpdateSource fall back to the full gate.
+	if packageName != "" {
+		ctx = withMutationPackageChecked(ctx, newURL)
+	}
+
 	lockResult, err := c.LockObject(ctx, newURL, "MODIFY")
 	if err != nil {
 		result.Errors = append(result.Errors, fmt.Sprintf("Failed to lock new object: %v", err))
 		return result, nil
 	}
 
+	// Track the release explicitly. The old form was an unconditional defer
+	// plus an inline unlock on the happy path, so every successful rename sent
+	// a second UNLOCK for a handle that was already gone.
+	newUnlocked := false
 	defer func() {
-		_ = c.UnlockObject(ctx, newURL, lockResult.LockHandle)
+		if !newUnlocked {
+			if unlockErr := c.releaseLockAfterFailure(ctx, newURL, lockResult.LockHandle); unlockErr != nil {
+				result.Errors = append(result.Errors, strandedLockAdvice(newURL, unlockErr))
+			}
+		}
 	}()
 
 	err = c.UpdateSource(ctx, newURL, newSource, lockResult.LockHandle, transport)
@@ -125,7 +146,10 @@ func (c *Client) RenameObject(ctx context.Context, objType CreatableObjectType, 
 		return result, nil
 	}
 
-	_ = c.UnlockObject(ctx, newURL, lockResult.LockHandle)
+	newUnlocked = true
+	if unlockErr := c.UnlockObject(ctx, newURL, lockResult.LockHandle); unlockErr != nil {
+		result.Errors = append(result.Errors, strandedLockAdvice(newURL, unlockErr))
+	}
 
 	// 5. Activate new object
 	activation, err := c.Activate(ctx, newURL, newName)
@@ -152,12 +176,27 @@ func (c *Client) RenameObject(ctx context.Context, objType CreatableObjectType, 
 		return result, nil
 	}
 
+	// A successful DELETE consumes the lock with the object; anything else
+	// leaves the ENQUEUE on an object the user has just been told to delete by
+	// hand — which is precisely what would make the manual delete fail. This
+	// branch had no defer at all, so the failure path returned Success=true
+	// with the lock still held and nothing said about it.
+	oldReleased := false
+	defer func() {
+		if !oldReleased {
+			if unlockErr := c.releaseLockAfterFailure(ctx, oldURL, oldLockResult.LockHandle); unlockErr != nil {
+				result.Errors = append(result.Errors, strandedLockAdvice(oldURL, unlockErr))
+			}
+		}
+	}()
+
 	err = c.DeleteObject(ctx, oldURL, oldLockResult.LockHandle, transport)
 	if err != nil {
 		result.Message = fmt.Sprintf("New object %s created successfully, but failed to delete old object %s: %v. Please delete manually.", newName, oldName, err)
 		result.Success = true
 		return result, nil
 	}
+	oldReleased = true
 
 	result.Success = true
 	result.Message = fmt.Sprintf("Successfully renamed %s to %s", oldName, newName)

--- a/pkg/adt/workflows_function.go
+++ b/pkg/adt/workflows_function.go
@@ -105,8 +105,29 @@ func (c *Client) SetFunctionModuleProcessingType(ctx context.Context, group, nam
 // module inside a single lock: LOCK → PUT metadata → PUT source → UNLOCK.
 // Either write is optional. Doing both under one lock keeps the ENQUEUE
 // footprint to one acquire/release even for a full create-and-fill flow.
-func (c *Client) writeFunctionModule(ctx context.Context, group, name, processingType, source, transport string) error {
+func (c *Client) writeFunctionModule(ctx context.Context, group, name, processingType, source, transport string) (retErr error) {
 	objectURL := GetObjectURL(ObjectTypeFunctionMod, name, group)
+
+	// Gate here, above the lock. Two reasons.
+	//
+	// Policy: the metadata PUT below is a mutation with no gate of its own, so
+	// SetFunctionModuleProcessingType could flip a module to RFC-enabled in any
+	// package, whitelist or not. The source write reaches UpdateSource, which
+	// does gate — but only from inside the lock.
+	//
+	// Sessions: that inner package lookup is a stateless request, and issued
+	// between the LOCK and either PUT it retires the session the lock handle
+	// belongs to (issue #91). Running the same check up here and marking the
+	// context keeps the check and removes the request from the window.
+	ctx, err := c.gateAndMark(ctx, MutationContext{
+		Op:        OpUpdate,
+		OpName:    "WriteFunctionModule",
+		ObjectURL: objectURL,
+		Transport: transport,
+	})
+	if err != nil {
+		return err
+	}
 
 	// The metadata PUT replaces the document, so start from what SAP has —
 	// otherwise the description is silently blanked.
@@ -122,7 +143,16 @@ func (c *Client) writeFunctionModule(ctx context.Context, group, name, processin
 	unlocked := false
 	defer func() {
 		if !unlocked {
-			_ = c.UnlockObject(ctx, objectURL, lock.LockHandle)
+			// The compensating unlock is the only place a leak can be
+			// observed, so its failure is reported rather than dropped.
+			if unlockErr := c.releaseLockAfterFailure(ctx, objectURL, lock.LockHandle); unlockErr != nil {
+				advice := strandedLockAdvice(objectURL, unlockErr)
+				if retErr != nil {
+					retErr = fmt.Errorf("%w — %s", retErr, advice)
+				} else {
+					retErr = fmt.Errorf("%s", advice)
+				}
+			}
 		}
 	}()
 
@@ -272,6 +302,13 @@ func (c *Client) CreateFunctionModule(ctx context.Context, opts CreateFunctionMo
 		result.Message = fmt.Sprintf("Failed to create function module: %v", err)
 		return result, err
 	}
+
+	// The module was just created in opts.PackageName, which CreateObject
+	// checked against the whitelist — so writeFunctionModule's gate need not
+	// resolve it over the wire. That matters twice over here: a module created
+	// moments ago may not be in the search index yet, and the lookup would sit
+	// inside writeFunctionModule's lock window (issue #91).
+	ctx = withMutationPackageChecked(ctx, result.ObjectURL)
 
 	processingType := ""
 	if opts.RFCEnabled {

--- a/pkg/adt/workflows_source.go
+++ b/pkg/adt/workflows_source.go
@@ -420,6 +420,12 @@ func (c *Client) writeSourceCreate(ctx context.Context, objectType, name, source
 			return result, nil
 		}
 
+		// The interface was created in opts.Package, which CreateObject only
+		// accepted after checking it against the whitelist — so UpdateSource
+		// need not resolve the same package again from inside the lock, where
+		// the lookup would retire the lock handle's session (issue #91).
+		ctx = withMutationPackageChecked(ctx, objectURL)
+
 		// Write source (using WriteProgram logic for interface)
 		sourceURL := objectURL + "/source/main"
 
@@ -520,6 +526,12 @@ func (c *Client) writeSourceCreate(ctx context.Context, objectType, name, source
 			result.Message = fmt.Sprintf("Failed to create %s: %v", objectType, err)
 			return result, nil
 		}
+
+		// Created in opts.Package, which CreateObject checked against the
+		// whitelist. Both branches below (BDEF shell fill, DDLS/SRVD source
+		// write) then lock and call UpdateSource; without this mark each would
+		// resolve the package again mid-window and lose the handle (#91).
+		ctx = withMutationPackageChecked(ctx, objectURL)
 
 		// For BDEF, creation creates empty shell, then update source
 		if objectType == "BDEF" {
@@ -765,6 +777,22 @@ func (c *Client) writeSourceUpdate(ctx context.Context, objectType, name, source
 		if opts.TestSource != "" {
 			objectURL := fmt.Sprintf("/sap/bc/adt/oo/classes/%s", url.PathEscape(name))
 
+			// Run the package check for the class here, above the lock, rather
+			// than letting UpdateClassInclude / CreateTestInclude each run it
+			// under the lock — a stateless lookup there retires the session the
+			// handle belongs to (issue #91). This is the full gate, so nothing
+			// is skipped, only moved out of the window.
+			ctx, err := c.gateAndMark(ctx, MutationContext{
+				Op:        OpUpdate,
+				OpName:    "WriteSource",
+				ObjectURL: objectURL,
+				Transport: opts.Transport,
+			})
+			if err != nil {
+				result.Message += fmt.Sprintf(" (Warning: test include not written: %v)", err)
+				return result, nil
+			}
+
 			// Lock for test update
 			lock, err := c.LockObject(ctx, objectURL, "MODIFY")
 			if err != nil {
@@ -812,6 +840,19 @@ func (c *Client) writeSourceUpdate(ctx context.Context, objectType, name, source
 		objectURL := fmt.Sprintf("/sap/bc/adt/oo/interfaces/%s", url.PathEscape(name))
 		sourceURL := objectURL + "/source/main"
 		result.ObjectURL = objectURL
+
+		// Full gate, run here rather than inside UpdateSource under the lock
+		// (issue #91). Nothing is skipped — the package lookup is only moved
+		// out of the lock window.
+		ctx, err := c.gateAndMark(ctx, MutationContext{
+			Op:        OpUpdate,
+			OpName:    "WriteSource",
+			ObjectURL: objectURL,
+			Transport: opts.Transport,
+		})
+		if err != nil {
+			return nil, err
+		}
 
 		// Syntax check
 		syntaxErrors, err := c.SyntaxCheck(ctx, objectURL, source)
@@ -895,6 +936,19 @@ func (c *Client) writeSourceUpdate(ctx context.Context, objectType, name, source
 		result.ObjectURL = objectURL
 		sourceURL := objectURL + "/source/main"
 
+		// Full gate, run here rather than inside UpdateSource under the lock
+		// (issue #91). Nothing is skipped — the package lookup is only moved
+		// out of the lock window.
+		ctx, err := c.gateAndMark(ctx, MutationContext{
+			Op:        OpUpdate,
+			OpName:    "WriteSource",
+			ObjectURL: objectURL,
+			Transport: opts.Transport,
+		})
+		if err != nil {
+			return nil, err
+		}
+
 		// Syntax check
 		syntaxErrors, err := c.SyntaxCheck(ctx, objectURL, source)
 		if err != nil {
@@ -976,6 +1030,18 @@ func (c *Client) writeClassMethodUpdate(ctx context.Context, className, methodNa
 	methodName = strings.ToUpper(methodName)
 	objectURL := fmt.Sprintf("/sap/bc/adt/oo/classes/%s", url.PathEscape(strings.ToLower(className)))
 	result.ObjectURL = objectURL
+
+	// Full gate up front, so UpdateSource does not repeat the networked
+	// package lookup between the LOCK and the PUT (issue #91).
+	ctx, err := c.gateAndMark(ctx, MutationContext{
+		Op:        OpUpdate,
+		OpName:    "WriteSource",
+		ObjectURL: objectURL,
+		Transport: transport,
+	})
+	if err != nil {
+		return nil, err
+	}
 
 	// Get method boundaries
 	methods, err := c.GetClassMethods(ctx, className)


### PR DESCRIPTION
Closes the live leg of #91: the `423 ExceptionResourceInvalidLockHandle` that survived `22517d4`, `9b98997` and `ff32cd7`.

## The defect

A lock handle is bound to the ADT session that issued it. Since `d84db03` made `SessionStateless` the client default (`config.go:198`), `http.go:502` stamps an explicit `X-sap-adt-sessiontype: stateless` on every request that does not set `RequestOptions.Stateful` — and such a request retires the stateful context server-side. So the 423 is never a lock bug. It is whatever request lands between LOCK and the write.

The live one at HEAD, reproduced with an `httptest` probe rather than read off a diff:

```
POST ?_action=LOCK              stateful    crud.go:50
GET  informationsystem/search   STATELESS   client.go:149   <- kills the session
PUT  .../source/main            stateful    crud.go:202     <- 423
```

That GET is the mutation gate's package lookup: `UpdateSource` ran `checkMutation` *after* the caller already held the lock. It fires when `--allowed-packages` is configured. Same diagnosis @Hallohannes123 posted on #91.

## The fix

`checkMutation` skips **only** its one networked step — the package lookup — and only when the context carries a mark saying *this exact object's* package was already resolved and accepted by an outer gate. The op-type and transportable-edit checks always run.

That scoping is the difference from #125, which returns `nil` from the whole gate: the outer gate is `OpWorkflow`, so skipping the inner one lets `--disallowed-ops U` through. The mark is a set of canonicalised object keys rather than a boolean, so a workflow that checked A cannot delegate an unchecked mutation of B.

Also fixed:

- **`CreateTable`'s source PUT** and **`WriteMessageClassTexts`' PUT** were themselves stateless. Both fail with no whitelist configured and no other failure needed — neither prior-art PR touches them. `CreateTable` now routes through `UpdateSource`, which brings it under `--allowed-packages` for the first time.
- **`probeCSRFToken`** inherits the in-flight request's statefulness — the one hop no configuration gated.
- **The enqueue leak.** All fourteen deferred unlocks reused the caller's context, so a mutation that failed *because* that context was cancelled could never release its lock: it died in `NewRequestWithContext` before a byte was sent. Compensating unlocks now run on `context.WithoutCancel` with their own deadline. `RenameObject`'s old-object lock finally has a defer. A release that fails now names the stranded object and says SM12 clears it, instead of being discarded with `_ =`. (Partial — the rest is #166.)

## Behaviour changes worth review

Stricter, deliberately: `UpdateFromFile`, `writeFunctionModule` (hence `SetFunctionModuleProcessingType` and `CreateFunctionModule`), `CreateTable` and the MCP deploy-zip loop now run package checks they did not run before. Anyone relying on those paths working outside their whitelist will now be refused.

## Tests

15 new tests in `pkg/adt/session_affinity_test.go`, 11 of which fail without this change. They assert the actual `X-sap-adt-sessiontype` header across each LOCK-to-write window, in request order, against a recording `httptest` server — not the shape of a mock. `go build ./...`, `go vet ./pkg/adt/ ./internal/mcp/` and `go test ./pkg/adt/ ./internal/mcp/` are green.

The `#132`/`#141`/`#165` LOCK guard (`crud.go:73`) and the syntax-before-lock ordering are untouched and unregressed.

## What this does not fix

Stated plainly so #91 is not closed on a half-claim:

1. **The keep-alive ticker** — `--keepalive` defaults to 5 minutes and MCP starts it for every session; the ping has no session affinity and can retire the context inside any lock window, on any configuration. Filed as #168; fixing it is a tradeoff, since a stateful ping holds a server-side session slot.
2. **The MCP cross-tool-call window** — `handleLockObject` hands the raw handle to the model and a *later* tool call consumes it. Every read the agent does in between is a stateless hop. No in-process design closes that — filed as #169.

Also found en route, left alone to keep this reviewable: `RenameObject` passes `newURL` instead of `newURL + "/source/main"` to `UpdateSource`, and `WriteSource` in update mode is unreachable when `--allowed-packages` is set (its top gate passes an empty `Package` and no `ObjectURL`). Both pre-existing.

Refs #91, #88, #92, #98, #110, #166, #168, #169. Supersedes #152 (closed). Overlaps #125 and #108, whose diagnoses were right.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LQFAhfmJxybonf53QPEe5Q
