### PR TITLE
style(adt): gofmt the two lines #128 arrived with

### DIFF
--- a/pkg/adt/browser_auth.go
+++ b/pkg/adt/browser_auth.go
@@ -121,13 +121,13 @@ func BrowserLogin(ctx context.Context, sapURL string, insecure bool, timeout tim
 	adtURL.Path = "/sap/bc/adt/"
 	adtURL.RawQuery = ""
 	adtURL.Fragment = ""
-	// if a valid sap-Client is provided, add it as a query parameter to ensure cookies are set for the correct client. 
+	// if a valid sap-Client is provided, add it as a query parameter to ensure cookies are set for the correct client.
 	matched, _ := regexp.MatchString(`^[0-9]{3}$`, sapClient)
 	if matched {
 		q := adtURL.Query()
 		q.Set("sap-client", sapClient)
 		adtURL.RawQuery = q.Encode()
-	} 
+	}
 	targetURL := adtURL.String()
 
 	// Create a headed (non-headless) browser context


### PR DESCRIPTION
Trailing whitespace on a comment and a closing brace in `pkg/adt/browser_auth.go`, introduced by #128 (whose actual fix is correct and wanted). `ci.yml` does not catch it — it runs build/vet/test, and the lint job is advisory.

Only `browser_auth.go` is touched. `browser_auth_test.go` was already unformatted before that merge and is left alone; the repo has 72 such files and reformatting them is its own change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LQFAhfmJxybonf53QPEe5Q