### PR TITLE
fix(adt): a syntax warning is reported, not enforced

### DIFF
--- a/internal/mcp/handlers_fileio.go
+++ b/internal/mcp/handlers_fileio.go
@@ -231,6 +231,9 @@ func (s *Server) handleEditSource(ctx context.Context, request mcp.CallToolReque
 		method = m
 	}
 
+	// Accepted and ignored. Warnings no longer block an edit (#131), so this
+	// has no effect — it is still read so an existing caller that passes it is
+	// not rejected for sending an argument that used to be required.
 	ignoreWarnings := false
 	if iw, ok := request.GetArguments()["ignore_warnings"].(bool); ok {
 		ignoreWarnings = iw

--- a/pkg/adt/edit_warnings_test.go
+++ b/pkg/adt/edit_warnings_test.go
@@ -1,0 +1,101 @@
+package adt
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// warningSyntaxServer answers an edit flow whose syntax check reports one
+// warning (severity "W") and no errors.
+func warningSyntaxServer(t *testing.T, severity string) *httptest.Server {
+	t.Helper()
+	const source = "REPORT zdemo_warn.\nDATA lv_unused TYPE i.\nWRITE / 'x'.\n"
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("x-csrf-token", "TOKEN")
+		switch {
+		case strings.Contains(r.URL.Path, "checkruns"):
+			w.Header().Set("Content-Type", "application/xml")
+			_, _ = w.Write([]byte(`<?xml version="1.0"?>
+			<chkrun:checkRunReports xmlns:chkrun="http://www.sap.com/adt/checkrun">
+			  <chkrun:checkReport chkrun:reporter="abapCheckRun">
+			    <chkrun:checkMessageList>
+			      <chkrun:checkMessage
+			        chkrun:uri="/sap/bc/adt/programs/programs/ZDEMO_WARN/source/main#start=2,0"
+			        chkrun:type="` + severity + `"
+			        chkrun:shortText="Variable LV_UNUSED is never used"/>
+			    </chkrun:checkMessageList>
+			  </chkrun:checkReport>
+			</chkrun:checkRunReports>`))
+		case r.URL.Query().Get("_action") == "LOCK":
+			w.Header().Set("Content-Type", "application/xml")
+			_, _ = w.Write([]byte(`<?xml version="1.0"?><asx:abap xmlns:asx="http://www.sap.com/abapxml">
+			  <asx:values><DATA><LOCK_HANDLE>HANDLE-1</LOCK_HANDLE>
+			  <MODIFICATION_SUPPORT>Modification</MODIFICATION_SUPPORT></DATA></asx:values></asx:abap>`))
+		case r.Method == http.MethodGet && strings.HasSuffix(r.URL.Path, "/source/main"):
+			_, _ = w.Write([]byte(source))
+		default:
+			w.WriteHeader(http.StatusOK)
+		}
+	}))
+}
+
+// TestEditSource_WarningsDoNotBlock pins the decision behind #131: a syntax
+// warning is reported, not enforced. It used to refuse the write unless the
+// caller passed ignore_warnings on that individual call, which made vsp
+// stricter than Eclipse ADT and cost a write to say something the result
+// already carried.
+func TestEditSource_WarningsDoNotBlock(t *testing.T) {
+	srv := warningSyntaxServer(t, "W")
+	defer srv.Close()
+
+	c := NewClient(srv.URL, "TESTUSER", "pw")
+	res, err := c.EditSourceWithOptions(context.Background(),
+		"/sap/bc/adt/programs/programs/ZDEMO_WARN",
+		"WRITE / 'x'.", "WRITE / 'y'.",
+		&EditSourceOptions{SyntaxCheck: true}) // note: no IgnoreWarnings
+	if err != nil {
+		t.Fatalf("EditSourceWithOptions: %v", err)
+	}
+
+	if !res.Success {
+		t.Fatalf("a warning must not stop the write; got Success=false, message=%q", res.Message)
+	}
+	if len(res.SyntaxWarnings) != 1 {
+		t.Fatalf("the warning must still be reported; SyntaxWarnings=%v", res.SyntaxWarnings)
+	}
+	if len(res.SyntaxErrors) != 0 {
+		t.Fatalf("a warning must not be reported as an error; SyntaxErrors=%v", res.SyntaxErrors)
+	}
+	if !strings.Contains(res.Message, "warning") {
+		t.Fatalf("the message must name the warnings, or the only trace is a field nobody reads; got %q", res.Message)
+	}
+}
+
+// TestEditSource_ErrorsStillBlock is the other half of the same decision, and
+// the more important one: dropping the warning gate must not weaken the error
+// gate. An error means the object would not compile.
+func TestEditSource_ErrorsStillBlock(t *testing.T) {
+	srv := warningSyntaxServer(t, "E")
+	defer srv.Close()
+
+	c := NewClient(srv.URL, "TESTUSER", "pw")
+	res, err := c.EditSourceWithOptions(context.Background(),
+		"/sap/bc/adt/programs/programs/ZDEMO_WARN",
+		"WRITE / 'x'.", "WRITE / 'y'.",
+		&EditSourceOptions{SyntaxCheck: true})
+	if err != nil {
+		t.Fatalf("EditSourceWithOptions: %v", err)
+	}
+	if res.Success {
+		t.Fatal("a syntax error must still stop the write")
+	}
+	if len(res.SyntaxErrors) != 1 {
+		t.Fatalf("the error must be reported; SyntaxErrors=%v", res.SyntaxErrors)
+	}
+	if !strings.Contains(res.Message, "NOT saved") {
+		t.Fatalf("the refusal must say the change was not saved; got %q", res.Message)
+	}
+}

--- a/pkg/adt/workflows_edit.go
+++ b/pkg/adt/workflows_edit.go
@@ -10,24 +10,28 @@ import (
 
 // EditSourceResult represents the result of editing source code.
 type EditSourceResult struct {
-	Success        bool                `json:"success"`
-	ObjectURL      string              `json:"objectUrl"`
-	ObjectName     string              `json:"objectName"`
-	MatchCount     int                 `json:"matchCount"`
-	OldString      string              `json:"oldString,omitempty"`
-	NewString      string              `json:"newString,omitempty"`
-	SyntaxErrors   []string            `json:"syntaxErrors,omitempty"`
-	SyntaxWarnings []string            `json:"syntaxWarnings,omitempty"`
-	Activation     *ActivationResult   `json:"activation,omitempty"`
-	Message        string              `json:"message,omitempty"`
-	Method         string              `json:"method,omitempty"` // Method name if method-level edit
+	Success        bool              `json:"success"`
+	ObjectURL      string            `json:"objectUrl"`
+	ObjectName     string            `json:"objectName"`
+	MatchCount     int               `json:"matchCount"`
+	OldString      string            `json:"oldString,omitempty"`
+	NewString      string            `json:"newString,omitempty"`
+	SyntaxErrors   []string          `json:"syntaxErrors,omitempty"`
+	SyntaxWarnings []string          `json:"syntaxWarnings,omitempty"`
+	Activation     *ActivationResult `json:"activation,omitempty"`
+	Message        string            `json:"message,omitempty"`
+	Method         string            `json:"method,omitempty"` // Method name if method-level edit
 }
 
 // EditSourceOptions provides optional parameters for EditSource.
 type EditSourceOptions struct {
-	ReplaceAll      bool   // If true, replace all occurrences; if false, require unique match
-	SyntaxCheck     bool   // If true, validate syntax before saving (default: true if not set)
-	IgnoreWarnings  bool   // If true, only block on errors (E), allow warnings (W) and info (I)
+	ReplaceAll  bool // If true, replace all occurrences; if false, require unique match
+	SyntaxCheck bool // If true, validate syntax before saving (default: true if not set)
+	// Deprecated: warnings no longer block an edit, so this has no effect.
+	// Kept so existing callers keep compiling and existing MCP arguments keep
+	// being accepted rather than rejected as unknown. Warnings are reported in
+	// EditSourceResult.SyntaxWarnings and named in the result message.
+	IgnoreWarnings  bool
 	CaseInsensitive bool   // If true, ignore case when matching
 	Method          string // For CLAS only: constrain search/replace to this method only
 	Transport       string // Transport request number (required for non-$TMP packages)
@@ -135,14 +139,16 @@ func (c *Client) EditSource(ctx context.Context, objectURL, oldString, newString
 //   - opts: Optional parameters (ReplaceAll, SyntaxCheck, CaseInsensitive, Method)
 //
 // Method-level isolation (CLAS only):
-//   When opts.Method is set, the search is constrained to the specified method only.
-//   This prevents accidental edits in other methods when the same pattern exists elsewhere.
+//
+//	When opts.Method is set, the search is constrained to the specified method only.
+//	This prevents accidental edits in other methods when the same pattern exists elsewhere.
 //
 // Example:
-//   EditSourceWithOptions(ctx, "/sap/bc/adt/oo/classes/ZCL_TEST",
-//     "METHOD foo.\n  ENDMETHOD.",
-//     "METHOD foo.\n  rv_result = 42.\n  ENDMETHOD.",
-//     &EditSourceOptions{Method: "FOO"})
+//
+//	EditSourceWithOptions(ctx, "/sap/bc/adt/oo/classes/ZCL_TEST",
+//	  "METHOD foo.\n  ENDMETHOD.",
+//	  "METHOD foo.\n  rv_result = 42.\n  ENDMETHOD.",
+//	  &EditSourceOptions{Method: "FOO"})
 func (c *Client) EditSourceWithOptions(ctx context.Context, objectURL, oldString, newString string, opts *EditSourceOptions) (*EditSourceResult, error) {
 	// Default options
 	if opts == nil {
@@ -353,12 +359,19 @@ func (c *Client) EditSourceWithOptions(ctx context.Context, objectURL, oldString
 				return result, nil
 			}
 
-			if len(warnings) > 0 && !opts.IgnoreWarnings {
-				// Block on warnings unless ignore_warnings is set
-				result.SyntaxErrors = warnings
-				result.Message = fmt.Sprintf("Edit has %d syntax warning(s). Use ignore_warnings=true to proceed. Changes NOT saved.", len(warnings))
-				return result, nil
-			}
+			// Warnings do not block. They used to, unless the caller passed
+			// ignore_warnings on that call — which made vsp stricter than
+			// Eclipse ADT, where a warning is shown and the save proceeds.
+			//
+			// Blocking added no information: the warnings are in
+			// result.SyntaxWarnings either way, so a caller who wants to act on
+			// them can, and one who does not would not have read the refusal
+			// either. What it added was a refused write and a parameter the
+			// caller had to know to pass on every single call.
+			//
+			// Errors still block, above. That distinction is the whole point:
+			// an error means the object would not compile, a warning means
+			// somebody should look.
 		}
 	}
 
@@ -425,13 +438,19 @@ func (c *Client) EditSourceWithOptions(ctx context.Context, objectURL, oldString
 	result.Activation = activation
 
 	result.Success = true
+	// Warnings no longer stop the write, so the message has to carry them —
+	// otherwise the only trace is a field the caller may not read, and a
+	// warning nobody sees is the thing the old block was trying to prevent.
+	warned := ""
+	if n := len(result.SyntaxWarnings); n > 0 {
+		warned = fmt.Sprintf(" (%d syntax warning(s): see syntaxWarnings)", n)
+	}
 	if opts.Method != "" {
-		result.Message = fmt.Sprintf("Successfully edited method %s and activated %s", opts.Method, result.ObjectName)
+		result.Message = fmt.Sprintf("Successfully edited method %s and activated %s%s", opts.Method, result.ObjectName, warned)
 	} else if opts.ReplaceAll {
-		result.Message = fmt.Sprintf("Successfully replaced %d occurrences and activated %s", result.MatchCount, result.ObjectName)
+		result.Message = fmt.Sprintf("Successfully replaced %d occurrences and activated %s%s", result.MatchCount, result.ObjectName, warned)
 	} else {
-		result.Message = fmt.Sprintf("Successfully edited and activated %s", result.ObjectName)
+		result.Message = fmt.Sprintf("Successfully edited and activated %s%s", result.ObjectName, warned)
 	}
 	return result, nil
 }
-


### PR DESCRIPTION
Closes #131. Implements the maintainer's decision: **stop blocking by default; keep showing the warnings.**

## What was happening

An edit whose syntax check produced warnings was **refused**, unless the caller passed `ignore_warnings` on that individual call. Errors blocked too — correctly, an error means the object would not compile. Warnings blocking was the problem: it made vsp stricter than Eclipse ADT, which shows a warning and saves, over the ordinary ABAP kind of remark (unused variable, obsolete statement, suggested pragma).

## Why the gate bought nothing

The warnings were already in `EditSourceResult.SyntaxWarnings` whether the write happened or not. So a caller who wanted to act on them could either way, and one who did not was not going to read the refusal either. What the gate added was a refused write and a parameter the caller had to know to pass **every single time** — and `ignore_warnings` is not declared in the tool schema (`handlers_fileio.go:235` reads it straight from the arguments), so an agent had no way to discover it existed.

## What changes

- Warnings no longer stop the write. **Errors still do**, and there is a test that fails if that ever stops being true.
- Warnings now appear in the **success message** as well as the field. The one real argument for blocking was that a warning nobody looks at is wasted, and a message is harder not to look at than a field.
- `ignore_warnings` stays accepted and does nothing, so a caller passing it today is not rejected for sending an argument that used to be required.

## Tests

`TestEditSource_WarningsDoNotBlock` — writes, reports the warning, names it in the message. Fails without this change.
`TestEditSource_ErrorsStillBlock` — the other half, and the one that matters more: dropping the warning gate must not weaken the error gate.

Building the fixture turned up its own small lesson: my first attempt used a plausible-looking `<chkl:messages>` shape and parsed to zero messages. The real response is `<chkrun:checkRunReports>` → `checkReport` → `checkMessageList`. A test that constructs the wrong shape passes for the wrong reason, so it is worth saying that this one was corrected against the parser rather than written from memory.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LQFAhfmJxybonf53QPEe5Q