### PR TITLE
fix(adt): the transport parsers each knew one shape, and neither was the tree

### DIFF
--- a/cmd/vsp/devops.go
+++ b/cmd/vsp/devops.go
@@ -556,7 +556,7 @@ func init() {
 	deployCmd.Flags().String("transport", "", "Transport request number")
 
 	// Transport list flags
-	transportListCmd.Flags().String("user", "", "Filter by user (default: current user)")
+	transportListCmd.Flags().String("user", "", "Filter by user (default: current user, '*' for every user)")
 
 	// Install flags
 	installZadtVspCmd.Flags().String("package", "$ZADT_VSP", "Target package for ZADT_VSP objects")

--- a/internal/mcp/tools_register.go
+++ b/internal/mcp/tools_register.go
@@ -1203,7 +1203,7 @@ func (s *Server) registerCRUDTools(shouldRegister func(string) bool) {
 			mcp.WithDescription("Get all transport requests for a user (requires --enable-transports flag). Returns both workbench and customizing requests grouped by target system."),
 			mcp.WithString("user_name",
 				mcp.Required(),
-				mcp.Description("SAP user name (will be converted to uppercase)"),
+				mcp.Description("SAP user name (will be converted to uppercase), or '*' for every user"),
 			),
 		), s.handleGetUserTransports)
 	}

--- a/pkg/adt/transport.go
+++ b/pkg/adt/transport.go
@@ -83,114 +83,99 @@ func (c *Client) GetUserTransports(ctx context.Context, userName string) (*UserT
 		return nil, fmt.Errorf("get user transports failed: %w", err)
 	}
 
-	return parseUserTransports(resp.Body)
+	transports, err := parseUserTransports(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(transports.Workbench) > 0 || len(transports.Customizing) > 0 {
+		return transports, nil
+	}
+
+	// Fallback: the same E070/E07T query ListTransports drops to. Without it,
+	// the two tools disagreed on the same system and the same user — one
+	// answered with transports and this one with a well-formed, plausible
+	// "none", which reads as "nothing to release" rather than as a failure
+	// (#111).
+	return c.userTransportsViaSQL(ctx, userName)
 }
 
-func parseUserTransports(data []byte) (*UserTransports, error) {
-	// Strip namespace prefixes
-	xmlStr := string(data)
-	xmlStr = strings.ReplaceAll(xmlStr, "tm:", "")
-	xmlStr = strings.ReplaceAll(xmlStr, "atom:", "")
-
-	type transportObject struct {
-		PGMID   string `xml:"pgmid,attr"`
-		Type    string `xml:"type,attr"`
-		Name    string `xml:"name,attr"`
-		ObjInfo string `xml:"obj_info,attr"`
-	}
-	type task struct {
-		Number  string            `xml:"number,attr"`
-		Owner   string            `xml:"owner,attr"`
-		Desc    string            `xml:"desc,attr"`
-		Status  string            `xml:"status,attr"`
-		Objects []transportObject `xml:"abap_object"`
-	}
-	type request struct {
-		Number string `xml:"number,attr"`
-		Owner  string `xml:"owner,attr"`
-		Desc   string `xml:"desc,attr"`
-		Status string `xml:"status,attr"`
-		Tasks  []task `xml:"task"`
-	}
-	type target struct {
-		Name      string    `xml:"name,attr"`
-		Modifiable struct {
-			Requests []request `xml:"request"`
-		} `xml:"modifiable"`
-		Released struct {
-			Requests []request `xml:"request"`
-		} `xml:"released"`
-	}
-	type root struct {
-		Workbench struct {
-			Targets []target `xml:"target"`
-		} `xml:"workbench"`
-		Customizing struct {
-			Targets []target `xml:"target"`
-		} `xml:"customizing"`
-	}
-
-	var resp root
-	if err := xml.Unmarshal([]byte(xmlStr), &resp); err != nil {
-		return nil, fmt.Errorf("parsing transport list: %w", err)
-	}
-
-	convertRequests := func(reqs []request, targetName string) []TransportRequest {
-		var result []TransportRequest
-		for _, r := range reqs {
-			tr := TransportRequest{
-				Number:      r.Number,
-				Owner:       r.Owner,
-				Description: r.Desc,
-				Status:      r.Status,
-				Target:      targetName,
-			}
-			for _, t := range r.Tasks {
-				task := TransportTask{
-					Number:      t.Number,
-					Owner:       t.Owner,
-					Description: t.Desc,
-					Status:      t.Status,
-				}
-				for _, o := range t.Objects {
-					task.Objects = append(task.Objects, TransportObject{
-						PGMID:   o.PGMID,
-						Type:    o.Type,
-						Name:    o.Name,
-						ObjInfo: o.ObjInfo,
-					})
-				}
-				tr.Tasks = append(tr.Tasks, task)
-			}
-			result = append(result, tr)
-		}
-		return result
+// userTransportsViaSQL groups the E070/E07T fallback rows the way the ADT tree
+// would have. A failing query is already swallowed inside listTransportsViaSQL;
+// what comes back as an error here is a caller mistake — no user name at all,
+// or one that is not a user name — and that is worth saying out loud rather
+// than answering with an empty list a second time.
+func (c *Client) userTransportsViaSQL(ctx context.Context, user string) (*UserTransports, error) {
+	rows, err := c.listTransportsViaSQL(ctx, user)
+	if err != nil {
+		return nil, err
 	}
 
 	result := &UserTransports{}
-
-	// Process workbench targets
-	for _, t := range resp.Workbench.Targets {
-		reqs := convertRequests(t.Modifiable.Requests, t.Name)
-		for i := range reqs {
-			reqs[i].Type = "workbench"
+	for _, row := range rows {
+		tr := TransportRequest{
+			Number:      row.Number,
+			Owner:       row.Owner,
+			Description: row.Description,
+			Status:      row.Status,
+			Target:      row.Target,
 		}
-		result.Workbench = append(result.Workbench, reqs...)
-
-		releasedReqs := convertRequests(t.Released.Requests, t.Name)
-		for i := range releasedReqs {
-			releasedReqs[i].Type = "workbench"
+		if row.Type == "W" {
+			tr.Type = "customizing"
+			result.Customizing = append(result.Customizing, tr)
+		} else {
+			tr.Type = "workbench"
+			result.Workbench = append(result.Workbench, tr)
 		}
-		result.Workbench = append(result.Workbench, releasedReqs...)
 	}
 
-	// Process customizing targets
-	for _, t := range resp.Customizing.Targets {
-		reqs := convertRequests(t.Modifiable.Requests, t.Name)
-		for i := range reqs {
-			reqs[i].Type = "customizing"
+	return result, nil
+}
+
+func parseUserTransports(data []byte) (*UserTransports, error) {
+	requests, err := parseCTSRequests(data)
+	if err != nil {
+		return nil, err
+	}
+
+	result := &UserTransports{}
+	for _, r := range requests {
+		r.fillFromStructure()
+
+		tr := TransportRequest{
+			Number:      r.Number,
+			Owner:       r.Owner,
+			Description: r.Desc,
+			Status:      r.Status,
+			Target:      r.Target,
 		}
-		result.Customizing = append(result.Customizing, reqs...)
+		for _, t := range r.Tasks {
+			task := TransportTask{
+				Number:      t.Number,
+				Owner:       t.Owner,
+				Description: t.Desc,
+				Status:      t.Status,
+			}
+			for _, o := range t.Objects {
+				task.Objects = append(task.Objects, TransportObject{
+					PGMID:   o.PgmID,
+					Type:    o.Type,
+					Name:    o.Name,
+					ObjInfo: o.Info,
+				})
+			}
+			tr.Tasks = append(tr.Tasks, task)
+		}
+
+		// A document that separates workbench from customizing says so
+		// structurally; one that does not carries it in tm:type (K/W).
+		if r.Section == "customizing" || (r.Section == "" && r.Type == "W") {
+			tr.Type = "customizing"
+			result.Customizing = append(result.Customizing, tr)
+		} else {
+			tr.Type = "workbench"
+			result.Workbench = append(result.Workbench, tr)
+		}
 	}
 
 	return result, nil
@@ -457,19 +442,73 @@ func (c *Client) ListTransports(ctx context.Context, user string) ([]TransportSu
 	return c.listTransportsViaSQL(ctx, user)
 }
 
+// as4userPredicate builds the E070~AS4USER condition for the fallback query,
+// or "" when every user is wanted.
+//
+// Eclipse ADT spells "all users" as '*', and so does this tool's own parameter
+// documentation. It reached the query as a literal, and AS4USER = '*' matches
+// no row, so a wildcard listing looked like an empty system (#140). A '*' now
+// drops the predicate entirely, and a '*' inside a name becomes a LIKE prefix
+// the way ADT treats it.
+//
+// The name is interpolated into SQL, so it is also the one place a caller's
+// string reaches the database: anything that is not a plausible SAP user name
+// is refused rather than quoted, since a name that could close the literal has
+// no legitimate reading.
+func as4userPredicate(user string) (string, error) {
+	name := strings.ToUpper(strings.TrimSpace(user))
+
+	if name == "" {
+		return "", fmt.Errorf("no user to list transports for: pass a user name, " +
+			"or '*' for every user (the connection does not carry one — a browser " +
+			"SSO session has no configured user name)")
+	}
+
+	if name == "*" {
+		return "", nil
+	}
+
+	for _, r := range name {
+		switch {
+		case r >= 'A' && r <= 'Z', r >= '0' && r <= '9':
+		case r == '_', r == '-', r == '.', r == '/', r == '*':
+		default:
+			return "", fmt.Errorf("invalid SAP user name %q: expected letters, digits, "+
+				"and _ - . / or '*' for every user", user)
+		}
+	}
+
+	if strings.Contains(name, "*") {
+		return "e070~AS4USER LIKE '" + strings.ReplaceAll(name, "*", "%") + "'", nil
+	}
+
+	return "e070~AS4USER = '" + name + "'", nil
+}
+
 // listTransportsViaSQL queries E070/E07T tables to get modifiable transports.
 // Used as fallback when ADT API returns empty (common on sandbox systems).
 func (c *Client) listTransportsViaSQL(ctx context.Context, user string) ([]TransportSummary, error) {
+	// '*' is the wildcard Eclipse ADT uses for "every user". It was being
+	// compared literally (AS4USER = '*'), which no row matches, so the wildcard
+	// answered "no transports found" instead of everyone's (#140).
+	predicate, err := as4userPredicate(user)
+	if err != nil {
+		return nil, err
+	}
+
 	// Query modifiable workbench requests (K) for the user
 	// TRFUNCTION: K=Workbench request, W=Customizing request, S=Task
 	// TRSTATUS: D=Modifiable, R=Released, N=Released (import started)
+	conditions := []string{"e070~TRSTATUS = 'D'", "e070~TRFUNCTION IN ('K', 'W')"}
+	if predicate != "" {
+		conditions = append([]string{predicate}, conditions...)
+	}
+
 	query := `SELECT e070~TRKORR, e070~TRFUNCTION, e070~TRSTATUS, e070~TARSYSTEM,
 		e070~AS4USER, e070~AS4DATE, e070~AS4TIME, e07t~AS4TEXT
 		FROM E070 AS e070
 		LEFT OUTER JOIN E07T AS e07t ON e070~TRKORR = e07t~TRKORR AND e07t~LANGU = 'E'
-		WHERE e070~AS4USER = '` + strings.ToUpper(user) + `'
-		AND e070~TRSTATUS = 'D'
-		AND e070~TRFUNCTION IN ('K', 'W')
+		WHERE ` + strings.Join(conditions, "\n\t\tAND ") + `
 		ORDER BY e070~TRKORR DESCENDING`
 
 	result, err := c.RunQuery(ctx, query, 100)
@@ -532,45 +571,36 @@ func getString(row map[string]interface{}, key string) string {
 	return ""
 }
 
+// parseTransportList extracts the transport summaries from a CTS listing.
+//
+// Requests the server placed in a released bucket are skipped: ListTransports
+// is documented to return modifiable requests, and the E070 fallback below
+// filters TRSTATUS = 'D'. A flat document, which carries no bucket, is
+// returned whole.
 func parseTransportList(data []byte) ([]TransportSummary, error) {
-	// Strip namespace prefixes
-	xmlStr := string(data)
-	xmlStr = strings.ReplaceAll(xmlStr, "tm:", "")
-
-	type request struct {
-		Number      string `xml:"number,attr"`
-		Owner       string `xml:"owner,attr"`
-		Desc        string `xml:"desc,attr"`
-		Type        string `xml:"type,attr"`
-		Status      string `xml:"status,attr"`
-		StatusText  string `xml:"status_text,attr"`
-		Target      string `xml:"target,attr"`
-		TargetDesc  string `xml:"target_desc,attr"`
-		LastChanged string `xml:"lastchanged_timestamp,attr"`
-		Client      string `xml:"source_client,attr"`
-	}
-	type root struct {
-		Requests []request `xml:"request"`
-	}
-
-	var resp root
-	if err := xml.Unmarshal([]byte(xmlStr), &resp); err != nil {
-		return nil, fmt.Errorf("parsing transport list: %w", err)
+	requests, err := parseCTSRequests(data)
+	if err != nil {
+		return nil, err
 	}
 
 	var transports []TransportSummary
-	for _, req := range resp.Requests {
+	for _, r := range requests {
+		if r.isReleased() {
+			continue
+		}
+		r.fillFromStructure()
+
 		transports = append(transports, TransportSummary{
-			Number:      req.Number,
-			Owner:       req.Owner,
-			Description: req.Desc,
-			Type:        req.Type,
-			Status:      req.Status,
-			StatusText:  req.StatusText,
-			Target:      req.Target,
-			TargetDesc:  req.TargetDesc,
-			ChangedAt:   req.LastChanged,
-			Client:      req.Client,
+			Number:      r.Number,
+			Owner:       r.Owner,
+			Description: r.Desc,
+			Type:        r.Type,
+			Status:      r.Status,
+			StatusText:  r.StatusText,
+			Target:      r.Target,
+			TargetDesc:  r.TargetDesc,
+			ChangedAt:   r.LastChanged,
+			Client:      r.Client,
 		})
 	}
 

--- a/pkg/adt/transport_tree.go
+++ b/pkg/adt/transport_tree.go
@@ -1,0 +1,238 @@
+package adt
+
+import (
+	"encoding/xml"
+	"fmt"
+	"strings"
+)
+
+// A CTS transport listing does not have one shape.
+//
+// `/sap/bc/adt/cts/transportrequests` answers with a tm:root whose depth
+// depends on the request and on the system: with transport targets it nests
+// requests under tm:workbench > tm:target > tm:modifiable, without targets it
+// drops the tm:target level, and a single-request document puts tm:request
+// straight under tm:root. The two hand-written parsers each hardcoded one of
+// those three, and encoding/xml answers a path that does not match with an
+// empty struct and a nil error — so the mismatch surfaced as "no transports
+// found" rather than as a parse failure (#111, #140).
+//
+// Everything below navigates the document instead of asserting its shape:
+// find every tm:request wherever it sits, and remember which section
+// (workbench/customizing), which target and which bucket (modifiable/released)
+// it was nested in. A shape we have not seen still yields its requests; it
+// only loses the grouping the extra levels would have carried.
+
+// ctsNamespace is the namespace CTS elements live in. Attribute lookups prefer
+// it, because a tm:request can also carry attributes from other namespaces
+// (adtcore:name, for one) whose local part collides with a tm one.
+const ctsNamespace = "http://www.sap.com/cts/adt/tm"
+
+// ctsNode is a namespace-agnostic view of any element in a CTS response.
+// Element and attribute names are read through their local part, so the
+// document parses whether or not the tm: prefix is declared.
+type ctsNode struct {
+	XMLName xml.Name
+	Attrs   []xml.Attr `xml:",any,attr"`
+	Nodes   []ctsNode  `xml:",any"`
+}
+
+// attr returns the value of an attribute by local name, preferring the CTS
+// namespace over any other when both are present.
+func (n ctsNode) attr(name string) string {
+	fallback := ""
+	for _, a := range n.Attrs {
+		if a.Name.Local != name {
+			continue
+		}
+		if a.Name.Space == ctsNamespace || a.Name.Space == "tm" || a.Name.Space == "" {
+			return a.Value
+		}
+		if fallback == "" {
+			fallback = a.Value
+		}
+	}
+	return fallback
+}
+
+// ctsObject is an abap_object entry inside a request or task.
+type ctsObject struct {
+	PgmID    string
+	Type     string
+	Name     string
+	WBType   string
+	Info     string
+	Position string
+}
+
+// ctsRequest is one tm:request (or tm:task, which carries the same attributes)
+// together with the position it was found at.
+type ctsRequest struct {
+	Number      string
+	Parent      string
+	Owner       string
+	Desc        string
+	Type        string
+	Status      string
+	StatusText  string
+	Target      string
+	TargetDesc  string
+	Client      string
+	LastChanged string
+
+	// Section is "workbench", "customizing", or "" when the document does not
+	// separate the two. Bucket is "modifiable", "released", or "".
+	Section string
+	Bucket  string
+
+	Tasks   []ctsRequest
+	Objects []ctsObject
+}
+
+// ctsScope carries the levels a request was nested in down the walk.
+type ctsScope struct {
+	section    string
+	target     string
+	targetDesc string
+	bucket     string
+}
+
+// parseCTSRequests returns every tm:request in a CTS document, at whatever
+// depth the server put it.
+func parseCTSRequests(data []byte) ([]ctsRequest, error) {
+	var root ctsNode
+	if err := xml.Unmarshal(data, &root); err != nil {
+		return nil, fmt.Errorf("parsing transport list: %w", err)
+	}
+
+	var out []ctsRequest
+	collectCTSRequests(root, ctsScope{}, &out)
+	return out, nil
+}
+
+func collectCTSRequests(n ctsNode, sc ctsScope, out *[]ctsRequest) {
+	switch strings.ToLower(n.XMLName.Local) {
+	case "workbench", "customizing":
+		sc.section = strings.ToLower(n.XMLName.Local)
+	case "target":
+		if v := n.attr("name"); v != "" {
+			sc.target = v
+		}
+		if v := n.attr("desc"); v != "" {
+			sc.targetDesc = v
+		}
+	case "modifiable":
+		sc.bucket = "modifiable"
+	case "released":
+		sc.bucket = "released"
+	case "request":
+		*out = append(*out, newCTSRequest(n, sc))
+		// Tasks and objects belong to this request; nothing below a request is
+		// another request.
+		return
+	}
+
+	for _, c := range n.Nodes {
+		collectCTSRequests(c, sc, out)
+	}
+}
+
+// newCTSRequest reads one request (or task) element and its children.
+func newCTSRequest(n ctsNode, sc ctsScope) ctsRequest {
+	r := ctsRequest{
+		Number:      n.attr("number"),
+		Parent:      n.attr("parent"),
+		Owner:       n.attr("owner"),
+		Desc:        n.attr("desc"),
+		Type:        n.attr("type"),
+		Status:      n.attr("status"),
+		StatusText:  n.attr("status_text"),
+		Target:      n.attr("target"),
+		TargetDesc:  n.attr("target_desc"),
+		Client:      n.attr("source_client"),
+		LastChanged: n.attr("lastchanged_timestamp"),
+		Section:     sc.section,
+		Bucket:      sc.bucket,
+	}
+
+	// The enclosing tm:target names the target when the request element does
+	// not carry one itself.
+	if r.Target == "" {
+		r.Target = sc.target
+	}
+	if r.TargetDesc == "" {
+		r.TargetDesc = sc.targetDesc
+	}
+
+	for _, c := range n.Nodes {
+		switch strings.ToLower(c.XMLName.Local) {
+		case "task":
+			r.Tasks = append(r.Tasks, newCTSRequest(c, sc))
+		case "abap_object":
+			r.Objects = append(r.Objects, newCTSObject(c))
+		default:
+			// Wrappers such as tm:abap_objects or tm:tasks: look one level in
+			// rather than requiring the element to exist.
+			for _, g := range c.Nodes {
+				switch strings.ToLower(g.XMLName.Local) {
+				case "task":
+					r.Tasks = append(r.Tasks, newCTSRequest(g, sc))
+				case "abap_object":
+					r.Objects = append(r.Objects, newCTSObject(g))
+				}
+			}
+		}
+	}
+
+	return r
+}
+
+func newCTSObject(n ctsNode) ctsObject {
+	return ctsObject{
+		PgmID:    n.attr("pgmid"),
+		Type:     n.attr("type"),
+		Name:     n.attr("name"),
+		WBType:   n.attr("wbtype"),
+		Info:     firstNonEmpty(n.attr("obj_info"), n.attr("obj_desc")),
+		Position: n.attr("position"),
+	}
+}
+
+// fillFromStructure supplies type and status from the position a request was
+// found at, for servers that carry them as levels rather than as attributes.
+func (r *ctsRequest) fillFromStructure() {
+	if r.Type == "" {
+		switch r.Section {
+		case "workbench":
+			r.Type = "K"
+		case "customizing":
+			r.Type = "W"
+		}
+	}
+	if r.Status == "" {
+		switch r.Bucket {
+		case "modifiable":
+			r.Status = "D"
+		case "released":
+			r.Status = "R"
+		}
+	}
+	if r.StatusText == "" {
+		switch r.Status {
+		case "D":
+			r.StatusText = "Modifiable"
+		case "R":
+			r.StatusText = "Released"
+		case "N":
+			r.StatusText = "Released (import started)"
+		}
+	}
+}
+
+// isReleased reports whether the server placed this request in a released
+// bucket. Only the structure counts: a status attribute alone is not enough,
+// because a released request reachable from a modifiable listing is still
+// something the caller asked to see.
+func (r ctsRequest) isReleased() bool {
+	return r.Bucket == "released"
+}

--- a/pkg/adt/transport_tree_test.go
+++ b/pkg/adt/transport_tree_test.go
@@ -1,0 +1,411 @@
+package adt
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+)
+
+// The CTS listing endpoint does not answer with one shape, and encoding/xml
+// answers a path that does not match with an empty struct and a nil error.
+// Both parsers hardcoded one shape each, so a system that sent either of the
+// other two got "no transports found" (#111, #140).
+
+// treeWithTargets is what the endpoint sends when transport targets exist:
+// workbench > target > modifiable > request.
+const treeWithTargets = `<?xml version="1.0" encoding="utf-8"?>
+<tm:root xmlns:tm="http://www.sap.com/cts/adt/tm" xmlns:adtcore="http://www.sap.com/adt/core">
+  <tm:workbench tm:desc="Workbench">
+    <tm:target tm:name="/ZDEMO/" tm:desc="Demo layer">
+      <tm:modifiable tm:desc="Modifiable">
+        <tm:request tm:number="TR-EXAMPLE-1" tm:owner="TESTUSER" tm:desc="First"
+                    tm:type="K" tm:status="D" tm:status_text="Modifiable"
+                    tm:lastchanged_timestamp="20260415195636" tm:source_client="001">
+          <tm:task tm:number="TR-EXAMPLE-2" tm:owner="TESTUSER" tm:desc="Task" tm:status="D">
+            <tm:abap_object tm:pgmid="R3TR" tm:type="CLAS" tm:name="ZCL_DEMO_ONE"
+                            tm:obj_info="Class ZCL_DEMO_ONE"/>
+          </tm:task>
+        </tm:request>
+      </tm:modifiable>
+      <tm:released tm:desc="Released">
+        <tm:request tm:number="TR-EXAMPLE-9" tm:owner="TESTUSER" tm:desc="Gone"
+                    tm:type="K" tm:status="R"/>
+      </tm:released>
+    </tm:target>
+  </tm:workbench>
+  <tm:customizing tm:desc="Customizing">
+    <tm:target tm:name="/ZDEMO/">
+      <tm:modifiable>
+        <tm:request tm:number="TR-EXAMPLE-3" tm:owner="TESTUSER" tm:desc="Cust"
+                    tm:type="W" tm:status="D"/>
+      </tm:modifiable>
+    </tm:target>
+  </tm:customizing>
+</tm:root>`
+
+// treeWithoutTargets is the same listing on a system with no configured
+// transport routes: the target level is simply absent.
+const treeWithoutTargets = `<?xml version="1.0" encoding="utf-8"?>
+<tm:root xmlns:tm="http://www.sap.com/cts/adt/tm">
+  <tm:workbench tm:desc="Workbench">
+    <tm:modifiable tm:desc="Modifiable">
+      <tm:request tm:number="TR-EXAMPLE-1" tm:owner="TESTUSER" tm:desc="First"/>
+    </tm:modifiable>
+  </tm:workbench>
+  <tm:customizing>
+    <tm:modifiable>
+      <tm:request tm:number="TR-EXAMPLE-3" tm:owner="TESTUSER" tm:desc="Cust"/>
+    </tm:modifiable>
+  </tm:customizing>
+</tm:root>`
+
+// flatTree is the single-request document: tm:request straight under tm:root.
+const flatTree = `<?xml version="1.0" encoding="utf-8"?>
+<tm:root xmlns:tm="http://www.sap.com/cts/adt/tm">
+  <tm:request tm:number="TR-EXAMPLE-1" tm:owner="TESTUSER" tm:desc="First"
+              tm:type="K" tm:status="D" tm:status_text="Modifiable"/>
+</tm:root>`
+
+func TestParseUserTransportsWithoutTargetLevel(t *testing.T) {
+	result, err := parseUserTransports([]byte(treeWithoutTargets))
+	if err != nil {
+		t.Fatalf("parseUserTransports: %v", err)
+	}
+	if len(result.Workbench) != 1 {
+		t.Fatalf("expected 1 workbench request from a target-less tree, got %d", len(result.Workbench))
+	}
+	if result.Workbench[0].Number != "TR-EXAMPLE-1" {
+		t.Errorf("expected TR-EXAMPLE-1, got %q", result.Workbench[0].Number)
+	}
+	if result.Workbench[0].Type != "workbench" {
+		t.Errorf("expected type 'workbench', got %q", result.Workbench[0].Type)
+	}
+	if len(result.Customizing) != 1 {
+		t.Fatalf("expected 1 customizing request, got %d", len(result.Customizing))
+	}
+}
+
+func TestParseUserTransportsFlatRoot(t *testing.T) {
+	result, err := parseUserTransports([]byte(flatTree))
+	if err != nil {
+		t.Fatalf("parseUserTransports: %v", err)
+	}
+	if len(result.Workbench) != 1 {
+		t.Fatalf("expected 1 workbench request from a flat tree, got %d", len(result.Workbench))
+	}
+	if result.Workbench[0].Owner != "TESTUSER" {
+		t.Errorf("expected owner TESTUSER, got %q", result.Workbench[0].Owner)
+	}
+}
+
+func TestParseUserTransportsKeepsTargetAndTasks(t *testing.T) {
+	result, err := parseUserTransports([]byte(treeWithTargets))
+	if err != nil {
+		t.Fatalf("parseUserTransports: %v", err)
+	}
+	if len(result.Workbench) != 2 {
+		t.Fatalf("expected 2 workbench requests (modifiable + released), got %d", len(result.Workbench))
+	}
+	first := result.Workbench[0]
+	if first.Target != "/ZDEMO/" {
+		t.Errorf("expected target /ZDEMO/ from the enclosing element, got %q", first.Target)
+	}
+	if len(first.Tasks) != 1 || len(first.Tasks[0].Objects) != 1 {
+		t.Fatalf("expected 1 task with 1 object, got %d tasks", len(first.Tasks))
+	}
+	if got := first.Tasks[0].Objects[0].Name; got != "ZCL_DEMO_ONE" {
+		t.Errorf("expected object ZCL_DEMO_ONE, got %q", got)
+	}
+	if len(result.Customizing) != 1 {
+		t.Fatalf("expected 1 customizing request, got %d", len(result.Customizing))
+	}
+}
+
+func TestParseTransportListNestedTree(t *testing.T) {
+	transports, err := parseTransportList([]byte(treeWithTargets))
+	if err != nil {
+		t.Fatalf("parseTransportList: %v", err)
+	}
+	// The released request is not part of a modifiable listing.
+	if len(transports) != 2 {
+		t.Fatalf("expected 2 modifiable transports from a nested tree, got %d", len(transports))
+	}
+	got := transports[0]
+	if got.Number != "TR-EXAMPLE-1" {
+		t.Errorf("expected TR-EXAMPLE-1, got %q", got.Number)
+	}
+	if got.Target != "/ZDEMO/" {
+		t.Errorf("expected target /ZDEMO/, got %q", got.Target)
+	}
+	if got.Type != "K" || got.Status != "D" || got.StatusText != "Modifiable" {
+		t.Errorf("expected K/D/Modifiable, got %q/%q/%q", got.Type, got.Status, got.StatusText)
+	}
+	if got.ChangedAt != "20260415195636" {
+		t.Errorf("expected changedAt 20260415195636, got %q", got.ChangedAt)
+	}
+	for _, tr := range transports {
+		if tr.Number == "TR-EXAMPLE-9" {
+			t.Errorf("released request TR-EXAMPLE-9 leaked into the modifiable listing")
+		}
+	}
+}
+
+func TestParseTransportListWithoutTargetLevel(t *testing.T) {
+	transports, err := parseTransportList([]byte(treeWithoutTargets))
+	if err != nil {
+		t.Fatalf("parseTransportList: %v", err)
+	}
+	if len(transports) != 2 {
+		t.Fatalf("expected 2 transports from a target-less tree, got %d", len(transports))
+	}
+	// Type and status come from the levels when the attributes are absent.
+	if transports[0].Type != "K" || transports[0].Status != "D" {
+		t.Errorf("expected K/D inferred from workbench+modifiable, got %q/%q",
+			transports[0].Type, transports[0].Status)
+	}
+	if transports[1].Type != "W" {
+		t.Errorf("expected W inferred from the customizing section, got %q", transports[1].Type)
+	}
+}
+
+func TestParseTransportListFlatRoot(t *testing.T) {
+	// The one shape that already worked. It must keep working.
+	transports, err := parseTransportList([]byte(flatTree))
+	if err != nil {
+		t.Fatalf("parseTransportList: %v", err)
+	}
+	if len(transports) != 1 || transports[0].Number != "TR-EXAMPLE-1" {
+		t.Fatalf("expected the flat shape to still parse, got %+v", transports)
+	}
+}
+
+func TestParseUserTransportsUndeclaredPrefix(t *testing.T) {
+	// Namespaces are resolved by the decoder, not by string surgery on the
+	// document, so an undeclared tm: prefix parses too.
+	doc := strings.ReplaceAll(treeWithoutTargets, ` xmlns:tm="http://www.sap.com/cts/adt/tm"`, "")
+	result, err := parseUserTransports([]byte(doc))
+	if err != nil {
+		t.Fatalf("parseUserTransports: %v", err)
+	}
+	if len(result.Workbench) != 1 {
+		t.Fatalf("expected 1 workbench request, got %d", len(result.Workbench))
+	}
+}
+
+func TestAs4userPredicate(t *testing.T) {
+	tests := []struct {
+		name    string
+		user    string
+		want    string
+		wantErr bool
+	}{
+		{"wildcard drops the predicate", "*", "", false},
+		{"named user is an equality", "TESTUSER", "e070~AS4USER = 'TESTUSER'", false},
+		{"lowercase is upper-cased", "testuser", "e070~AS4USER = 'TESTUSER'", false},
+		{"prefix wildcard becomes LIKE", "TEST*", "e070~AS4USER LIKE 'TEST%'", false},
+		{"empty user is refused", "", "", true},
+		{"blank user is refused", "   ", "", true},
+		{"a name that could close the literal is refused", "X' OR '1'='1", "", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := as4userPredicate(tt.user)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected an error for %q, got predicate %q", tt.user, got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error for %q: %v", tt.user, err)
+			}
+			if got != tt.want {
+				t.Errorf("as4userPredicate(%q) = %q, want %q", tt.user, got, tt.want)
+			}
+		})
+	}
+}
+
+// --- End-to-end over httptest: no SAP system is contacted. ---
+
+// ctsServer answers the CTS listing with a document the old parsers could not
+// navigate, and the E070 fallback query with two rows.
+type ctsServer struct {
+	mu       sync.Mutex
+	listing  string
+	queries  []string
+	sqlCalls int
+}
+
+func (s *ctsServer) start(t *testing.T) *Client {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case strings.Contains(r.URL.Path, "/discovery"):
+			w.Header().Set("X-CSRF-Token", "TOKEN")
+			w.WriteHeader(http.StatusOK)
+
+		case strings.Contains(r.URL.Path, "/cts/transportrequests"):
+			w.Header().Set("Content-Type", "application/xml")
+			_, _ = w.Write([]byte(s.listing))
+
+		case strings.Contains(r.URL.Path, "/datapreview/freestyle"):
+			body := make([]byte, r.ContentLength)
+			_, _ = r.Body.Read(body)
+			s.mu.Lock()
+			s.queries = append(s.queries, string(body))
+			s.sqlCalls++
+			s.mu.Unlock()
+			w.Header().Set("Content-Type", "application/xml")
+			_, _ = w.Write([]byte(e070Rows))
+
+		default:
+			w.WriteHeader(http.StatusOK)
+		}
+	}))
+	t.Cleanup(srv.Close)
+
+	cfg := NewConfig(srv.URL, "TESTUSER", "secret")
+	cfg.Safety.EnableTransports = true
+	return NewClientWithTransport(cfg, NewTransport(cfg))
+}
+
+func (s *ctsServer) lastQuery() string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if len(s.queries) == 0 {
+		return ""
+	}
+	return s.queries[len(s.queries)-1]
+}
+
+const e070Rows = `<?xml version="1.0" encoding="utf-8"?>
+<dataPreview:tableData xmlns:dataPreview="http://www.sap.com/adt/dataPreview">
+  <dataPreview:columns>
+    <dataPreview:metadata dataPreview:name="TRKORR" dataPreview:type="C" dataPreview:length="20"/>
+    <dataPreview:dataSet>
+      <dataPreview:data>TR-EXAMPLE-1</dataPreview:data>
+      <dataPreview:data>TR-EXAMPLE-3</dataPreview:data>
+    </dataPreview:dataSet>
+  </dataPreview:columns>
+  <dataPreview:columns>
+    <dataPreview:metadata dataPreview:name="AS4USER" dataPreview:type="C" dataPreview:length="12"/>
+    <dataPreview:dataSet>
+      <dataPreview:data>TESTUSER</dataPreview:data>
+      <dataPreview:data>OTHERUSER</dataPreview:data>
+    </dataPreview:dataSet>
+  </dataPreview:columns>
+  <dataPreview:columns>
+    <dataPreview:metadata dataPreview:name="TRFUNCTION" dataPreview:type="C" dataPreview:length="1"/>
+    <dataPreview:dataSet>
+      <dataPreview:data>K</dataPreview:data>
+      <dataPreview:data>W</dataPreview:data>
+    </dataPreview:dataSet>
+  </dataPreview:columns>
+  <dataPreview:columns>
+    <dataPreview:metadata dataPreview:name="TRSTATUS" dataPreview:type="C" dataPreview:length="1"/>
+    <dataPreview:dataSet>
+      <dataPreview:data>D</dataPreview:data>
+      <dataPreview:data>D</dataPreview:data>
+    </dataPreview:dataSet>
+  </dataPreview:columns>
+</dataPreview:tableData>`
+
+// The whole of #111: the two tools were asked the same question on the same
+// connection and only one of them answered.
+func TestGetUserTransportsAgreesWithListTransports(t *testing.T) {
+	// A shape neither parser handled, so both have to reach the fallback.
+	srv := &ctsServer{listing: `<?xml version="1.0"?><tm:root xmlns:tm="http://www.sap.com/cts/adt/tm"/>`}
+	client := srv.start(t)
+	ctx := context.Background()
+
+	list, err := client.ListTransports(ctx, "TESTUSER")
+	if err != nil {
+		t.Fatalf("ListTransports: %v", err)
+	}
+	if len(list) != 2 {
+		t.Fatalf("expected 2 transports from the E070 fallback, got %d", len(list))
+	}
+
+	user, err := client.GetUserTransports(ctx, "TESTUSER")
+	if err != nil {
+		t.Fatalf("GetUserTransports: %v", err)
+	}
+	total := len(user.Workbench) + len(user.Customizing)
+	if total != len(list) {
+		t.Fatalf("GetUserTransports returned %d requests where ListTransports returned %d "+
+			"on the same connection (workbench=%d customizing=%d)",
+			total, len(list), len(user.Workbench), len(user.Customizing))
+	}
+	if len(user.Workbench) != 1 || user.Workbench[0].Number != "TR-EXAMPLE-1" {
+		t.Errorf("expected the K request in workbench, got %+v", user.Workbench)
+	}
+	if len(user.Customizing) != 1 || user.Customizing[0].Number != "TR-EXAMPLE-3" {
+		t.Errorf("expected the W request in customizing, got %+v", user.Customizing)
+	}
+}
+
+// GetUserTransports must not reach for SQL when the tree answered.
+func TestGetUserTransportsPrefersTheTree(t *testing.T) {
+	srv := &ctsServer{listing: treeWithoutTargets}
+	client := srv.start(t)
+
+	result, err := client.GetUserTransports(context.Background(), "TESTUSER")
+	if err != nil {
+		t.Fatalf("GetUserTransports: %v", err)
+	}
+	if len(result.Workbench) != 1 || len(result.Customizing) != 1 {
+		t.Fatalf("expected 1 workbench and 1 customizing, got %d/%d",
+			len(result.Workbench), len(result.Customizing))
+	}
+	srv.mu.Lock()
+	defer srv.mu.Unlock()
+	if srv.sqlCalls != 0 {
+		t.Errorf("expected no SQL fallback when the tree answered, got %d queries", srv.sqlCalls)
+	}
+}
+
+// #140: '*' is what Eclipse ADT means by "every user".
+func TestListTransportsWildcardUser(t *testing.T) {
+	srv := &ctsServer{listing: `<?xml version="1.0"?><tm:root xmlns:tm="http://www.sap.com/cts/adt/tm"/>`}
+	client := srv.start(t)
+
+	list, err := client.ListTransports(context.Background(), "*")
+	if err != nil {
+		t.Fatalf("ListTransports('*'): %v", err)
+	}
+	if len(list) != 2 {
+		t.Fatalf("expected every user's transports, got %d", len(list))
+	}
+
+	query := srv.lastQuery()
+	if strings.Contains(query, "AS4USER = '*'") {
+		t.Errorf("the wildcard reached the database as a literal:\n%s", query)
+	}
+	if strings.Contains(query, "AS4USER =") || strings.Contains(query, "AS4USER LIKE") {
+		t.Errorf("expected no AS4USER predicate for the wildcard:\n%s", query)
+	}
+	owners := map[string]bool{}
+	for _, tr := range list {
+		owners[tr.Owner] = true
+	}
+	if !owners["TESTUSER"] || !owners["OTHERUSER"] {
+		t.Errorf("expected transports from more than one owner, got %v", owners)
+	}
+}
+
+func TestListTransportsNamedUserStillFilters(t *testing.T) {
+	srv := &ctsServer{listing: `<?xml version="1.0"?><tm:root xmlns:tm="http://www.sap.com/cts/adt/tm"/>`}
+	client := srv.start(t)
+
+	if _, err := client.ListTransports(context.Background(), "TESTUSER"); err != nil {
+		t.Fatalf("ListTransports: %v", err)
+	}
+	if q := srv.lastQuery(); !strings.Contains(q, "AS4USER = 'TESTUSER'") {
+		t.Errorf("expected an AS4USER equality for a named user:\n%s", q)
+	}
+}


### PR DESCRIPTION
Closes #111. Partial for #140 — see the limit below.

## Cause

Both transport parsers hardcode a single XML path and neither matches what the CTS listing endpoint sends. `parseUserTransports` navigated `workbench>target>modifiable>request`; `parseTransportList` navigated `root>request`, which is the *detail* shape, not a listing. `encoding/xml` answers a non-matching path with an empty struct and no error, so both failed silently. `ListTransports` survived only because it falls back to SQL; `GetUserTransports` has no fallback — which is exactly #111's "these two tools disagree".

## Change

- `pkg/adt/transport_tree.go` — a shape-tolerant parser that walks the document instead of asserting a path. Target-level, flat and nested trees all answer.
- `GetUserTransports` gets the same SQL fallback `ListTransports` has.
- `as4userPredicate` replaces the interpolated `AS4USER = '<user>'` so `*` stops being matched literally (#140).

## The limit on #140, stated so the issue is not closed early

`as4userPredicate` governs the **E070 fallback only**. Now that the tree parser actually answers, a real server's reply to `?user=*` is what gets consumed first, and whether SAP honours the wildcard there cannot be settled from fixtures — **no CTS listing capture from a live system exists anywhere in this repo**. If anyone can capture a real `?user=X&targets=true` response, it belongs in `transport_tree_test.go`.

## Behaviour change

An empty user under browser SSO now returns an error rather than `No transport requests found.` The old answer claimed the system had no transports when it had not been asked a valid question.

## Verification

12 tests; 8 fail against the old parsers and one does not compile without the new predicate — independently reproduced by a second reviewer. `go build`, `go vet`, and `go test ./...` green on current main. No open PR touches these parsers (#155 touches the same file, but only `CreateTransport` and gofmt hunks).

Fixtures use `TESTUSER` / `TR-EXAMPLE-*` / `ZDEMO` per the repo's sanitize policy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LQFAhfmJxybonf53QPEe5Q