### PR TITLE
ci(lint): the advisory job has never linted anything

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,8 @@ name: CI
 
 # The point of this workflow is a cheap verdict on someone else's patch: does it
 # build, vet clean, and pass the tests. It deliberately stays small — the heavy
-# cross-platform work belongs to the release pipeline, and lint is advisory.
+# cross-platform work belongs to the release pipeline, and lint is advisory and
+# pull-request-only.
 # Nothing here talks to a SAP system: live tests sit behind the `integration` tag.
 on:
   push:
@@ -55,6 +56,10 @@ jobs:
 
   lint:
     name: lint (advisory)
+    # Pull requests only. On main the gate is build/vet/test; lint is here to
+    # tell a contributor what their own diff introduced, which is a question
+    # that only has a meaning on a PR.
+    if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     # Advisory: a linter release built against an older Go than this module's
     # directive fails before it reads a line of code, and that must not block a
@@ -63,6 +68,9 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          # only-new-issues needs the merge base to diff against.
+          fetch-depth: 0
 
       - name: Set up Go
         uses: actions/setup-go@v5
@@ -73,5 +81,15 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v8
         with:
-          version: latest
+          # Pinned, not `latest`. `latest` is what broke this job: v2 shipped,
+          # refused the v1 .golangci.yml, and failed in 67ms without reading a
+          # line of Go. Every run in the retained history failed that way, and
+          # because the job is advisory nobody had reason to look. A major
+          # version must move because someone moved it.
+          version: v2.13.2
+          # The repo carries 264 findings that predate this job ever running.
+          # Reporting them on every PR would bury whatever the PR itself
+          # introduced, which is the only part its author can act on. Raise the
+          # backlog separately; this flag keeps the signal.
+          only-new-issues: true
           args: --timeout=5m

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,37 +1,68 @@
+# Schema version. golangci-lint v2 refuses a v1 config outright — "unsupported
+# version of the configuration" — before it reads a line of Go. That is what
+# happened here: the action asked for `latest`, v2 shipped, and this file stayed
+# v1, so the advisory lint job failed in 67ms on every run and checked nothing
+# at all. Keep this line, and pin the version in ci.yml.
+version: "2"
+
 run:
-  timeout: 5m
   modules-download-mode: readonly
 
 linters:
   enable:
-    - errcheck
-    - gosimple
-    - govet
-    - ineffassign
-    - staticcheck
-    - unused
-    - gofmt
-    - goimports
-    - misspell
-    - unconvert
-    - unparam
     - bodyclose
+    - misspell
     - noctx
     - prealloc
+    - unconvert
+    - unparam
 
-linters-settings:
-  errcheck:
-    check-type-assertions: true
-  govet:
-    enable-all: true
-    disable:
-      - fieldalignment
-  goimports:
-    local-prefixes: github.com/vibingsteamer/mcp-abap-adt-go
+  settings:
+    errcheck:
+      check-type-assertions: true
+    govet:
+      enable-all: true
+      disable:
+        - fieldalignment
+    misspell:
+      # CLAS is the ADT object-type code for a class, not a typo for CLASS.
+      # It appears in URLs, tool schemas and switch statements; "correcting" it
+      # breaks the code. The first lint run after the v2 migration flagged six
+      # of these, which is a fair illustration of why lint output gets read
+      # rather than applied.
+      ignore-rules:
+        - clas
 
-issues:
-  exclude-rules:
-    - path: _test\.go
-      linters:
-        - errcheck
-        - unparam
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    rules:
+      - path: _test\.go
+        linters:
+          - errcheck
+          - unparam
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
+
+formatters:
+  enable:
+    - gofmt
+    - goimports
+  settings:
+    goimports:
+      # Was github.com/vibingsteamer/mcp-abap-adt-go — a module path this repo
+      # has never had (see go.mod), so local-import grouping matched nothing.
+      local-prefixes:
+        - github.com/oisee/vibing-steampunk
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$


### PR DESCRIPTION
`lint (advisory)` is red, and the cause is not in the Go.

## What was happening

The action asks for `version: latest`. golangci-lint v2 shipped. **v2 refuses a v1 config file outright** and exits before reading a line of code:

```
Error: can't load config: unsupported version of the configuration: ""
##[error]golangci-lint exit with code 3
Ran golangci-lint in 67ms
```

67 milliseconds, zero checks run, red badge. `.golangci.yml` was last touched 2025-12-21; every CI run in the retained history failed this way. Reproduced locally with v2.13.2 before changing anything.

Advisory is what let it sit — a job that cannot block is a job nobody has to explain. The cost isn't the failed job, it's that a permanently red check stops carrying information. That is the same shrug that let `go vet` fail on main for six days last week (#171).

## Changes

Migrated with `golangci-lint migrate`, plus three corrections it could not make:

- **`local-prefixes` named a module that never existed here** — `github.com/vibingsteamer/mcp-abap-adt-go` against `go.mod`'s `github.com/oisee/vibing-steampunk`. Local-import grouping had matched nothing even back when the linter did run.
- **`misspell` now ignores `clas`.** Its first act on being switched on was to report six "misspellings of CLASS" — `CLAS` is the ADT object-type code, in URLs, tool schemas and switch statements. Applying that output would have broken the code.
- **The version is pinned** to `v2.13.2`. `latest` is what moved a major version under this repo without anyone choosing it.

The job now runs on **pull requests only**, with **`only-new-issues: true`**. On main the gate is build/vet/test; on a PR the useful question is what that diff introduced.

## The backlog is real and is not fixed here

Switching the linter on reveals **264 findings** that predate it ever running:

| linter | n | | linter | n |
|---|--:|---|---|--:|
| staticcheck | 50 | | noctx | 12 |
| govet | 50 | | ineffassign | 6 |
| prealloc | 41 | | bodyclose | 3 |
| unused | 33 | | gofmt | 3 |
| errcheck | 33 | | unconvert | 2 |
| unparam | 31 | | | |

Reporting these on every PR would bury the part its author can act on, hence `only-new-issues`. They deserve their own pass by category. I checked the two categories most likely to hide real defects: all 6 `ineffassign` are benign default-then-overwrite patterns, but the **3 `bodyclose` are genuine leaks** on the WebSocket auth-retry path (`pkg/adt/websocket_base.go:134,173`) and are the ones I would do first.

**This PR is its own test:** the lint job runs on pull requests, so its result here is the verification that the config loads and the linter actually executes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LQFAhfmJxybonf53QPEe5Q