### PR TITLE
fix(adt): the keep-alive kept the session by ending it

### DIFF
--- a/cmd/vsp/main.go
+++ b/cmd/vsp/main.go
@@ -125,7 +125,7 @@ func init() {
 	rootCmd.Flags().String("credential-cmd", "", "External command returning JSON {\"username\":...,\"password\":...} (space-separated argv, no shell quoting — use a wrapper script for paths with spaces)")
 
 	// Session keep-alive
-	rootCmd.Flags().Duration("keepalive", 5*time.Minute, "Session keep-alive interval (e.g., 60s, 5m). Prevents session timeout during idle periods. 0 = disabled")
+	rootCmd.Flags().Duration("keepalive", 0, "Session keep-alive interval (e.g., 60s, 5m). Prevents session timeout during idle periods. 0 = disabled (default; see #168)")
 
 	// Safety options
 	rootCmd.Flags().BoolVar(&cfg.ReadOnly, "read-only", false, "Block all write operations (create, update, delete, activate)")

--- a/pkg/adt/client.go
+++ b/pkg/adt/client.go
@@ -25,6 +25,10 @@ type Client struct {
 	keepAliveCancel context.CancelFunc
 	keepAliveDone   chan struct{}
 	keepAliveMu     sync.Mutex
+
+	// Lock handles believed outstanding, so the keep-alive ping does not
+	// retire the session one of them is bound to. See lock_window.go.
+	locks lockWindow
 }
 
 // NewClient creates a new ADT client with the given configuration.
@@ -78,6 +82,16 @@ func (c *Client) StartKeepAlive(interval time.Duration, verbose bool) {
 				}
 				return
 			case <-ticker.C:
+				// A ping is an ordinary request, and an ordinary request is
+				// stamped stateless — which retires the session a lock handle
+				// lives in. Skipping a tick costs nothing; sending it during a
+				// write costs the write (#168).
+				if c.lockOutstanding() {
+					if verbose {
+						fmt.Fprintf(LogOutput, "[KEEPALIVE] Skipped: a lock is outstanding\n")
+					}
+					continue
+				}
 				if err := c.transport.Ping(ctx); err != nil {
 					if ctx.Err() != nil {
 						return // context cancelled, expected

--- a/pkg/adt/crud.go
+++ b/pkg/adt/crud.go
@@ -80,6 +80,8 @@ func (c *Client) LockObject(ctx context.Context, objectURL string, accessMode st
 			objectURL, result.ModificationSupport)
 	}
 
+	c.noteLockOpened(result.LockHandle)
+
 	return result, nil
 }
 
@@ -161,6 +163,10 @@ func (c *Client) UnlockObject(ctx context.Context, objectURL string, lockHandle 
 	if err != nil {
 		return fmt.Errorf("unlocking object: %w", err)
 	}
+
+	// Only a *successful* unlock ends the window. A failed one may have left
+	// the lock held, and suppressing a ping is the cheaper mistake.
+	c.noteLockClosed(lockHandle)
 
 	return nil
 }
@@ -911,6 +917,10 @@ func (c *Client) DeleteObject(ctx context.Context, objectURL string, lockHandle 
 	if err != nil {
 		return fmt.Errorf("deleting object: %w", err)
 	}
+
+	// A delete consumes the handle without an UNLOCK ever being sent, which is
+	// how a lock-window counter ends up permanently non-zero.
+	c.noteLockClosed(lockHandle)
 
 	return nil
 }

--- a/pkg/adt/lock_window.go
+++ b/pkg/adt/lock_window.go
@@ -1,0 +1,74 @@
+package adt
+
+import (
+	"sync"
+	"time"
+)
+
+// lockWindowMaxAge bounds how long a recorded lock can suppress the keep-alive
+// ping. Nothing here can prove a lock was released — a delete consumes the
+// handle, a failed unlock leaves it held by a session that may already be gone,
+// and a caller can drop a handle on the floor. So an entry that is never closed
+// expires instead of suppressing the ping forever. Thirty minutes sits under
+// SAP's own ADT session timeout (typically ~60), which is the point past which
+// a lock this client is still tracking cannot be alive anyway.
+const lockWindowMaxAge = 30 * time.Minute
+
+// lockWindow records the lock handles this client believes are outstanding.
+//
+// Its only consumer is the keep-alive ticker. A keep-alive ping is a request
+// like any other, and under the stateless default (config.go SessionType) an
+// unflagged request carries an explicit X-sap-adt-sessiontype: stateless that
+// retires the ADT session — including the session a lock handle is bound to.
+// A ping that lands between LOCK and the write therefore kills the handle and
+// the write returns 423, which is issue #168: a keep-alive that kills the
+// session it exists to keep alive.
+//
+// Suppressing a tick is free. Sending one at the wrong moment costs a write.
+// So this errs toward suppression: it clears an entry only on a *successful*
+// unlock or delete, and lets anything else age out.
+type lockWindow struct {
+	mu   sync.Mutex
+	open map[string]time.Time
+}
+
+// noteLockOpened records a handle as outstanding. Called after a LOCK that
+// returned a usable handle.
+func (c *Client) noteLockOpened(handle string) {
+	if handle == "" {
+		return
+	}
+	c.locks.mu.Lock()
+	defer c.locks.mu.Unlock()
+	if c.locks.open == nil {
+		c.locks.open = make(map[string]time.Time)
+	}
+	c.locks.open[handle] = time.Now()
+}
+
+// noteLockClosed forgets a handle. Called after a successful UNLOCK, and after
+// a successful DELETE — a delete consumes the handle without unlocking it,
+// which is the case that leaves a naive counter permanently non-zero.
+func (c *Client) noteLockClosed(handle string) {
+	if handle == "" {
+		return
+	}
+	c.locks.mu.Lock()
+	defer c.locks.mu.Unlock()
+	delete(c.locks.open, handle)
+}
+
+// lockOutstanding reports whether this client is inside a lock window, pruning
+// entries old enough that the lock they name cannot still be alive.
+func (c *Client) lockOutstanding() bool {
+	c.locks.mu.Lock()
+	defer c.locks.mu.Unlock()
+
+	cutoff := time.Now().Add(-lockWindowMaxAge)
+	for handle, opened := range c.locks.open {
+		if opened.Before(cutoff) {
+			delete(c.locks.open, handle)
+		}
+	}
+	return len(c.locks.open) > 0
+}

--- a/pkg/adt/lock_window_test.go
+++ b/pkg/adt/lock_window_test.go
@@ -1,0 +1,186 @@
+package adt
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+)
+
+// lockWindowServer answers LOCK, UNLOCK, DELETE and the CSRF/ping probe, and
+// records every path it is asked for.
+func lockWindowServer(t *testing.T, seen *[]string, mu *sync.Mutex) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		*seen = append(*seen, r.URL.Path+"?"+r.URL.Query().Get("_action"))
+		mu.Unlock()
+		w.Header().Set("x-csrf-token", "TOKEN")
+		if r.URL.Query().Get("_action") == "LOCK" {
+			w.Header().Set("Content-Type", "application/xml")
+			_, _ = w.Write([]byte(`<?xml version="1.0"?><asx:abap xmlns:asx="http://www.sap.com/abapxml">
+			  <asx:values><DATA><LOCK_HANDLE>HANDLE-1</LOCK_HANDLE>
+			  <MODIFICATION_SUPPORT>Modification</MODIFICATION_SUPPORT></DATA></asx:values></asx:abap>`))
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+}
+
+func newLockWindowClient(t *testing.T, url string) *Client {
+	t.Helper()
+	return NewClient(url, "TESTUSER", "pw")
+}
+
+// TestLockWindow_SuppressesTheKeepAlivePing is the regression guard for #168:
+// a keep-alive ping is an ordinary request, an ordinary request is stamped
+// stateless, and a stateless request retires the session the lock handle lives
+// in. So no ping may go out while a lock is outstanding.
+func TestLockWindow_SuppressesTheKeepAlivePing(t *testing.T) {
+	var mu sync.Mutex
+	var seen []string
+	srv := lockWindowServer(t, &seen, &mu)
+	defer srv.Close()
+
+	c := newLockWindowClient(t, srv.URL)
+	if c.lockOutstanding() {
+		t.Fatal("a fresh client must not report an outstanding lock")
+	}
+
+	if _, err := c.LockObject(context.Background(), "/sap/bc/adt/programs/programs/ZDEMO", "MODIFY"); err != nil {
+		t.Fatalf("LockObject: %v", err)
+	}
+	if !c.lockOutstanding() {
+		t.Fatal("after a LOCK that returned a handle, the client must be inside a lock window")
+	}
+
+	if err := c.UnlockObject(context.Background(), "/sap/bc/adt/programs/programs/ZDEMO", "HANDLE-1"); err != nil {
+		t.Fatalf("UnlockObject: %v", err)
+	}
+	if c.lockOutstanding() {
+		t.Fatal("a successful UNLOCK must end the window")
+	}
+}
+
+// TestLockWindow_DeleteEndsTheWindow pins the defect that sank the first design
+// of this feature: DELETE consumes the lock handle and no UNLOCK is ever sent,
+// so a window keyed only on unlock stays open forever and the keep-alive is
+// disabled for the life of the process.
+func TestLockWindow_DeleteEndsTheWindow(t *testing.T) {
+	var mu sync.Mutex
+	var seen []string
+	srv := lockWindowServer(t, &seen, &mu)
+	defer srv.Close()
+
+	c := newLockWindowClient(t, srv.URL)
+	if _, err := c.LockObject(context.Background(), "/sap/bc/adt/programs/programs/ZDEMO", "MODIFY"); err != nil {
+		t.Fatalf("LockObject: %v", err)
+	}
+	if err := c.DeleteObject(context.Background(), "/sap/bc/adt/programs/programs/ZDEMO", "HANDLE-1", ""); err != nil {
+		t.Fatalf("DeleteObject: %v", err)
+	}
+
+	// Assert on the record itself, not on lockOutstanding(): the predicate can
+	// be made to answer "closed" for reasons that have nothing to do with the
+	// delete path, and this test exists precisely to pin that path.
+	c.locks.mu.Lock()
+	remaining := len(c.locks.open)
+	c.locks.mu.Unlock()
+	if remaining != 0 {
+		t.Fatalf("a successful DELETE consumes the handle and must clear it; %d entries left", remaining)
+	}
+}
+
+// TestLockWindow_StaleEntriesExpire proves a leaked handle cannot disable the
+// keep-alive permanently. Nothing can prove a lock was released, so an entry
+// that is never closed has to age out rather than suppress the ping forever.
+func TestLockWindow_StaleEntriesExpire(t *testing.T) {
+	c := &Client{}
+	c.noteLockOpened("LEAKED")
+	if !c.lockOutstanding() {
+		t.Fatal("a just-opened lock must count as outstanding")
+	}
+
+	c.locks.mu.Lock()
+	c.locks.open["LEAKED"] = time.Now().Add(-lockWindowMaxAge - time.Minute)
+	c.locks.mu.Unlock()
+
+	if c.lockOutstanding() {
+		t.Fatal("an entry older than lockWindowMaxAge must be pruned, not suppress the ping forever")
+	}
+}
+
+// TestLockWindow_IsConcurrencySafe runs locks and unlocks from several
+// goroutines because Client is shared across MCP handler calls. Run with -race.
+func TestLockWindow_IsConcurrencySafe(t *testing.T) {
+	c := &Client{}
+	var wg sync.WaitGroup
+	for i := 0; i < 32; i++ {
+		wg.Add(1)
+		go func(n int) {
+			defer wg.Done()
+			h := string(rune('A' + n%26))
+			c.noteLockOpened(h)
+			_ = c.lockOutstanding()
+			c.noteLockClosed(h)
+		}(i)
+	}
+	wg.Wait()
+	if c.lockOutstanding() {
+		t.Fatal("every lock was closed; the window must be empty")
+	}
+}
+
+// TestKeepAlive_DoesNotPingDuringALockWindow is the end-to-end guard: it drives
+// the real keep-alive goroutine rather than asserting on the flag it reads.
+// Without the skip, a tick inside the window sends a request to the discovery
+// endpoint, and on a live system that request retires the ADT session the lock
+// handle is bound to.
+func TestKeepAlive_DoesNotPingDuringALockWindow(t *testing.T) {
+	var mu sync.Mutex
+	var seen []string
+	srv := lockWindowServer(t, &seen, &mu)
+	defer srv.Close()
+
+	c := newLockWindowClient(t, srv.URL)
+	if _, err := c.LockObject(context.Background(), "/sap/bc/adt/programs/programs/ZDEMO", "MODIFY"); err != nil {
+		t.Fatalf("LockObject: %v", err)
+	}
+
+	mu.Lock()
+	afterLock := len(seen)
+	mu.Unlock()
+
+	c.StartKeepAlive(10*time.Millisecond, false)
+	time.Sleep(150 * time.Millisecond) // ~15 ticks
+	c.StopKeepAlive()
+
+	mu.Lock()
+	extra := seen[afterLock:]
+	mu.Unlock()
+
+	if len(extra) != 0 {
+		t.Fatalf("keep-alive sent %d request(s) while a lock was outstanding: %v", len(extra), extra)
+	}
+
+	// And once the lock is released it must resume, or the feature is just off.
+	if err := c.UnlockObject(context.Background(), "/sap/bc/adt/programs/programs/ZDEMO", "HANDLE-1"); err != nil {
+		t.Fatalf("UnlockObject: %v", err)
+	}
+	mu.Lock()
+	afterUnlock := len(seen)
+	mu.Unlock()
+
+	c.StartKeepAlive(10*time.Millisecond, false)
+	time.Sleep(150 * time.Millisecond)
+	c.StopKeepAlive()
+
+	mu.Lock()
+	resumed := len(seen) - afterUnlock
+	mu.Unlock()
+	if resumed == 0 {
+		t.Fatal("with no lock outstanding the keep-alive must ping; it pinged not at all")
+	}
+}


### PR DESCRIPTION
Closes #168. Implements the maintainer's decision: **default to 0 now, skip during the lock window**, with a switch between skipping and a stateful ping left as a follow-up.

## The defect

A keep-alive ping is an ordinary request. Under the stateless default an ordinary request carries an explicit `X-sap-adt-sessiontype: stateless`, which retires the ADT session — including the one a lock handle is bound to. A tick between LOCK and the write kills the handle; the write returns 423.

It was **on by default at five minutes** and started for every MCP session, gated by nothing: no whitelist, no object type, no command. That is the profile of the *intermittent* 423 in #91 — long runs of successful writes, then one failure with nothing changed.

## Changes

**`--keepalive` now defaults to 0.** An expired session tells the user and costs a re-login. A write that fails silently costs the write.

**A tick inside a lock window is skipped.** The tracking is deliberately modest — a map of handle → open-time, cleared on a successful UNLOCK and on a successful DELETE.

The delete case is the one that **sank an earlier attempt at this design**: a delete consumes the handle and no UNLOCK is ever sent, so a window keyed only on unlock stays open for the life of the process and silently disables the keep-alive. `TestLockWindow_DeleteEndsTheWindow` asserts on the record itself rather than the predicate, and fails if that hook is removed (verified by removing it).

**Entries expire after 30 minutes.** Nothing can prove a lock was released — a failed unlock may leave it held, a caller can drop a handle. So a leaked entry ages out instead of suppressing the ping forever; 30 min sits under SAP's ADT session timeout, past which a tracked lock cannot be alive. Entries clear only on *success*, because suppressing a ping is the cheap mistake.

## Tests

Five. Three fail without the change; two are guards, one of which fails if the delete hook is removed. `-race` clean, because `Client` is shared across MCP handler calls. `go build`, `go vet`, `go test ./...` green.

## Follow-up, not in scope here

The switch between *skip* and *stateful ping*, so a long idle session can be held without a lock window disabling it. The mechanism in this PR is what that switch would select against.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LQFAhfmJxybonf53QPEe5Q