### PR TITLE
fix(adt): an activation that failed could still report success

### DIFF
--- a/pkg/adt/activation_checklist_test.go
+++ b/pkg/adt/activation_checklist_test.go
@@ -1,0 +1,166 @@
+package adt
+
+import (
+	"strings"
+	"testing"
+)
+
+// Three ways a refused activation still reads as a success, all of them the same
+// bug as #136's headline: SAP said no, in the body, and the parser threw the
+// sentence away. The namespace premise in the issue is false — encoding/xml
+// matches `adtcore:type="E"` against `xml:"type,attr"` — and the root-element
+// half is already fixed. These are what is left.
+
+//  1. The refusal arrives as a list of objects that are still inactive, with
+//     <ioc:inactiveObjects> as the document ROOT. The parser understood the
+//     wrapped form only, so the whole payload decoded to nothing and an object
+//     that never activated was reported as activated.
+const activationInactiveRoot = `<?xml version="1.0" encoding="utf-8"?>
+<ioc:inactiveObjects xmlns:ioc="http://www.sap.com/abapxml/inactiveCtsObjects" xmlns:adtcore="http://www.sap.com/adt/core">
+  <ioc:entry>
+    <ioc:object>
+      <ioc:ref adtcore:uri="/sap/bc/adt/programs/programs/zdemo_still_inactive" adtcore:type="PROG/P" adtcore:name="ZDEMO_STILL_INACTIVE"/>
+    </ioc:object>
+  </ioc:entry>
+</ioc:inactiveObjects>`
+
+//  2. SAP splits one message over several <txt> siblings. A string field takes
+//     each in turn and keeps the last, so the error itself is dropped and the
+//     hint that follows it is reported as the error.
+const activationMultiTxt = `<?xml version="1.0" encoding="utf-8"?>
+<chkl:messages xmlns:chkl="http://www.sap.com/abapxml/checklist">
+  <msg objDescr="Class ZCL_DEMO" type="E" line="12" href="/sap/bc/adt/oo/classes/zcl_demo/source/main#start=12,4" forceSupported="false">
+    <shortText><txt>Field "FOO" is unknown.</txt><txt>"Editing canceled" (EU 202)</txt></shortText>
+  </msg>
+</chkl:messages>`
+
+//  3. The checklist's own verdict. Nothing in it is error-typed — the only
+//     message is a W — but <chkl:properties activationExecuted="false"/> says the
+//     activation never ran, and the object is inactive.
+const activationNotExecuted = `<?xml version="1.0" encoding="utf-8"?>
+<chkl:messages xmlns:chkl="http://www.sap.com/abapxml/checklist">
+  <chkl:properties checkExecuted="true" activationExecuted="false" generationExecuted="false"/>
+  <msg objDescr="" type="W" line="0" href="" forceSupported="true">
+    <shortText><txt>Activation was cancelled.</txt></shortText>
+  </msg>
+</chkl:messages>`
+
+// An activation that really ran is not a refusal, and the attribute must not
+// turn every warning into a failure.
+const activationExecutedWithWarning = `<?xml version="1.0" encoding="utf-8"?>
+<chkl:messages xmlns:chkl="http://www.sap.com/abapxml/checklist">
+  <chkl:properties checkExecuted="true" activationExecuted="true" generationExecuted="true"/>
+  <msg objDescr="Class ZCL_DEMO" type="W" line="3" href="x" forceSupported="true">
+    <shortText><txt>Variable is never used</txt></shortText>
+  </msg>
+</chkl:messages>`
+
+func TestParseActivationResultInactiveObjectsAsRoot(t *testing.T) {
+	res, err := parseActivationResult([]byte(activationInactiveRoot))
+	if err != nil {
+		t.Fatalf("parseActivationResult: %v", err)
+	}
+	if res.Success {
+		t.Fatal("an object SAP listed as still inactive was reported as activated")
+	}
+	if len(res.Inactive) != 1 {
+		t.Fatalf("inactive = %d, want 1: %+v", len(res.Inactive), res.Inactive)
+	}
+	got := res.Inactive[0]
+	if got.Name != "ZDEMO_STILL_INACTIVE" || got.Type != "PROG/P" {
+		t.Fatalf("inactive object not parsed: %+v", got)
+	}
+	if got.URI != "/sap/bc/adt/programs/programs/zdemo_still_inactive" {
+		t.Fatalf("uri lost: %q", got.URI)
+	}
+}
+
+func TestParseActivationResultKeepsEveryTxt(t *testing.T) {
+	res, err := parseActivationResult([]byte(activationMultiTxt))
+	if err != nil {
+		t.Fatalf("parseActivationResult: %v", err)
+	}
+	if len(res.Messages) != 1 {
+		t.Fatalf("messages = %d, want 1", len(res.Messages))
+	}
+	text := res.Messages[0].ShortText
+	// The error is the half that was being dropped, so assert on it by name.
+	if !strings.Contains(text, `Field "FOO" is unknown.`) {
+		t.Fatalf("SAP's error text was dropped, kept only: %q", text)
+	}
+	if !strings.Contains(text, "EU 202") {
+		t.Fatalf("the trailing txt was dropped: %q", text)
+	}
+}
+
+func TestParseActivationResultHonoursActivationExecutedFalse(t *testing.T) {
+	res, err := parseActivationResult([]byte(activationNotExecuted))
+	if err != nil {
+		t.Fatalf("parseActivationResult: %v", err)
+	}
+	if res.Success {
+		t.Fatal(`activationExecuted="false" means the object is still inactive, but it was reported as a success`)
+	}
+	// And the reason has to survive to whoever ran the deploy. Before this, a
+	// refusal with no error-typed message rendered as "SAP named no reason"
+	// while the W beside it held the reason.
+	lines := res.ProblemLines()
+	if len(lines) != 1 || !strings.Contains(lines[0], "Activation was cancelled.") {
+		t.Fatalf("SAP's reason did not reach the caller: %v", lines)
+	}
+}
+
+func TestParseActivationResultActivationExecutedTrueIsNotAFailure(t *testing.T) {
+	res, err := parseActivationResult([]byte(activationExecutedWithWarning))
+	if err != nil {
+		t.Fatalf("parseActivationResult: %v", err)
+	}
+	if !res.Success {
+		t.Fatal("an activation that ran, with only a warning, is not a refusal")
+	}
+	if len(res.ProblemLines()) != 0 {
+		t.Fatalf("a success has no problem lines: %v", res.ProblemLines())
+	}
+}
+
+// The wrapped shape still has to work. PR #148 fixes the root form by declaring
+// <msg> directly on the response struct and nothing else, which stops matching
+// the wrapper — this is the test that catches that.
+func TestParseActivationResultStillHandlesBothRootAndWrapped(t *testing.T) {
+	for name, body := range map[string]string{
+		"root":    activationFailedRoot,
+		"wrapped": activationFailedWrapped,
+	} {
+		t.Run(name, func(t *testing.T) {
+			res, err := parseActivationResult([]byte(body))
+			if err != nil {
+				t.Fatalf("parseActivationResult: %v", err)
+			}
+			if res.Success || len(res.Messages) != 1 {
+				t.Fatalf("shape %s regressed: %+v", name, res)
+			}
+			if res.Messages[0].ShortText != `Field "FOO" is unknown` {
+				t.Fatalf("text lost: %q", res.Messages[0].ShortText)
+			}
+		})
+	}
+}
+
+// Some releases put the text straight in <shortText> with no <txt> at all.
+// Either way the caller must not be handed an empty string.
+func TestParseActivationResultReadsShortTextWithoutTxt(t *testing.T) {
+	body := `<?xml version="1.0" encoding="utf-8"?>
+<chkl:messages xmlns:chkl="http://www.sap.com/abapxml/checklist">
+  <msg objDescr="Class ZCL_DEMO" type="E" line="4" href="x"><shortText>Field "BAR" is unknown</shortText></msg>
+</chkl:messages>`
+	res, err := parseActivationResult([]byte(body))
+	if err != nil {
+		t.Fatalf("parseActivationResult: %v", err)
+	}
+	if res.Success {
+		t.Fatal("a type=E message is a refusal")
+	}
+	if len(res.Messages) != 1 || res.Messages[0].ShortText != `Field "BAR" is unknown` {
+		t.Fatalf("shortText without <txt> was dropped: %+v", res.Messages)
+	}
+}

--- a/pkg/adt/activation_failure.go
+++ b/pkg/adt/activation_failure.go
@@ -56,8 +56,18 @@ func (r *ActivationResult) ProblemLines() []string {
 	if r == nil || r.Success {
 		return nil
 	}
+	// A checklist can refuse without an E in it: activationExecuted="false" and
+	// a type="W" "Activation was cancelled." is a real refusal whose only reason
+	// is that warning. Leading with "SAP named no reason" while holding SAP's
+	// reason is the same silence this file exists to end, so when nothing is
+	// error-typed the warnings are what there is to report.
+	msgs := r.ErrorMessages()
+	if len(msgs) == 0 {
+		msgs = r.Messages
+	}
+
 	var lines []string
-	for _, m := range r.ErrorMessages() {
+	for _, m := range msgs {
 		text := strings.TrimSpace(m.ShortText)
 		if text == "" {
 			text = "(SAP gave no text for this message)"

--- a/pkg/adt/devtools.go
+++ b/pkg/adt/devtools.go
@@ -71,11 +71,16 @@ func (c *Client) SyntaxCheck(ctx context.Context, objectURL string, content stri
 }
 
 func parseSyntaxCheckResults(data []byte) ([]SyntaxCheckResult, error) {
-	// The response uses namespace prefixes like chkrun:uri, chkrun:type, etc.
-	// Go's xml package doesn't handle namespaced attributes well, so we strip the prefix
-	xmlStr := string(data)
-	xmlStr = strings.ReplaceAll(xmlStr, "chkrun:", "")
-
+	// The response uses namespace prefixes — chkrun:uri, chkrun:type — and this
+	// used to strip "chkrun:" out of the whole document first, on the belief that
+	// encoding/xml cannot match a prefixed attribute. It can: a tag of
+	// `xml:"type,attr"` matches on local name, whatever the prefix, which is why
+	// the activation checklist reads adtcore:type without any such help.
+	//
+	// The strip was not merely unnecessary. It rewrote every byte of the payload,
+	// message text included, so a shortText that mentioned the namespace came
+	// back with the prefix cut out of the sentence — SAP's diagnostic, quietly
+	// altered on the way to the caller.
 	type checkMessage struct {
 		URI       string `xml:"uri,attr"`
 		Type      string `xml:"type,attr"`
@@ -92,7 +97,7 @@ func parseSyntaxCheckResults(data []byte) ([]SyntaxCheckResult, error) {
 	}
 
 	var resp checkRunReports
-	if err := xml.Unmarshal([]byte(xmlStr), &resp); err != nil {
+	if err := xml.Unmarshal(data, &resp); err != nil {
 		return nil, fmt.Errorf("parsing syntax check response: %w", err)
 	}
 
@@ -194,18 +199,33 @@ func parseActivationResult(data []byte) (*ActivationResult, error) {
 		return result, nil
 	}
 
+	// SAP splits one message across several <txt> siblings — "Activation was
+	// cancelled." and `"Editing canceled" (EU 202)` arrive as two — so this is a
+	// list, not a string. A string field would be overwritten by each element in
+	// turn and keep only the last, which is reliably the least informative half.
+	// Chardata covers the releases that put the text straight in <shortText>.
+	type shortText struct {
+		Texts    []string `xml:"txt"`
+		CharData string   `xml:",chardata"`
+	}
 	type msg struct {
-		ObjDescr       string `xml:"objDescr,attr"`
-		Type           string `xml:"type,attr"`
-		Line           int    `xml:"line,attr"`
-		Href           string `xml:"href,attr"`
-		ForceSupported bool   `xml:"forceSupported,attr"`
-		ShortText      struct {
-			Text string `xml:"txt"`
-		} `xml:"shortText"`
+		ObjDescr       string    `xml:"objDescr,attr"`
+		Type           string    `xml:"type,attr"`
+		Line           int       `xml:"line,attr"`
+		Href           string    `xml:"href,attr"`
+		ForceSupported bool      `xml:"forceSupported,attr"`
+		ShortText      shortText `xml:"shortText"`
+	}
+	// The checklist's own verdict on whether anything happened. A checklist can
+	// refuse with nothing but warnings in it — activationExecuted="false" beside
+	// a type="W" "Activation was cancelled." — and reading only message types
+	// calls that a success while the object is still inactive.
+	type properties struct {
+		ActivationExecuted string `xml:"activationExecuted,attr"`
 	}
 	type messages struct {
-		Msgs []msg `xml:"msg"`
+		Props *properties `xml:"properties"`
+		Msgs  []msg       `xml:"msg"`
 	}
 	type inactiveRef struct {
 		URI       string `xml:"uri,attr"`
@@ -221,7 +241,17 @@ func parseActivationResult(data []byte) (*ActivationResult, error) {
 	type inactiveObjects struct {
 		Entries []inactiveEntry `xml:"entry"`
 	}
+	// ADT sends the checklist either as the document root (<chkl:messages> or
+	// <ioc:inactiveObjects>, whose children land directly on this struct) or
+	// wrapped in an outer element (where they are one level down). Both shapes
+	// are declared here rather than parsed in two passes, because the root and
+	// the wrapper never use the same element names and so cannot collide.
 	type response struct {
+		// Root shape: this struct *is* <chkl:messages> / <ioc:inactiveObjects>.
+		Props   *properties     `xml:"properties"`
+		Msgs    []msg           `xml:"msg"`
+		Entries []inactiveEntry `xml:"entry"`
+		// Wrapped shape.
 		Messages messages        `xml:"messages"`
 		Inactive inactiveObjects `xml:"inactiveObjects"`
 	}
@@ -237,16 +267,11 @@ func parseActivationResult(data []byte) (*ActivationResult, error) {
 		return result, nil
 	}
 
-	// ADT returns the checklist either wrapped or as the document root
-	// (<chkl:messages> with <msg> children). Only the wrapped shape matches the
-	// struct above, so fall back to the root shape — otherwise a failed
-	// activation parses to nothing and is reported as a success.
-	msgs := resp.Messages.Msgs
-	if len(msgs) == 0 {
-		var root messages
-		if err := xml.Unmarshal(data, &root); err == nil {
-			msgs = root.Msgs
-		}
+	msgs := append(append([]msg{}, resp.Msgs...), resp.Messages.Msgs...)
+	entries := append(append([]inactiveEntry{}, resp.Entries...), resp.Inactive.Entries...)
+	props := resp.Props
+	if props == nil {
+		props = resp.Messages.Props
 	}
 
 	for _, m := range msgs {
@@ -256,15 +281,15 @@ func parseActivationResult(data []byte) (*ActivationResult, error) {
 			Line:           m.Line,
 			Href:           m.Href,
 			ForceSupported: m.ForceSupported,
-			ShortText:      m.ShortText.Text,
+			ShortText:      joinShortText(m.ShortText.Texts, m.ShortText.CharData),
 		})
 		// Check for errors
-		if strings.ContainsAny(m.Type, "EAX") {
+		if strings.ContainsAny(m.Type, activationErrorTypes) {
 			result.Success = false
 		}
 	}
 
-	for _, entry := range resp.Inactive.Entries {
+	for _, entry := range entries {
 		if entry.Object != nil {
 			result.Success = false
 			result.Inactive = append(result.Inactive, InactiveObject{
@@ -276,7 +301,29 @@ func parseActivationResult(data []byte) (*ActivationResult, error) {
 		}
 	}
 
+	// Only an explicit "false" is a refusal. An absent attribute means this
+	// release did not say, and guessing from silence is how the messages got
+	// dropped in the first place.
+	if props != nil && strings.EqualFold(strings.TrimSpace(props.ActivationExecuted), "false") {
+		result.Success = false
+	}
+
 	return result, nil
+}
+
+// joinShortText renders SAP's <shortText> as the one line the rest of the code
+// expects, keeping every <txt> sibling in the order SAP wrote them.
+func joinShortText(texts []string, chardata string) string {
+	parts := make([]string, 0, len(texts))
+	for _, t := range texts {
+		if t = strings.TrimSpace(t); t != "" {
+			parts = append(parts, t)
+		}
+	}
+	if len(parts) == 0 {
+		return strings.TrimSpace(chardata)
+	}
+	return strings.Join(parts, " ")
 }
 
 // GetInactiveObjects retrieves all inactive objects for the current user.

--- a/pkg/adt/syntaxcheck_parse_test.go
+++ b/pkg/adt/syntaxcheck_parse_test.go
@@ -1,0 +1,89 @@
+package adt
+
+import "testing"
+
+// The checkrun response as ADT sends it: prefixed element and attribute names
+// throughout, the position in the uri fragment, the text in a shortText
+// attribute. There was no unit test on this parser at all — only integration
+// tests, which need a live SAP system and so never run in CI.
+const syntaxCheckErrorsXML = `<?xml version="1.0" encoding="utf-8"?>
+<chkrun:checkRunReports xmlns:chkrun="http://www.sap.com/adt/checkrun">
+  <chkrun:checkReport chkrun:reporter="abapCheckRun" chkrun:triggeringUri="/sap/bc/adt/oo/classes/zcl_demo" chkrun:status="processed" chkrun:statusText="">
+    <chkrun:checkMessageList>
+      <chkrun:checkMessage chkrun:uri="/sap/bc/adt/oo/classes/zcl_demo/source/main#start=12,4" chkrun:type="E" chkrun:shortText="Field &quot;FOO&quot; is unknown"/>
+      <chkrun:checkMessage chkrun:uri="/sap/bc/adt/oo/classes/zcl_demo/source/main#start=19,0" chkrun:type="W" chkrun:shortText="Variable is never used"/>
+    </chkrun:checkMessageList>
+  </chkrun:checkReport>
+</chkrun:checkRunReports>`
+
+func TestParseSyntaxCheckResults(t *testing.T) {
+	results, err := parseSyntaxCheckResults([]byte(syntaxCheckErrorsXML))
+	if err != nil {
+		t.Fatalf("parseSyntaxCheckResults: %v", err)
+	}
+	if len(results) != 2 {
+		t.Fatalf("results = %d, want 2: %+v", len(results), results)
+	}
+
+	first := results[0]
+	if first.Severity != "E" {
+		t.Fatalf("severity = %q, want E", first.Severity)
+	}
+	if first.Text != `Field "FOO" is unknown` {
+		t.Fatalf("text = %q", first.Text)
+	}
+	if first.Line != 12 || first.Offset != 4 {
+		t.Fatalf("position = %d,%d, want 12,4", first.Line, first.Offset)
+	}
+	if first.URI != "/sap/bc/adt/oo/classes/zcl_demo/source/main" {
+		t.Fatalf("uri kept its fragment: %q", first.URI)
+	}
+
+	if results[1].Severity != "W" || results[1].Line != 19 {
+		t.Fatalf("second message not parsed: %+v", results[1])
+	}
+}
+
+// The parser used to delete the string "chkrun:" from the entire document
+// before unmarshalling, on the false premise that encoding/xml cannot match a
+// prefixed attribute — the same premise #136 was filed on. It can. The strip
+// only ever managed to rewrite SAP's own message text.
+func TestParseSyntaxCheckResultsDoesNotRewriteMessageText(t *testing.T) {
+	body := `<?xml version="1.0" encoding="utf-8"?>
+<chkrun:checkRunReports xmlns:chkrun="http://www.sap.com/adt/checkrun">
+  <chkrun:checkReport chkrun:reporter="abapCheckRun">
+    <chkrun:checkMessageList>
+      <chkrun:checkMessage chkrun:uri="/x/main#start=9,0" chkrun:type="E" chkrun:shortText="Reporter chkrun:syntaxCheck rejected the artifact"/>
+    </chkrun:checkMessageList>
+  </chkrun:checkReport>
+</chkrun:checkRunReports>`
+
+	results, err := parseSyntaxCheckResults([]byte(body))
+	if err != nil {
+		t.Fatalf("parseSyntaxCheckResults: %v", err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("results = %d, want 1", len(results))
+	}
+	if results[0].Text != "Reporter chkrun:syntaxCheck rejected the artifact" {
+		t.Fatalf("SAP's text was rewritten in transit: %q", results[0].Text)
+	}
+}
+
+// A clean check is an empty report, not an error.
+func TestParseSyntaxCheckResultsCleanIsEmpty(t *testing.T) {
+	body := `<?xml version="1.0" encoding="utf-8"?>
+<chkrun:checkRunReports xmlns:chkrun="http://www.sap.com/adt/checkrun">
+  <chkrun:checkReport chkrun:reporter="abapCheckRun" chkrun:status="processed">
+    <chkrun:checkMessageList/>
+  </chkrun:checkReport>
+</chkrun:checkRunReports>`
+
+	results, err := parseSyntaxCheckResults([]byte(body))
+	if err != nil {
+		t.Fatalf("parseSyntaxCheckResults: %v", err)
+	}
+	if len(results) != 0 {
+		t.Fatalf("a clean check reported %d problems: %+v", len(results), results)
+	}
+}


### PR DESCRIPTION
Closes #136. Prerequisite for reworking PR #150 (#137).

## The issue's stated cause is not the cause

#136 blames an XML namespace mismatch. Verified false: `encoding/xml` **does** match `adtcomp:type="E"` against `xml:"type,attr"`, and `strings.ReplaceAll(x, "chkrun:", "")` does **not** turn `xmlns:chkrun=` into a default namespace. The root-element half is already fixed at HEAD by `18050c2`, with a test. Recording that here so nobody re-chases it.

## The three legs that are real

Each reproduced against the current parser before being fixed:

1. An `<ioc:inactiveObjects>` root parsed as zero messages — **a refusal read as an empty success**.
2. `shortText` with several `<txt>` children collapsed to the first, discarding the human-readable text and keeping the MSGKEY.
3. `activationExecuted="false"` — SAP saying it did not even try — read as success.

An activation result that lies is worse than one that fails: the 2026-08 truthfulness work sits on these two parsers and inherits what they get wrong.

## On PR #148

Assessed, and it cannot merge as it stands. It fixes leg 1 only, and its struct rewrite **drops the wrapped-`<messages>` shape HEAD has a passing test for** — compiled against the five payloads it yields `msgs=0` where HEAD yields `msgs=1`, so merging it would turn `TestParseActivationResultFailure/messages_wrapped` red. Its diagnosis of the root shape was correct and is credited.

## Verification

Five tests fail against the current parser with the exact stated output; three guard tests pass at HEAD (they pin what must not change). Independently re-verified by a second reviewer who reverted the source files and re-ran. `go build`, `go vet`, `go test ./...` green on current main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LQFAhfmJxybonf53QPEe5Q