### PR TITLE
fix(mcp): the dead return that has kept CI red since 25 August

### DIFF
--- a/agenda/2026-08-29-001-silence-as-an-answer.md
+++ b/agenda/2026-08-29-001-silence-as-an-answer.md
@@ -1,0 +1,236 @@
+# Silence, returned as an answer
+
+**Author:** vsp-bug-fix
+**Date:** 2026-08-29
+**Status:** planned, nothing started
+**Scope:** tier 1 — four defects and one stalled deploy. Target release v2.55.0.
+
+## The thing they have in common
+
+A session working in another repo spent a day on the question "why does the
+test runner not see the test class in this function group". It filed two
+reports. Reading them against our code turned up four defects, and three of the
+four are the same defect wearing different clothes:
+
+> The tool could not answer, so it answered anyway.
+
+- A file type it could not determine, determined forever, until the stack ran out.
+- An object type it does not know, silently asked about as a class of the same name.
+- A response it could not parse, reported as "no tests found".
+
+The fourth — `action="test"` ignoring its `target` — is a plain routing bug, but
+it belongs in the same release because it is what the reporting session hit
+first and it is what sent them looking in the wrong place.
+
+The report puts the cost better than a bug tracker would: *a test that never ran
+reports exactly what a passing test reports*. Every item below is an instance of
+that sentence.
+
+None of this needs a SAP system. All four are checked by unit tests, which
+matters because the systems in the reports are not ones this session may touch.
+
+---
+
+## 1. `ParseABAPFile` ↔ `parseFromContent` recurse until the stack ends
+
+**Where:** `pkg/adt/fileparser.go` — dispatcher at `:131`, detector at `:269`.
+
+**What happens.** The extension switch falls through to `case ext == ".abap"`
+and calls `parseFromContent`. The detector scans for `CLASS … DEFINITION`,
+`REPORT`, `PROGRAM`, `INTERFACE`, `FUNCTION-POOL` or `FUNCTION`, and on a hit
+calls `ParseABAPFile` back with the same path. Neither the path nor any state
+changes, so the recursion is unconditional. Reproduced in isolation:
+`fatal error: stack overflow`, exit 2, the two frames alternating for the whole
+dump.
+
+The comment on the recursive call reads `// Re-parse with known type`. The
+knowledge it describes is never carried anywhere.
+
+**Blast radius.** Every bare `.abap` file whose first meaningful line is one of
+those six statements — which is precisely the set the content branch exists to
+serve. `vsp deploy` is gone for all of them. A file starting with a comment is
+fine, because it reaches the end of the detector without matching, which is why
+this survived to a release.
+
+**Fix.** Split the dispatcher so the detector can hand its finding forward
+rather than re-entering:
+
+```go
+func ParseABAPFile(path string) (*ABAPFileInfo, error) {
+        return parseABAPFile(path, "")           // "" = detect from extension
+}
+func parseABAPFile(path string, hint CreatableObjectType) (*ABAPFileInfo, error)
+```
+
+The `.abap` arm calls the detector, the detector calls `parseABAPFile(path, t)`
+with the type it found, and the hinted call skips the extension switch. Any
+shape works as long as the argument changes between the two calls; today
+nothing does.
+
+**Test that proves it.** `fileparser_test.go` has twelve tests and **not one of
+them uses a bare `.abap` file** — the branch has never had coverage, which is
+the whole story of how this shipped. Add one case per detected statement, each
+asserting the resulting `ObjectType`, plus the comment-only file as the control
+that must still return a clean error.
+
+**Done when:** the six statements each parse to the right type, the control case
+still errors cleanly, and `go test ./pkg/adt/` passes with no new skips.
+
+---
+
+## 2. `graph --direction callers` asks about a class when it does not recognise the type
+
+**Where:** `cmd/vsp/cli_extra.go` — the `objURI` switch in `runGraph`, `:829`.
+
+**What happens.** `CLAS`, `PROG`, `INTF`, `FUGR` are mapped. Everything else
+hits `default:` and is built as `/sap/bc/adt/oo/classes/{name}`. So
+`vsp graph TABL ZDEMO_POSTINGS --direction callers` asks the where-used service
+about a *class* named `ZDEMO_POSTINGS`, gets 200 and an empty list, and prints
+"nobody calls this — or the name does not exist". Both halves of that sentence
+are true about the class it asked about. Neither is about the table.
+
+This is the same failure the `FUNC` case was fixed for, and the comment above
+that fix already says why it is bad: *a 404 that then looks like a call graph
+the system declined to give*. The `default` arm turns the same mistake into a
+200 and an empty list, which is worse, because there is nothing to notice.
+
+**Blast radius.** Every type not in the switch: `TABL`, `INCL`, `DDLS`, `TRAN`
+before its own resolution, `STRUCT`, `DTEL`, `MSAG`. A false negative delivered
+in the tool's ordinary voice.
+
+**Fix.** Delete the `default` fallback. Map the types we can address —
+`/sap/bc/adt/ddic/tables/{name}` is already formed in `pkg/adt/crud.go:952` and
+`/sap/bc/adt/programs/includes/{name}` in `pkg/adt/revisions.go:149`, so most of
+this is moving strings that exist. For anything still unmapped, refuse by name:
+name the type, say it is not addressable here, and list what is. An error is a
+worse user experience than an answer and a better one than a wrong answer.
+
+**Test that proves it.** A table test over the type→URI mapping, plus one case
+asserting that an unmapped type returns an error rather than a class URI.
+
+**Done when:** no input to `runGraph` can produce a URI for a different object
+than the one named.
+
+---
+
+## 3. `action="test"` is the only action that ignores its target
+
+**Where:** `internal/mcp/handlers_devtools.go:16–31`; message built in
+`internal/mcp/handlers_help.go:530`.
+
+**What happens.** The router reads `params.object_url` and nothing else. Given
+none, it returns `nil, false, nil`, the chain runs out, and the caller gets:
+
+```
+No handler found for action="test" target="CLAS ZCL_DEMO_THING".
+
+Valid actions: read, edit, create, delete, search, query, grep, test, analyze, …
+```
+
+`test` is in the list in the same breath as the claim that nothing handles it.
+Verified by calling `getUnhandledErrorMessage` directly — the target-bearing
+form fails identically to the bare one.
+
+The reporting session read this and concluded the action was unimplemented.
+Their proposed remedies were "wire it up" and "drop it from the list". Both are
+wrong: it is wired up, and it is the documented way to run tests.
+
+**Fix.** Two parts, and both are needed:
+
+1. Build the URL from `target` when `object_url` is absent, using the same
+   mapping the CLI has in `buildObjectURL` (`cmd/vsp/devops.go:3721`). That
+   mapping is about to be reworked for item 2 — share one table rather than
+   growing a third copy.
+2. Put `test` in `actionsNeedingTarget` (`handlers_help.go:520`) so a genuinely
+   under-specified call says what is missing instead of denying the action
+   exists.
+
+**Test that proves it.** Assert the message for `test` with no target names the
+missing input; assert the router claims `test` when given only a target. The
+existing `handlers_help_examples_test.go` executes every documented example —
+extend it so the target-only form is documented and therefore covered.
+
+**Done when:** `SAP(action="test", target="CLAS ZCL_DEMO_THING")` reaches the
+handler, and no reachable input produces "No handler found" for a live action.
+
+---
+
+## 4. `parseUnitTestResult` reports every unparsed document as "no tests"
+
+**Where:** `pkg/adt/devtools.go:693`, printed at `cmd/vsp/devops.go` in
+`runTest`.
+
+**What happens.** The response is unmarshalled into a struct keyed on
+`<program>` elements. Go's XML decoder ignores what it does not recognise, so
+any document without them — an error body under 200, a rejected URI, an
+exception node — produces zero classes and no error. `runTest` then prints
+`No test classes found.` So three different facts arrive as one sentence:
+
+- the object has no tests,
+- the URI was not one the service accepts,
+- the service said something we did not parse.
+
+This is the item that matters most and is easiest to skip, because unlike the
+other three it produces no crash and no obviously wrong output. It is also the
+one the whole reporting session was actually about.
+
+**Fix.** Distinguish the cases before formatting. If the body is non-empty and
+unmarshals to zero programs, keep it and say so — that the service answered,
+that nothing in the answer was a test program, and (behind `--verbose` or the
+existing `VSP_DEBUG_XML` path) what it did say. Check for an ADT exception
+element explicitly and surface its message. Reserve "no test classes found" for
+a well-formed run result that genuinely contains none.
+
+**Also, one line while in there.** The run payload hardcodes
+`<testDeterminationStrategy sameProgram="true" assignedTests="false"/>`
+(`devtools.go:~660`). It is a plausible reason a function group's include is not
+searched. Making it a flag costs nothing and turns an unanswerable question into
+an experiment someone can run in one command. Do not claim it is the cause —
+nobody has measured that.
+
+**Test that proves it.** Feed `parseUnitTestResult` three bodies: a real run
+result, an ADT exception, and a well-formed document with no programs. Assert
+three distinguishable outcomes.
+
+**Done when:** a caller can tell "ran, found nothing" from "did not run".
+
+---
+
+## 5. Redeploy `C:\bin` to v2.54.0
+
+Not code. `make deploy-windows` has been blocked since the release by running
+`vsp.exe` processes holding the file, so the released version is on GitHub and
+not on the machine that uses it. Do this first if the processes are closed, or
+last; it does not interact with anything above.
+
+---
+
+## Order, and why
+
+**1 → 2 → 3 → 4.** One and two are independent and are the cheapest; doing them
+first means the release has value even if it is cut short. Three depends on the
+type→URI mapping that item two is already reworking, so it wants to come after.
+Four is last because it is the largest and the only one where the fix shape is a
+judgement call rather than a correction.
+
+Items two and three both touch object-type→URI mapping and there are now three
+copies of it (`runGraph`, `buildObjectURL`, `handlers_devtools`). Unifying them
+is tempting and is not in this sprint — say so in the commit rather than
+quietly leaving the reader to wonder.
+
+## What this sprint does not settle
+
+Whether the ADT test runner can see a `FOR TESTING` class inside a function
+group's own include. That needs a system and a SAP GUI trace, and neither is
+available from here. Item 4 does not answer the question; it makes the tool stop
+pretending it already did.
+
+## Release
+
+v2.55.0 when items 1–4 are in. The honest headline is not "bug fixes" — it is
+that the tool stopped presenting silence as an answer.
+
+The sweep gate applies as it did for v2.52.0: the release gate must cover the
+changed code. Items 1–4 are all unit-testable, so the coverage here is `go test`
+rather than new sweep probes; the `SAP()` surface changes only in item 3, which
+the examples test already walks.

--- a/agenda/AGENDA.md
+++ b/agenda/AGENDA.md
@@ -18,6 +18,91 @@ two worktrees, which is why it says so.
 > — state, direction and where to resume. This board carries the items; that
 > file carries the shape and the order.
 
+## Raised — 2026-08-29 — from outside this repo
+
+Two bug reports and one feature request arrived from a session working in
+another repo (`docs/bugs/` there, both filed against v2.54.0 / `9b8789d`).
+Their identifiers are live, so they stay out of this file; the findings below
+are checked against our own code and named with synthetic objects.
+
+### Confirmed, reproducible without SAP
+
+**`ParseABAPFile` and `parseFromContent` recurse into each other forever.**
+`pkg/adt/fileparser.go` — the dispatcher falls to `ext == ".abap"` and calls
+the content detector, which on `CLASS … DEFINITION`, `REPORT`, `PROGRAM`,
+`INTERFACE`, `FUNCTION-POOL` or `FUNCTION` calls the dispatcher back with the
+same path. Nothing changes between iterations. Reproduced in an isolated test:
+`fatal error: stack overflow`, frames alternating `:131 ↔ :269`. Every bare
+`.abap` file the content branch exists to serve takes the binary down, so
+`vsp deploy` is gone for that whole class of input. The detector needs to
+carry the type it found instead of re-entering the dispatcher.
+
+### Reported as "the MCP tool lists an action it cannot dispatch" — it is worse than that
+
+`test` is dispatched (`handlers_devtools.go`), but only from
+`params.object_url`. It is the one action that ignores its `target`
+altogether, so `SAP(action="test", target="CLAS ZCL_DEMO_THING")` — the shape
+every other action takes — falls through the whole router chain and comes back
+`No handler found for action="test"` with `test` printed in the valid-actions
+line right below. So neither of the two remedies the report proposes is right:
+it is wired up, and it must not be dropped. It should build the URL from the
+target the way `buildObjectURL` does for the CLI, and join
+`actionsNeedingTarget` so the message names what is missing.
+
+### Unknown params are dropped in silence
+
+`params={"function_group": …}` where the documented key is `parent` reads back
+as empty, and the failure then says *give its group explicitly* to a caller who
+did. Rejecting unknown keys turns a misleading error into an obvious one.
+
+### `vsp test` on a function group: the client half, answered
+
+`buildObjectURL` (`cmd/vsp/devops.go`) sends `FUGR` to
+`/sap/bc/adt/functions/groups/{name}` — correct. But a function group's main
+program and its includes both go to `/sap/bc/adt/programs/programs/{name}`,
+which is the wrong resource kind for either: an include lives under
+`/sap/bc/adt/programs/includes/{name}`, and `INCL` is not a case in that switch
+at all. Two of the three addressing attempts in the report were never going to
+work regardless of what the backend does; only the `FUGR` one is evidence.
+
+Two things to try before blaming the server, both client-side:
+`<testDeterminationStrategy sameProgram="true" assignedTests="false"/>` is
+hardcoded in the run payload (`pkg/adt/devtools.go`), and
+`parseUnitTestResult` unmarshals into a struct keyed on `<program>` elements —
+any document without them yields zero classes and the CLI prints
+`No test classes found.` A rejected URI, an error body under 200, and an object
+with genuinely no tests are one sentence. That is our own instance of the thing
+the report is complaining about: a test that never ran reports what a passing
+test reports.
+
+Whether the backend finds a `FOR TESTING` class in a function group's own
+include is still open and needs a system.
+
+## Backlog — 2026-08-29 — `who-touches TABL`
+
+**Asked for:** before changing a table, the full perimeter of what touches it,
+split by access — read vs `INSERT`/`UPDATE`/`MODIFY`/`DELETE` — including AMDP
+bodies and CDS views layered over it. Grep finds the easy half and misses
+dynamic SQL, AMDP and views.
+
+**Today: nothing answers this, and the nearest command answers it wrongly.**
+`vsp graph <type> <name> --direction callers` has no `TABL` case; the `default`
+arm builds `/sap/bc/adt/oo/classes/{name}`, so a table name is asked for as a
+class of the same name. The where-used list then returns empty with a 200 and
+prints "nobody calls this — or the name does not exist", which is true of the
+class it asked about and says nothing about the table. Same failure family as
+the `FUNC` case fixed earlier in that switch. `effects` runs unit→world and
+`examples` takes FUNC/CLAS/INTF/PROG only.
+
+**The parts already exist**, which makes this small:
+`client.WhereUsed` posts to `/sap/bc/adt/repository/informationsystem/usageReferences`
+and takes any URI; `pkg/adt/crud.go` already forms `/sap/bc/adt/ddic/tables/{name}`;
+and `graph.ExtractEffects` returns `ReadsDB` / `WritesDB` per unit. Inverting
+those over a perimeter is the feature. Two notes: `WritesDB` lumps all four
+write statements together, so an R/I/U/D split means widening it; and
+`ExtractEffects` has had no caller since it was written — this would be its
+first.
+
 ## Landed — 2026-08-27 — v2.54.0
 
 **Defaults chosen for a terminal were being paid for in a context window.**

--- a/agenda/AGENDA.md
+++ b/agenda/AGENDA.md
@@ -18,6 +18,11 @@ two worktrees, which is why it says so.
 > — state, direction and where to resume. This board carries the items; that
 > file carries the shape and the order.
 
+> **Start here for the next release:**
+> [agenda/2026-08-29-001-silence-as-an-answer.md](2026-08-29-001-silence-as-an-answer.md)
+> — the v2.55.0 sprint. Four defects that are one defect: the tool could not
+> answer, so it answered anyway. Ordered, with the test that proves each.
+
 ## Raised — 2026-08-29 — from outside this repo
 
 Two bug reports and one feature request arrived from a session working in
@@ -78,30 +83,94 @@ test reports.
 Whether the backend finds a `FOR TESTING` class in a function group's own
 include is still open and needs a system.
 
-## Backlog — 2026-08-29 — `who-touches TABL`
+## Backlog — 2026-08-29 — everything tier 1 does not cover
 
-**Asked for:** before changing a table, the full perimeter of what touches it,
-split by access — read vs `INSERT`/`UPDATE`/`MODIFY`/`DELETE` — including AMDP
-bodies and CDS views layered over it. Grep finds the easy half and misses
-dynamic SQL, AMDP and views.
+Tier 1 is the sprint linked at the top of this file and is not repeated here.
+What follows is ordered by return on the work, not by age. Two of these need a
+decision from Alice before anyone starts; both say so.
 
-**Today: nothing answers this, and the nearest command answers it wrongly.**
-`vsp graph <type> <name> --direction callers` has no `TABL` case; the `default`
-arm builds `/sap/bc/adt/oo/classes/{name}`, so a table name is asked for as a
-class of the same name. The where-used list then returns empty with a 200 and
-prints "nobody calls this — or the name does not exist", which is true of the
-class it asked about and says nothing about the table. Same failure family as
-the `FUNC` case fixed earlier in that switch. `effects` runs unit→world and
-`examples` takes FUNC/CLAS/INTF/PROG only.
+### `who-touches TABL <name>` — the only item with an outside caller
 
-**The parts already exist**, which makes this small:
-`client.WhereUsed` posts to `/sap/bc/adt/repository/informationsystem/usageReferences`
-and takes any URI; `pkg/adt/crud.go` already forms `/sap/bc/adt/ddic/tables/{name}`;
-and `graph.ExtractEffects` returns `ReadsDB` / `WritesDB` per unit. Inverting
-those over a perimeter is the feature. Two notes: `WritesDB` lumps all four
-write statements together, so an R/I/U/D split means widening it; and
-`ExtractEffects` has had no caller since it was written — this would be its
-first.
+Asked for by a session about to add fields to a posting table: before changing
+it, the full perimeter of what touches it, split by access — read versus
+`INSERT`/`UPDATE`/`MODIFY`/`DELETE` — including AMDP bodies and CDS views
+layered over it. Grep gets the easy half and misses dynamic SQL, AMDP and views
+that reach the table through layers.
+
+Nothing answers this today, and `vsp graph --direction callers` answers it
+*wrongly* — see tier 1 item 2, which is a prerequisite rather than a separate
+concern. Fix that first or this feature inherits the same lie.
+
+The parts are already in the tree, which is what makes this a feature and not a
+subsystem:
+
+- `client.WhereUsed` posts to
+  `/sap/bc/adt/repository/informationsystem/usageReferences` and accepts any
+  URI, so a table URI needs no new plumbing;
+- `pkg/adt/crud.go:952` already forms `/sap/bc/adt/ddic/tables/{name}`;
+- `graph.ExtractEffects` returns `ReadsDB` / `WritesDB` per unit.
+
+Perimeter from where-used, access kind from parsing each hit. Two things to
+settle before starting: `WritesDB` lumps all four write statements together, so
+the requested R/I/U/D split means widening `EffectInfo`; and `ExtractEffects`
+has had no caller since it was written, so this would be its first — which also
+retires the line in CLAUDE.md calling it "Library, not feature".
+
+Worth asking the requester whether R/W is enough before building R/I/U/D.
+
+### Reject unknown keys in `params` — needs a decision, not just work
+
+`params={"function_group": …}` where the documented key is `parent` reads back
+empty, and the failure then tells the caller to *give its group explicitly* when
+they did exactly that under a name the tool does not know. Every handler using
+`getStringParam` has this shape.
+
+Technically small. But it changes the contract: today an unknown key is free,
+after this it is an error, and calls that work now would start failing. That is
+Alice's call, not a maintainer's.
+
+### The root MCP-server command ignores `-s <system>`
+
+`vsp -s a4h` works for every CLI subcommand and not for the server itself,
+which reads only `SAP_URL` / `SAP_USER` / … from the environment. Found while
+releasing v2.54.0, flagged, not changed. Small, and unpleasant to discover by
+watching a server connect to the wrong system.
+
+### `analyze type=call_graph` defaults to `callers`
+
+`handleGetCallGraph` is a deliberate `direction`-parameterised entry, so
+`callers` and `call_graph` returning byte-identical output is by design and not
+a defect. The default is still arguably wrong — `both` is what someone asking
+for a *graph* means. One-line change, needs agreement that it is an improvement
+and not a break.
+
+### D010INC — the load graph
+
+Still two constants, `EdgeLoads` and `SourceD010INC`. It is the one genuinely
+novel source in the original graph design, and it has been pending long enough
+that CLAUDE.md had to be corrected for understating the package around it. This
+is a sprint of its own, not an afternoon; it is listed here so it is not
+mistaken for small.
+
+### `i18n write_message_texts` is unverified
+
+The sweep reaches it; nothing proves it writes. Needs a scratch message class,
+and the client has no MSAG creation path, so the verification costs more than
+the capability did. Named rather than quietly counted as working.
+
+### `read CLAS` returns 23,653 bytes
+
+Measured during the v2.54.0 output-size work and deliberately left alone. The
+answer here is not truncation — it is `pkg/ctxcomp` spending its budget better.
+Anything else trades a large honest answer for a small misleading one.
+
+### Three copies of object-type → URI
+
+`runGraph` (`cmd/vsp/cli_extra.go`), `buildObjectURL` (`cmd/vsp/devops.go`) and
+the MCP test router each map object types to ADT URIs, and they disagree about
+which types exist. Tier 1 touches two of the three and deliberately does not
+unify them, because a refactor inside a bug-fix release hides which change
+caused what. Do it after v2.55.0 ships, as its own commit.
 
 ## Landed — 2026-08-27 — v2.54.0
 

--- a/internal/mcp/handlers_grep.go
+++ b/internal/mcp/handlers_grep.go
@@ -48,7 +48,6 @@ func (s *Server) routeGrepAction(ctx context.Context, action, objectType, object
 		[]string{"package_name (or package)", "object_url (or object)", "packages", "object_urls"},
 		`SAP(action="grep", params={"pattern": "SELECT", "package": "$TMP"})
   SAP(action="grep", params={"pattern": "TODO", "object_url": "/sap/bc/adt/oo/classes/zcl_demo"})`), true, nil
-	return nil, false, nil
 }
 
 // --- Grep/Search Handlers ---


### PR DESCRIPTION
One line. It unblocks every other pull request in the repo.

`routeGrepAction` (`internal/mcp/handlers_grep.go`) ends with `return needParams(...), true, nil`, followed by an unreachable `return nil, false, nil`. Harmless at runtime — and `go vet` refuses it.

The consequence is not local. **Every CI run on `main` has failed since `3a84261` (2026-08-24)**, and every open PR inherits the failure:

- #164, #126, #121 are marked UNSTABLE, and this is the *only* failing check on each.
- #167 fails its only check for this and nothing else.

None of those PRs introduced it. They are built on a branch where `go vet` has never passed, so their red is not theirs.

After this: `go vet ./...` is clean, `go build ./...` and `go test ./...` unchanged and green.

Worth landing before the merge train, otherwise every merge lands on a red main and the next contributor reads their own PR as broken.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LQFAhfmJxybonf53QPEe5Q
