### PR TITLE
fix: fail closed on write and deployment outcomes

### DIFF
--- a/cmd/vsp/copy_cmd.go
+++ b/cmd/vsp/copy_cmd.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/oisee/vibing-steampunk/embedded/deps"
+	installer "github.com/oisee/vibing-steampunk/internal/install"
 	"github.com/oisee/vibing-steampunk/pkg/adt"
 	"github.com/spf13/cobra"
 )
@@ -140,7 +141,7 @@ func runCopy(cmd *cobra.Command, args []string) error {
 	// Check if ZADT_VSP is available
 	wsAvailable := checkWebSocketAvailable(client, ctx)
 	if wsAvailable {
-		fmt.Println("Mode: WebSocket (ZADT_VSP available - full object type support)")
+		fmt.Println("Mode: ADT Native (ZADT_VSP detected; WebSocket copy deployment is not implemented)")
 	} else {
 		fmt.Println("Mode: ADT Native (fallback - PROG, CLAS, INTF, DDLS, BDEF, SRVD)")
 	}
@@ -150,21 +151,12 @@ func runCopy(cmd *cobra.Command, args []string) error {
 	fmt.Printf("Deployment Plan (%d objects):\n", len(filteredObjects))
 	fmt.Println(strings.Repeat("-", 60))
 
-	adtSupported := map[string]bool{
-		"PROG": true,
-		"CLAS": true,
-		"INTF": true,
-		"DDLS": true,
-		"BDEF": true,
-		"SRVD": true,
-	}
-
 	var deployable, skipped int
 	for _, obj := range filteredObjects {
-		supported := wsAvailable || adtSupported[obj.Type]
+		supported, reason := copyObjectSupported(obj)
 		status := "✓"
 		if !supported {
-			status = "⊘ (requires ZADT_VSP)"
+			status = fmt.Sprintf("⊘ (%s)", reason)
 			skipped++
 		} else {
 			deployable++
@@ -197,17 +189,12 @@ func runCopy(cmd *cobra.Command, args []string) error {
 
 	// Ensure package exists
 	fmt.Printf("Checking package %s...\n", copyToPackage)
-	_, err = client.GetPackage(ctx, copyToPackage)
+	created, err := installer.EnsurePackage(ctx, client, copyToPackage, fmt.Sprintf("Deployed from %s", sourceName))
 	if err != nil {
-		fmt.Printf("Creating package %s...\n", copyToPackage)
-		err = client.CreateObject(ctx, adt.CreateObjectOptions{
-			ObjectType:  adt.ObjectTypePackage,
-			Name:        copyToPackage,
-			Description: fmt.Sprintf("Deployed from %s", sourceName),
-		})
-		if err != nil {
-			return fmt.Errorf("failed to create package: %w", err)
-		}
+		return fmt.Errorf("failed to ensure target package: %w", err)
+	}
+	if created {
+		fmt.Printf("Created and verified package %s\n", copyToPackage)
 	}
 
 	// Deploy objects
@@ -215,14 +202,14 @@ func runCopy(cmd *cobra.Command, args []string) error {
 	var success, failed int
 
 	for _, obj := range filteredObjects {
-		supported := wsAvailable || adtSupported[obj.Type]
+		supported, _ := copyObjectSupported(obj)
 		if !supported {
 			continue
 		}
 
 		fmt.Printf("  Deploying %s %s... ", obj.Type, obj.Name)
 
-		err := deployObject(ctx, client, obj, copyToPackage, wsAvailable)
+		err := deployObject(ctx, client, obj, copyToPackage)
 		if err != nil {
 			fmt.Printf("FAILED: %v\n", err)
 			failed++
@@ -235,13 +222,32 @@ func runCopy(cmd *cobra.Command, args []string) error {
 	fmt.Println()
 	fmt.Printf("Deployment complete: %d success, %d failed\n", success, failed)
 
-	if !wsAvailable && skipped > 0 {
-		fmt.Println("\nNote: Some objects were skipped because ZADT_VSP is not installed.")
-		fmt.Println("Install ZADT_VSP first to enable full object type support:")
-		fmt.Println("  vsp -s <system> copy --embedded zadt-vsp --to $ZADT_VSP")
+	if skipped > 0 {
+		fmt.Println("\nNote: Unsupported or incomplete object types were skipped before deployment.")
 	}
 
-	return nil
+	return deploymentSummaryError(failed, skipped)
+}
+
+func deploymentSummaryError(failed, skipped int) error {
+	if failed == 0 && skipped == 0 {
+		return nil
+	}
+	return fmt.Errorf("deployment incomplete: %d failed and %d skipped object(s)", failed, skipped)
+}
+
+func copyObjectSupported(obj deps.DeploymentObject) (bool, string) {
+	switch obj.Type {
+	case "PROG", "INTF", "DDLS", "BDEF", "SRVD":
+		return true, ""
+	case "CLAS": //nolint:misspell // CLAS is the SAP object type.
+		if len(obj.Includes) > 0 {
+			return false, "class include deployment is not implemented"
+		}
+		return true, ""
+	default:
+		return false, "object type is not supported by ADT copy deployment"
+	}
 }
 
 // checkWebSocketAvailable tests if ZADT_VSP WebSocket is available.
@@ -254,13 +260,8 @@ func checkWebSocketAvailable(client *adt.Client, ctx context.Context) bool {
 	return results[0].Name == "ZCL_VSP_APC_HANDLER"
 }
 
-// deployObject deploys a single object using ADT native or WebSocket.
-func deployObject(ctx context.Context, client *adt.Client, obj deps.DeploymentObject, packageName string, useWebSocket bool) error {
-	if useWebSocket {
-		// TODO: Implement WebSocket-based deployment
-		// For now, fall through to ADT native
-	}
-
+// deployObject deploys a single object using ADT native.
+func deployObject(ctx context.Context, client *adt.Client, obj deps.DeploymentObject, packageName string) error {
 	// ADT Native deployment
 	switch obj.Type {
 	case "PROG":
@@ -295,36 +296,26 @@ func deployProgram(ctx context.Context, client *adt.Client, obj deps.DeploymentO
 	if err != nil {
 		return err
 	}
-	if !result.Success {
-		return fmt.Errorf("WriteSource failed: %s", result.Message)
-	}
-	return nil
+	return adt.WriteSourceResultError(result)
 }
 
 func deployClass(ctx context.Context, client *adt.Client, obj deps.DeploymentObject, packageName string) error {
+	if len(obj.Includes) > 0 {
+		return fmt.Errorf("class include deployment is not implemented; refusing partial deployment")
+	}
 	desc := obj.Description
 	if desc == "" {
 		desc = fmt.Sprintf("Deployed: %s", obj.Name)
 	}
 	// Deploy main class
-	_, err := client.WriteSource(ctx, "CLAS", obj.Name, obj.MainSource, &adt.WriteSourceOptions{
+	result, err := client.WriteSource(ctx, "CLAS", obj.Name, obj.MainSource, &adt.WriteSourceOptions{ //nolint:misspell // CLAS is the SAP object type.
 		Package:     packageName,
 		Description: desc,
 	})
 	if err != nil {
 		return err
 	}
-
-	// Deploy includes (TODO: implement include deployment)
-	if len(obj.Includes) > 0 {
-		var incTypes []string
-		for t := range obj.Includes {
-			incTypes = append(incTypes, t)
-		}
-		fmt.Printf("\n    Note: class includes [%s] not yet deployed (TODO)\n", strings.Join(incTypes, ","))
-	}
-
-	return nil
+	return adt.WriteSourceResultError(result)
 }
 
 func deployInterface(ctx context.Context, client *adt.Client, obj deps.DeploymentObject, packageName string) error {
@@ -332,11 +323,14 @@ func deployInterface(ctx context.Context, client *adt.Client, obj deps.Deploymen
 	if desc == "" {
 		desc = fmt.Sprintf("Deployed: %s", obj.Name)
 	}
-	_, err := client.WriteSource(ctx, "INTF", obj.Name, obj.MainSource, &adt.WriteSourceOptions{
+	result, err := client.WriteSource(ctx, "INTF", obj.Name, obj.MainSource, &adt.WriteSourceOptions{
 		Package:     packageName,
 		Description: desc,
 	})
-	return err
+	if err != nil {
+		return err
+	}
+	return adt.WriteSourceResultError(result)
 }
 
 func deployDDLS(ctx context.Context, client *adt.Client, obj deps.DeploymentObject, packageName string) error {
@@ -344,11 +338,14 @@ func deployDDLS(ctx context.Context, client *adt.Client, obj deps.DeploymentObje
 	if desc == "" {
 		desc = fmt.Sprintf("Deployed: %s", obj.Name)
 	}
-	_, err := client.WriteSource(ctx, "DDLS", obj.Name, obj.MainSource, &adt.WriteSourceOptions{
+	result, err := client.WriteSource(ctx, "DDLS", obj.Name, obj.MainSource, &adt.WriteSourceOptions{
 		Package:     packageName,
 		Description: desc,
 	})
-	return err
+	if err != nil {
+		return err
+	}
+	return adt.WriteSourceResultError(result)
 }
 
 func deployBDEF(ctx context.Context, client *adt.Client, obj deps.DeploymentObject, packageName string) error {
@@ -356,11 +353,14 @@ func deployBDEF(ctx context.Context, client *adt.Client, obj deps.DeploymentObje
 	if desc == "" {
 		desc = fmt.Sprintf("Deployed: %s", obj.Name)
 	}
-	_, err := client.WriteSource(ctx, "BDEF", obj.Name, obj.MainSource, &adt.WriteSourceOptions{
+	result, err := client.WriteSource(ctx, "BDEF", obj.Name, obj.MainSource, &adt.WriteSourceOptions{
 		Package:     packageName,
 		Description: desc,
 	})
-	return err
+	if err != nil {
+		return err
+	}
+	return adt.WriteSourceResultError(result)
 }
 
 func deploySRVD(ctx context.Context, client *adt.Client, obj deps.DeploymentObject, packageName string) error {
@@ -368,9 +368,12 @@ func deploySRVD(ctx context.Context, client *adt.Client, obj deps.DeploymentObje
 	if desc == "" {
 		desc = fmt.Sprintf("Deployed: %s", obj.Name)
 	}
-	_, err := client.WriteSource(ctx, "SRVD", obj.Name, obj.MainSource, &adt.WriteSourceOptions{
+	result, err := client.WriteSource(ctx, "SRVD", obj.Name, obj.MainSource, &adt.WriteSourceOptions{
 		Package:     packageName,
 		Description: desc,
 	})
-	return err
+	if err != nil {
+		return err
+	}
+	return adt.WriteSourceResultError(result)
 }

--- a/cmd/vsp/copy_cmd_test.go
+++ b/cmd/vsp/copy_cmd_test.go
@@ -1,0 +1,43 @@
+package main
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/oisee/vibing-steampunk/embedded/deps"
+)
+
+func TestDeploymentSummaryError(t *testing.T) {
+	if err := deploymentSummaryError(0, 0); err != nil {
+		t.Fatalf("deploymentSummaryError(0, 0) = %v, want nil", err)
+	}
+	if err := deploymentSummaryError(2, 1); err == nil || !strings.Contains(err.Error(), "2 failed and 1 skipped") {
+		t.Fatalf("deploymentSummaryError(2, 1) = %v, want failure and skip counts", err)
+	}
+}
+
+func TestCopyObjectSupported(t *testing.T) {
+	tests := []struct {
+		name       string
+		object     deps.DeploymentObject
+		want       bool
+		wantReason string
+	}{
+		{name: "program", object: deps.DeploymentObject{Type: "PROG"}, want: true},
+		{name: "class main", object: deps.DeploymentObject{Type: "CLAS"}, want: true},
+		{name: "class includes", object: deps.DeploymentObject{Type: "CLAS", Includes: map[string]string{"testclasses": "synthetic"}}, wantReason: "include deployment"},
+		{name: "unsupported type", object: deps.DeploymentObject{Type: "TABL"}, wantReason: "not supported"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, reason := copyObjectSupported(tt.object)
+			if got != tt.want {
+				t.Fatalf("copyObjectSupported() = %v, want %v", got, tt.want)
+			}
+			if tt.wantReason != "" && !strings.Contains(reason, tt.wantReason) {
+				t.Fatalf("reason = %q, want substring %q", reason, tt.wantReason)
+			}
+		})
+	}
+}

--- a/cmd/vsp/devops.go
+++ b/cmd/vsp/devops.go
@@ -12,6 +12,7 @@ import (
 
 	embedded "github.com/oisee/vibing-steampunk/embedded/abap"
 	"github.com/oisee/vibing-steampunk/embedded/deps"
+	installer "github.com/oisee/vibing-steampunk/internal/install"
 	"github.com/oisee/vibing-steampunk/pkg/adt"
 	"github.com/oisee/vibing-steampunk/pkg/ctxcomp"
 	"github.com/oisee/vibing-steampunk/pkg/graph"
@@ -3380,13 +3381,12 @@ func runInstallZadtVsp(cmd *cobra.Command, args []string) error {
 	// Check if package exists.
 	// GetPackage reads the nodestructure API and cannot distinguish
 	// "package does not exist" from "package exists but has no children",
-	// so we use the direct PackageExists probe here. If the probe itself
-	// errors (5xx, network), we fall through to the create path and let
-	// SAP's own error surface there.
+	// so we use the direct PackageExists probe here. An inconclusive probe
+	// must not be treated as absence, because that could turn a network or
+	// authorization failure into an unintended create attempt.
 	packageExists, err := client.PackageExists(ctx, packageName)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "  Package %s existence check failed: %v — will attempt create\n", packageName, err)
-		packageExists = false
+		return fmt.Errorf("failed to check package %s: %w", packageName, err)
 	}
 	if packageExists {
 		fmt.Fprintf(os.Stderr, "  Package %s exists\n", packageName)
@@ -3451,17 +3451,12 @@ func runInstallZadtVsp(cmd *cobra.Command, args []string) error {
 	}
 
 	// Phase 2: Create package if needed
-	if !packageExists {
-		fmt.Fprintf(os.Stderr, "Creating package %s...\n", packageName)
-		err := client.CreateObject(ctx, adt.CreateObjectOptions{
-			ObjectType:  adt.ObjectTypePackage,
-			Name:        packageName,
-			Description: "VSP WebSocket Handler",
-		})
-		if err != nil {
-			return fmt.Errorf("failed to create package %s: %w", packageName, err)
-		}
-		fmt.Fprintf(os.Stderr, "  Package created\n\n")
+	created, err := installer.EnsurePackage(ctx, client, packageName, "VSP WebSocket Handler")
+	if err != nil {
+		return fmt.Errorf("failed to ensure package %s: %w", packageName, err)
+	}
+	if created {
+		fmt.Fprintf(os.Stderr, "Package %s created and verified\n\n", packageName)
 	} else {
 		fmt.Fprintf(os.Stderr, "Using existing package %s\n\n", packageName)
 	}
@@ -3488,19 +3483,11 @@ func runInstallZadtVsp(cmd *cobra.Command, args []string) error {
 			Description: obj.Description,
 			Mode:        adt.WriteModeUpsert,
 		}
-		res, err := client.WriteSource(ctx, obj.Type, obj.Name, obj.Source, opts)
-		switch {
-		case err != nil:
+		_, err := installer.DeploySource(ctx, client, obj.Type, obj.Name, obj.Source, opts)
+		if err != nil {
 			fmt.Fprintf(os.Stderr, "FAILED: %v\n", err)
 			failed++
-		case res == nil || !res.Success:
-			msg := "unknown failure"
-			if res != nil && res.Message != "" {
-				msg = res.Message
-			}
-			fmt.Fprintf(os.Stderr, "FAILED: %s\n", msg)
-			failed++
-		default:
+		} else {
 			fmt.Fprintf(os.Stderr, "OK\n")
 			deployed++
 		}
@@ -3512,6 +3499,7 @@ func runInstallZadtVsp(cmd *cobra.Command, args []string) error {
 	if failed > 0 {
 		fmt.Fprintf(os.Stderr, "DEPLOYMENT PARTIALLY FAILED\n")
 		fmt.Fprintf(os.Stderr, "Deployed: %d, Skipped: %d, Failed: %d\n\n", deployed, skipped, failed)
+		return fmt.Errorf("%d object(s) failed to deploy; post-deployment features were not declared ready", failed)
 	} else {
 		fmt.Fprintf(os.Stderr, "DEPLOYMENT COMPLETE\n")
 		fmt.Fprintf(os.Stderr, "Deployed: %d, Skipped: %d\n\n", deployed, skipped)
@@ -3531,9 +3519,6 @@ func runInstallZadtVsp(cmd *cobra.Command, args []string) error {
 		fmt.Fprintf(os.Stderr, "  abapGit export NOT available (install abapGit first)\n")
 	}
 
-	if failed > 0 {
-		return fmt.Errorf("%d object(s) failed to deploy", failed)
-	}
 	return nil
 }
 
@@ -3640,22 +3625,12 @@ func runInstallAbapGit(cmd *cobra.Command, args []string) error {
 	// a GetPackage-based check cannot distinguish "absent" from "present but
 	// empty" because nodestructure returns an empty tree in both cases.
 	fmt.Fprintf(os.Stderr, "Checking package %s...\n", packageName)
-	exists, pkgErr := client.PackageExists(ctx, packageName)
+	created, pkgErr := installer.EnsurePackage(ctx, client, packageName, fmt.Sprintf("abapGit %s edition", edition))
 	if pkgErr != nil {
-		fmt.Fprintf(os.Stderr, "  Package existence check failed: %v — will attempt create\n", pkgErr)
-		exists = false
+		return fmt.Errorf("failed to ensure package: %w", pkgErr)
 	}
-	if !exists {
-		fmt.Fprintf(os.Stderr, "Creating package %s...\n", packageName)
-		err = client.CreateObject(ctx, adt.CreateObjectOptions{
-			ObjectType:  adt.ObjectTypePackage,
-			Name:        packageName,
-			Description: fmt.Sprintf("abapGit %s edition", edition),
-		})
-		if err != nil {
-			return fmt.Errorf("failed to create package: %w", err)
-		}
-		fmt.Fprintf(os.Stderr, "  Package created\n")
+	if created {
+		fmt.Fprintf(os.Stderr, "  Package created and verified\n")
 	} else {
 		fmt.Fprintf(os.Stderr, "  Package exists\n")
 	}
@@ -3682,7 +3657,7 @@ func runInstallAbapGit(cmd *cobra.Command, args []string) error {
 			Description: desc,
 			Mode:        adt.WriteModeUpsert,
 		}
-		_, err := client.WriteSource(ctx, obj.Type, obj.Name, obj.MainSource, wopts)
+		_, err := installer.DeploySource(ctx, client, obj.Type, obj.Name, obj.MainSource, wopts)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "FAILED: %v\n", err)
 			failCount++

--- a/internal/install/install.go
+++ b/internal/install/install.go
@@ -1,0 +1,87 @@
+// Package install contains fail-closed primitives shared by CLI and MCP
+// installers.
+package install
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/oisee/vibing-steampunk/pkg/adt"
+)
+
+// Client is the subset of the ADT client required by installers.
+type Client interface {
+	PackageExists(context.Context, string) (bool, error)
+	CreateObject(context.Context, adt.CreateObjectOptions) error
+	WriteSource(context.Context, string, string, string, *adt.WriteSourceOptions) (*adt.WriteSourceResult, error)
+	GetSource(context.Context, string, string, *adt.GetSourceOptions) (string, error)
+}
+
+// EnsurePackage proves that a package exists, creating and re-probing it only
+// after a definite missing result. A create error is tolerated only if a fresh
+// probe proves that the package now exists, as can happen with a concurrent
+// create.
+func EnsurePackage(ctx context.Context, client Client, name, description string) (created bool, err error) {
+	exists, err := client.PackageExists(ctx, name)
+	if err != nil {
+		return false, fmt.Errorf("package existence check was inconclusive: %w", err)
+	}
+	if exists {
+		return false, nil
+	}
+
+	createErr := client.CreateObject(ctx, adt.CreateObjectOptions{
+		ObjectType:  adt.ObjectTypePackage,
+		Name:        name,
+		Description: description,
+	})
+	exists, verifyErr := client.PackageExists(ctx, name)
+	if verifyErr != nil {
+		if createErr != nil {
+			return false, fmt.Errorf("package create failed (%v) and verification was inconclusive: %w", createErr, verifyErr)
+		}
+		return false, fmt.Errorf("package creation could not be verified: %w", verifyErr)
+	}
+	if !exists {
+		if createErr != nil {
+			return false, fmt.Errorf("package create failed and package is still absent: %w", createErr)
+		}
+		return false, fmt.Errorf("package creation returned success but package is still absent")
+	}
+	if createErr != nil {
+		return false, nil
+	}
+	return true, nil
+}
+
+// DeploySource writes one object, validates the structured workflow result,
+// and proves the object can be read back before reporting success.
+func DeploySource(ctx context.Context, client Client, objectType, name, source string, opts *adt.WriteSourceOptions) (*adt.WriteSourceResult, error) {
+	result, err := client.WriteSource(ctx, objectType, name, source, opts)
+	if err != nil {
+		return result, err
+	}
+	if err := adt.WriteSourceResultError(result); err != nil {
+		return result, err
+	}
+	for _, syntax := range result.SyntaxErrors {
+		severity := strings.ToUpper(strings.TrimSpace(syntax.Severity))
+		if severity == "E" || severity == "A" || severity == "X" {
+			return result, fmt.Errorf("WriteSource reported a syntax error")
+		}
+	}
+	if result.Activation != nil {
+		if err := adt.ActivationResultError(result.Activation); err != nil {
+			return result, fmt.Errorf("WriteSource reported %w", err)
+		}
+	}
+	readBack, err := client.GetSource(ctx, objectType, name, nil)
+	if err != nil {
+		return result, fmt.Errorf("source read-back failed: %w", err)
+	}
+	if strings.TrimSpace(readBack) == "" {
+		return result, fmt.Errorf("source read-back was empty")
+	}
+	return result, nil
+}

--- a/internal/install/install.go
+++ b/internal/install/install.go
@@ -62,8 +62,8 @@ func DeploySource(ctx context.Context, client Client, objectType, name, source s
 	if err != nil {
 		return result, err
 	}
-	if err := adt.WriteSourceResultError(result); err != nil {
-		return result, err
+	if resultErr := adt.WriteSourceResultError(result); resultErr != nil {
+		return result, resultErr
 	}
 	for _, syntax := range result.SyntaxErrors {
 		severity := strings.ToUpper(strings.TrimSpace(syntax.Severity))
@@ -72,8 +72,8 @@ func DeploySource(ctx context.Context, client Client, objectType, name, source s
 		}
 	}
 	if result.Activation != nil {
-		if err := adt.ActivationResultError(result.Activation); err != nil {
-			return result, fmt.Errorf("WriteSource reported %w", err)
+		if activationErr := adt.ActivationResultError(result.Activation); activationErr != nil {
+			return result, fmt.Errorf("WriteSource reported %w", activationErr)
 		}
 	}
 	readBack, err := client.GetSource(ctx, objectType, name, nil)

--- a/internal/install/install_test.go
+++ b/internal/install/install_test.go
@@ -1,0 +1,115 @@
+package install
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/oisee/vibing-steampunk/pkg/adt"
+)
+
+type fakeClient struct {
+	packageProbes []packageProbe
+	probeIndex    int
+	createErr     error
+	createCalls   int
+	writeResult   *adt.WriteSourceResult
+	writeErr      error
+	writeOpts     *adt.WriteSourceOptions
+	readBack      string
+	readBackErr   error
+}
+
+type packageProbe struct {
+	exists bool
+	err    error
+}
+
+func (f *fakeClient) PackageExists(context.Context, string) (bool, error) {
+	if f.probeIndex >= len(f.packageProbes) {
+		return false, errors.New("unexpected package probe")
+	}
+	probe := f.packageProbes[f.probeIndex]
+	f.probeIndex++
+	return probe.exists, probe.err
+}
+
+func (f *fakeClient) CreateObject(context.Context, adt.CreateObjectOptions) error {
+	f.createCalls++
+	return f.createErr
+}
+
+func (f *fakeClient) WriteSource(_ context.Context, _, _, _ string, opts *adt.WriteSourceOptions) (*adt.WriteSourceResult, error) {
+	f.writeOpts = opts
+	return f.writeResult, f.writeErr
+}
+
+func (f *fakeClient) GetSource(context.Context, string, string, *adt.GetSourceOptions) (string, error) {
+	return f.readBack, f.readBackErr
+}
+
+func TestEnsurePackage(t *testing.T) {
+	tests := []struct {
+		name        string
+		fake        *fakeClient
+		wantCreated bool
+		wantErr     bool
+		wantCreates int
+	}{
+		{name: "existing", fake: &fakeClient{packageProbes: []packageProbe{{exists: true}}}},
+		{name: "created and verified", fake: &fakeClient{packageProbes: []packageProbe{{}, {exists: true}}}, wantCreated: true, wantCreates: 1},
+		{name: "concurrent create verified", fake: &fakeClient{packageProbes: []packageProbe{{}, {exists: true}}, createErr: errors.New("already exists")}, wantCreates: 1},
+		{name: "initial probe inconclusive", fake: &fakeClient{packageProbes: []packageProbe{{err: errors.New("synthetic auth failure")}}}, wantErr: true},
+		{name: "success but absent", fake: &fakeClient{packageProbes: []packageProbe{{}, {}}}, wantErr: true, wantCreates: 1},
+		{name: "create failed and absent", fake: &fakeClient{packageProbes: []packageProbe{{}, {}}, createErr: errors.New("synthetic create failure")}, wantErr: true, wantCreates: 1},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			created, err := EnsurePackage(context.Background(), tt.fake, "$SYNTHETIC", "Synthetic package")
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("error = %v, wantErr=%t", err, tt.wantErr)
+			}
+			if created != tt.wantCreated {
+				t.Fatalf("created = %t, want %t", created, tt.wantCreated)
+			}
+			if tt.fake.createCalls != tt.wantCreates {
+				t.Fatalf("create calls = %d, want %d", tt.fake.createCalls, tt.wantCreates)
+			}
+		})
+	}
+}
+
+func TestDeploySource(t *testing.T) {
+	tests := []struct {
+		name    string
+		fake    *fakeClient
+		wantErr string
+	}{
+		{name: "verified", fake: &fakeClient{writeResult: &adt.WriteSourceResult{Success: true, Activation: &adt.ActivationResult{Success: true}}, readBack: "synthetic source"}},
+		{name: "transport error", fake: &fakeClient{writeErr: errors.New("synthetic request failure")}, wantErr: "synthetic request failure"},
+		{name: "nil result", fake: &fakeClient{}, wantErr: "no result"},
+		{name: "logical failure", fake: &fakeClient{writeResult: &adt.WriteSourceResult{Message: "synthetic workflow failure"}}, wantErr: "synthetic workflow failure"},
+		{name: "syntax failure", fake: &fakeClient{writeResult: &adt.WriteSourceResult{Success: true, SyntaxErrors: []adt.SyntaxCheckResult{{Severity: "E"}}}}, wantErr: "syntax error"},
+		{name: "activation failure", fake: &fakeClient{writeResult: &adt.WriteSourceResult{Success: true, Activation: &adt.ActivationResult{Messages: []adt.ActivationResultMessage{{Type: "E", ShortText: "synthetic activation failure"}}}}}, wantErr: "activation failure"},
+		{name: "read-back failure", fake: &fakeClient{writeResult: &adt.WriteSourceResult{Success: true}, readBackErr: errors.New("synthetic read failure")}, wantErr: "read-back failed"},
+		{name: "empty read-back", fake: &fakeClient{writeResult: &adt.WriteSourceResult{Success: true}, readBack: "  "}, wantErr: "read-back was empty"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			opts := &adt.WriteSourceOptions{Description: "Synthetic object"}
+			_, err := DeploySource(context.Background(), tt.fake, "CLAS", "ZCL_SYNTHETIC", "synthetic source", opts)
+			if tt.wantErr == "" && err != nil {
+				t.Fatal(err)
+			}
+			if tt.wantErr != "" && (err == nil || !strings.Contains(err.Error(), tt.wantErr)) {
+				t.Fatalf("error = %v, want substring %q", err, tt.wantErr)
+			}
+			if tt.fake.writeOpts != opts {
+				t.Fatal("write options were not forwarded")
+			}
+		})
+	}
+}

--- a/internal/mcp/handlers_devtools.go
+++ b/internal/mcp/handlers_devtools.go
@@ -91,6 +91,9 @@ func (s *Server) handleActivate(ctx context.Context, request mcp.CallToolRequest
 	if err != nil {
 		return newToolResultError(fmt.Sprintf("Activation failed: %v", err)), nil
 	}
+	if err := adt.ActivationResultError(result); err != nil {
+		return newToolResultError(err.Error()), nil
+	}
 
 	output, _ := json.MarshalIndent(result, "", "  ")
 	return mcp.NewToolResultText(string(output)), nil

--- a/internal/mcp/handlers_devtools.go
+++ b/internal/mcp/handlers_devtools.go
@@ -92,7 +92,10 @@ func (s *Server) handleActivate(ctx context.Context, request mcp.CallToolRequest
 		return newToolResultError(fmt.Sprintf("Activation failed: %v", err)), nil
 	}
 	if err := adt.ActivationResultError(result); err != nil {
-		return newToolResultError(err.Error()), nil
+		// Same reasoning as the WriteSource boundary: the activation messages
+		// are the diagnosis, and a verdict without them is not actionable.
+		payload, _ := json.MarshalIndent(result, "", "  ")
+		return newToolResultError(fmt.Sprintf("%v\n\n%s", err, payload)), nil
 	}
 
 	output, _ := json.MarshalIndent(result, "", "  ")

--- a/internal/mcp/handlers_install.go
+++ b/internal/mcp/handlers_install.go
@@ -10,6 +10,7 @@ import (
 	"github.com/mark3labs/mcp-go/mcp"
 	embedded "github.com/oisee/vibing-steampunk/embedded/abap"
 	"github.com/oisee/vibing-steampunk/embedded/deps"
+	installer "github.com/oisee/vibing-steampunk/internal/install"
 	"github.com/oisee/vibing-steampunk/pkg/adt"
 )
 
@@ -85,31 +86,23 @@ func (s *Server) handleInstallDummyTest(ctx context.Context, request mcp.CallToo
 
 	// Step 1: Check/Create package (upsert strategy)
 	step("Package Check/Create")
-	pkg, err := s.adtClient.GetPackage(ctx, testPackage)
-	packageExists := err == nil && pkg.URI != "" // URI empty = package doesn't really exist
-	if !packageExists {
+	packageExists, err := s.adtClient.PackageExists(ctx, testPackage)
+	switch {
+	case err != nil:
+		fail(fmt.Sprintf("PackageExists failed: %v", err))
+	case !packageExists:
 		info("Package doesn't exist, creating...")
 		if checkOnly {
 			info("SKIP (check_only mode)")
 		} else {
-			err = s.adtClient.CreateObject(ctx, adt.CreateObjectOptions{
-				ObjectType:  adt.ObjectTypePackage,
-				Name:        testPackage,
-				Description: "Install Tools Test Package",
-			})
+			_, err = installer.EnsurePackage(ctx, s.adtClient, testPackage, "Install Tools Test Package")
 			if err != nil {
-				fail(fmt.Sprintf("CreateObject(package) failed: %v", err))
+				fail(fmt.Sprintf("EnsurePackage failed: %v", err))
 			} else {
-				// Verify
-				pkg, err = s.adtClient.GetPackage(ctx, testPackage)
-				if err != nil || pkg.URI == "" {
-					fail("Verification failed: package not found after create")
-				} else {
-					pass("Package created and verified")
-				}
+				pass("Package created and verified")
 			}
 		}
-	} else {
+	default:
 		pass("Package exists")
 	}
 
@@ -331,11 +324,11 @@ func (s *Server) handleInstallZADTVSP(ctx context.Context, request mcp.CallToolR
 	// Phase 1: Check prerequisites
 	sb.WriteString("Checking prerequisites...\n")
 
-	// Check if package exists (verify URI is populated - empty URI means package doesn't really exist)
-	packageExists := false
-	pkg, err := s.adtClient.GetPackage(ctx, packageName)
-	if err == nil && pkg.URI != "" {
-		packageExists = true
+	packageExists, err := s.adtClient.PackageExists(ctx, packageName)
+	if err != nil {
+		return newToolResultError(fmt.Sprintf("Failed to check package %s: %v", packageName, err)), nil
+	}
+	if packageExists {
 		fmt.Fprintf(&sb, "  ✓ Package %s exists\n", packageName)
 	} else {
 		fmt.Fprintf(&sb, "  → Package %s will be created\n", packageName)
@@ -387,23 +380,12 @@ func (s *Server) handleInstallZADTVSP(ctx context.Context, request mcp.CallToolR
 	defer cleanupPkgSafety()
 
 	// Phase 2: Create package if needed
-	if !packageExists {
-		fmt.Fprintf(&sb, "Creating package %s...\n", packageName)
-		createOpts := adt.CreateObjectOptions{
-			ObjectType:  adt.ObjectTypePackage,
-			Name:        packageName,
-			Description: "VSP WebSocket Handler",
-		}
-		err := s.adtClient.CreateObject(ctx, createOpts)
-		if err != nil {
-			// On older SAP releases (e.g. 7.40), /sap/bc/adt/packages may not exist.
-			// Don't abort — the package may have been pre-created via SE21/SE80,
-			// and WriteSource will fail with a clear error if it truly doesn't exist.
-			fmt.Fprintf(&sb, "  ⚠ Package creation failed: %v\n", err)
-			fmt.Fprintf(&sb, "  → Continuing anyway (package may already exist via SE21/SE80)\n\n")
-		} else {
-			fmt.Fprintf(&sb, "  ✓ Package %s created\n\n", packageName)
-		}
+	created, err := installer.EnsurePackage(ctx, s.adtClient, packageName, "VSP WebSocket Handler")
+	if err != nil {
+		return newToolResultError(fmt.Sprintf("Failed to ensure package %s: %v", packageName, err)), nil
+	}
+	if created {
+		fmt.Fprintf(&sb, "Package %s created and verified\n\n", packageName)
 	} else {
 		fmt.Fprintf(&sb, "Using existing package %s\n\n", packageName)
 	}
@@ -431,19 +413,11 @@ func (s *Server) handleInstallZADTVSP(ctx context.Context, request mcp.CallToolR
 			Description: obj.Description,
 			Mode:        adt.WriteModeUpsert,
 		}
-		res, err := s.adtClient.WriteSource(ctx, obj.Type, obj.Name, obj.Source, opts)
-		switch {
-		case err != nil:
+		_, err := installer.DeploySource(ctx, s.adtClient, obj.Type, obj.Name, obj.Source, opts)
+		if err != nil {
 			fmt.Fprintf(&sb, "✗ Failed: %v\n", err)
 			failed = append(failed, obj.Name+": "+err.Error())
-		case res == nil || !res.Success:
-			msg := "unknown failure"
-			if res != nil && res.Message != "" {
-				msg = res.Message
-			}
-			fmt.Fprintf(&sb, "✗ Failed: %s\n", msg)
-			failed = append(failed, obj.Name+": "+msg)
-		default:
+		} else {
 			sb.WriteString("✓ Deployed\n")
 			deployed = append(deployed, obj.Name)
 		}
@@ -466,6 +440,9 @@ func (s *Server) handleInstallZADTVSP(ctx context.Context, request mcp.CallToolR
 	}
 
 	fmt.Fprintf(&sb, "\nDeployed: %d, Skipped: %d, Failed: %d\n\n", len(deployed), len(skipped), len(failed))
+	if len(failed) > 0 {
+		return newToolResultError(sb.String()), nil
+	}
 
 	// Post-deployment instructions
 	sb.WriteString(embedded.PostDeploymentInstructions())

--- a/internal/mcp/handlers_source.go
+++ b/internal/mcp/handlers_source.go
@@ -249,6 +249,9 @@ func (s *Server) handleWriteSource(ctx context.Context, request mcp.CallToolRequ
 	if err != nil {
 		return newToolResultError(fmt.Sprintf("WriteSource failed: %v", err)), nil
 	}
+	if err := adt.WriteSourceResultError(result); err != nil {
+		return newToolResultError(err.Error()), nil
+	}
 
 	output, _ := json.MarshalIndent(result, "", "  ")
 	return mcp.NewToolResultText(string(output)), nil

--- a/internal/mcp/handlers_source.go
+++ b/internal/mcp/handlers_source.go
@@ -250,7 +250,13 @@ func (s *Server) handleWriteSource(ctx context.Context, request mcp.CallToolRequ
 		return newToolResultError(fmt.Sprintf("WriteSource failed: %v", err)), nil
 	}
 	if err := adt.WriteSourceResultError(result); err != nil {
-		return newToolResultError(err.Error()), nil
+		// Fail closed, but do not throw away the diagnosis with the verdict.
+		// The commonest way for this to fail is a syntax error, and
+		// result.SyntaxErrors carries the line, offset and text the caller
+		// needs to fix it. Returning only the message would hand an agent
+		// "Source has syntax errors - not saved" and nothing to act on.
+		payload, _ := json.MarshalIndent(result, "", "  ")
+		return newToolResultError(fmt.Sprintf("%v\n\n%s", err, payload)), nil
 	}
 
 	output, _ := json.MarshalIndent(result, "", "  ")

--- a/internal/mcp/write_failure_payload_test.go
+++ b/internal/mcp/write_failure_payload_test.go
@@ -1,0 +1,44 @@
+package mcp
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/oisee/vibing-steampunk/pkg/adt"
+)
+
+// TestWriteSourceFailureKeepsTheDiagnosis guards the boundary added in #182.
+// Failing closed is right — an HTTP 200 carrying success=false must not read as
+// success. But the verdict alone is not actionable: the commonest failure is a
+// syntax error, and the line, offset and text live in result.SyntaxErrors. An
+// agent handed only "Source has syntax errors - not saved" has to guess.
+func TestWriteSourceFailureKeepsTheDiagnosis(t *testing.T) {
+	result := &adt.WriteSourceResult{
+		Success:    false,
+		ObjectType: "PROG",
+		ObjectName: "ZDEMO_ONE",
+		Message:    "Source has syntax errors - not saved",
+		SyntaxErrors: []adt.SyntaxCheckResult{
+			{Line: 42, Offset: 7, Severity: "E", Text: "Field LV_X is unknown"},
+		},
+	}
+
+	err := adt.WriteSourceResultError(result)
+	if err == nil {
+		t.Fatal("success=false must become an error, or the caller reads a failure as a success")
+	}
+
+	payload, marshalErr := json.MarshalIndent(result, "", "  ")
+	if marshalErr != nil {
+		t.Fatalf("marshalling the result: %v", marshalErr)
+	}
+	text := fmt.Sprintf("%v\n\n%s", err, payload)
+
+	for _, want := range []string{"Source has syntax errors", "Field LV_X is unknown", `"line": 42`} {
+		if !strings.Contains(text, want) {
+			t.Errorf("the failure text must carry %q so the caller can act on it; got:\n%s", want, text)
+		}
+	}
+}

--- a/pkg/adt/activation_checklist_test.go
+++ b/pkg/adt/activation_checklist_test.go
@@ -123,6 +123,19 @@ func TestParseActivationResultActivationExecutedTrueIsNotAFailure(t *testing.T) 
 	}
 }
 
+func TestActivationResultError(t *testing.T) {
+	if err := ActivationResultError(&ActivationResult{Success: true}); err != nil {
+		t.Fatalf("success returned error: %v", err)
+	}
+	if err := ActivationResultError(nil); err == nil || !strings.Contains(err.Error(), "no result") {
+		t.Fatalf("nil result error = %v", err)
+	}
+	refused := &ActivationResult{Messages: []ActivationResultMessage{{Type: "E", ShortText: "synthetic activation failure"}}}
+	if err := ActivationResultError(refused); err == nil || !strings.Contains(err.Error(), "synthetic activation failure") {
+		t.Fatalf("logical failure error = %v", err)
+	}
+}
+
 // The wrapped shape still has to work. PR #148 fixes the root form by declaring
 // <msg> directly on the response struct and nothing else, which stops matching
 // the wrapper — this is the test that catches that.

--- a/pkg/adt/activation_failure.go
+++ b/pkg/adt/activation_failure.go
@@ -1,6 +1,7 @@
 package adt
 
 import (
+	"fmt"
 	"strconv"
 	"strings"
 )
@@ -28,6 +29,18 @@ import (
 // activate: SAP's E (error), A (abort) and X (short dump). W and I are produced
 // by activations that succeed, so they prove nothing on their own.
 const activationErrorTypes = "EAX"
+
+// ActivationResultError converts SAP's HTTP-200 activation refusal into an
+// error for callers that must not continue after a logical failure.
+func ActivationResultError(result *ActivationResult) error {
+	if result == nil {
+		return fmt.Errorf("activation returned no result")
+	}
+	if result.Success {
+		return nil
+	}
+	return fmt.Errorf("activation failed: %s", strings.Join(result.ProblemLines(), "; "))
+}
 
 // ErrorMessages returns the messages that say the object did not activate, in
 // the order SAP listed them — the first is the one to lead with.

--- a/pkg/adt/crud.go
+++ b/pkg/adt/crud.go
@@ -429,6 +429,13 @@ func (c *Client) objectExistsByURL(ctx context.Context, objectURL string) (bool,
 // returned PartialCreateError. Manual recovery hints are only added
 // when our best-effort attempt could not finish.
 func (c *Client) reconcileFailedCreate(ctx context.Context, opts CreateObjectOptions, createErr error) error {
+	// An already-exists response proves the object predates this create attempt.
+	// It is not partial persistence owned by this request, so reconciliation
+	// must never lock or delete it.
+	if isAlreadyExistsError(createErr) {
+		return createErr
+	}
+
 	objectURL := GetObjectURL(opts.ObjectType, opts.Name, opts.ParentName)
 	if objectURL == "" {
 		// Object type we cannot URL-encode → no probe possible.
@@ -450,6 +457,20 @@ func (c *Client) reconcileFailedCreate(ctx context.Context, opts CreateObjectOpt
 	pce := c.cleanupPartialObject(ctx, objectURL, opts.PackageName, opts.Transport)
 	pce.OriginalErr = createErr
 	return pce
+}
+
+func isAlreadyExistsError(err error) bool {
+	if err == nil {
+		return false
+	}
+	var apiErr *APIError
+	if !errors.As(err, &apiErr) || (apiErr.StatusCode != http.StatusBadRequest && apiErr.StatusCode != http.StatusConflict) {
+		return false
+	}
+	message := strings.ToLower(apiErr.Message)
+	return strings.Contains(message, "exceptionresourcealreadyexists") ||
+		strings.Contains(message, "already exists") ||
+		strings.Contains(message, "does already exist")
 }
 
 // cleanupPartialObject runs the best-effort compensating cleanup for a

--- a/pkg/adt/crud_reconcile_test.go
+++ b/pkg/adt/crud_reconcile_test.go
@@ -156,6 +156,27 @@ func TestCreateObject_CleanFailureBeforePersistence(t *testing.T) {
 	}
 }
 
+func TestReconcileFailedCreateDoesNotDeletePreExistingObject(t *testing.T) {
+	mock := &methodPathMock{}
+	client := newReconcileClient(t, mock)
+	createErr := &APIError{
+		StatusCode: http.StatusBadRequest,
+		Message:    "ExceptionResourceAlreadyExists: synthetic object already exists",
+	}
+
+	err := client.reconcileFailedCreate(context.Background(), CreateObjectOptions{
+		ObjectType:  ObjectTypePackage,
+		Name:        "$SYNTHETIC",
+		PackageName: "$SYNTHETIC",
+	}, createErr)
+	if !errors.Is(err, createErr) {
+		t.Fatalf("error = %v, want original already-exists error", err)
+	}
+	if len(mock.calls) != 0 {
+		t.Fatalf("reconciliation touched a pre-existing object: %#v", mock.calls)
+	}
+}
+
 // TestCreateObject_PartialPersistenceCleanupOK covers the prod-incident
 // scenario: CreateObject POST returns 500 but SAP already persisted the
 // object. The existence probe returns 200, lock acquisition succeeds,

--- a/pkg/adt/workflows_deploy.go
+++ b/pkg/adt/workflows_deploy.go
@@ -511,8 +511,9 @@ func (c *Client) DeployFromFile(ctx context.Context, filePath, packageName, tran
 			// Regular object - create it
 			return c.CreateFromFile(ctx, filePath, packageName, transport)
 		}
-		// For other errors (session timeout, network issues, etc.), proceed with update
-		// The parent class might still exist - let UpdateFromFile handle it
+		// Authentication, network and server failures are inconclusive. Do not
+		// turn them into an update attempt; fail closed before locking or writing.
+		return nil, fmt.Errorf("checking whether %s %s exists: %w", info.ObjectType, info.ObjectName, err)
 	}
 
 	// Object exists - update it (handles both regular objects and class includes)

--- a/pkg/adt/workflows_deploy_exists_test.go
+++ b/pkg/adt/workflows_deploy_exists_test.go
@@ -1,0 +1,32 @@
+package adt
+
+import (
+	"context"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+//nolint:bodyclose // Transport.Request owns and closes every synthetic response body.
+func TestDeployFromFileStopsOnInconclusiveExistenceCheck(t *testing.T) {
+	filePath := filepath.Join(t.TempDir(), "zsynthetic.prog.abap")
+	if err := os.WriteFile(filePath, []byte("REPORT zsynthetic."), 0o600); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+
+	mock := &mockHTTPClient{responses: []*http.Response{
+		newMockResponse(http.StatusInternalServerError, "synthetic server failure", nil),
+	}}
+	cfg := NewConfig("https://sap.example.com:44300", "user", "pass")
+	client := NewClientWithTransport(cfg, NewTransportWithClient(cfg, mock))
+
+	result, err := client.DeployFromFile(context.Background(), filePath, "$TMP", "")
+	if err == nil || !strings.Contains(err.Error(), "checking whether") {
+		t.Fatalf("DeployFromFile() result = %#v, error = %v, want inconclusive existence error", result, err)
+	}
+	if len(mock.requests) != 1 {
+		t.Fatalf("requests = %d, want only the existence probe", len(mock.requests))
+	}
+}

--- a/pkg/adt/workflows_result_test.go
+++ b/pkg/adt/workflows_result_test.go
@@ -1,0 +1,34 @@
+package adt
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestWriteSourceResultError(t *testing.T) {
+	tests := []struct {
+		name    string
+		result  *WriteSourceResult
+		wantErr string
+	}{
+		{name: "success", result: &WriteSourceResult{Success: true}},
+		{name: "nil result", wantErr: "no result"},
+		{name: "diagnostic", result: &WriteSourceResult{Message: "synthetic activation failure"}, wantErr: "synthetic activation failure"},
+		{name: "missing diagnostic", result: &WriteSourceResult{}, wantErr: "without a diagnostic"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := WriteSourceResultError(tt.result)
+			if tt.wantErr == "" {
+				if err != nil {
+					t.Fatalf("WriteSourceResultError() error = %v", err)
+				}
+				return
+			}
+			if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+				t.Fatalf("WriteSourceResultError() error = %v, want substring %q", err, tt.wantErr)
+			}
+		})
+	}
+}

--- a/pkg/adt/workflows_source.go
+++ b/pkg/adt/workflows_source.go
@@ -173,6 +173,22 @@ type WriteSourceResult struct {
 	Message      string              `json:"message,omitempty"`
 }
 
+// WriteSourceResultError converts a logical WriteSource failure into an error
+// for callers that must not report success after an HTTP-level success.
+func WriteSourceResultError(result *WriteSourceResult) error {
+	if result == nil {
+		return fmt.Errorf("WriteSource failed: no result returned")
+	}
+	if result.Success {
+		return nil
+	}
+	message := strings.TrimSpace(result.Message)
+	if message == "" {
+		message = "operation returned success=false without a diagnostic"
+	}
+	return fmt.Errorf("WriteSource failed: %s", message)
+}
+
 // WriteSource is a unified tool for writing ABAP source code across different object types.
 // Replaces WriteProgram, WriteClass, CreateAndActivateProgram, CreateClassWithTests.
 //
@@ -218,6 +234,10 @@ func (c *Client) WriteSource(ctx context.Context, objectType, name, source strin
 	result := &WriteSourceResult{
 		ObjectType: objectType,
 		ObjectName: name,
+	}
+	if opts.Mode != WriteModeCreate && opts.Mode != WriteModeUpdate && opts.Mode != WriteModeUpsert {
+		result.Message = fmt.Sprintf("Invalid mode %q (supported: create, update, upsert)", opts.Mode)
+		return result, nil
 	}
 
 	// Function modules take their own path: they are addressed through their

--- a/pkg/adt/workflows_source_mode_test.go
+++ b/pkg/adt/workflows_source_mode_test.go
@@ -1,0 +1,27 @@
+package adt
+
+import (
+	"context"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+func TestClientWriteSourceRejectsUnknownMode(t *testing.T) {
+	cfg := NewConfig("https://sap.example.com:44300", "user", "pass")
+	mock := &mockWorkflowTransport{responses: map[string]*http.Response{}}
+	client := NewClientWithTransport(cfg, NewTransportWithClient(cfg, mock))
+
+	result, err := client.WriteSource(context.Background(), "PROG", "Z_SYNTHETIC", "REPORT z_synthetic.", &WriteSourceOptions{
+		Mode: WriteSourceMode("replace"),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Success || !strings.Contains(result.Message, "Invalid mode") {
+		t.Fatalf("unexpected result: %#v", result)
+	}
+	if len(mock.requests) != 0 {
+		t.Fatalf("invalid mode made network requests: %d", len(mock.requests))
+	}
+}

--- a/pkg/dsl/workflow.go
+++ b/pkg/dsl/workflow.go
@@ -463,7 +463,7 @@ func handleSyntaxCheck(ctx *ExecutionContext, params map[string]interface{}) (in
 		results = append(results, map[string]interface{}{
 			"object":    obj.Name,
 			"success":   !hasErrors,
-			"messages":  checkResults,
+			"messages": checkResults,
 		})
 	}
 
@@ -514,6 +514,9 @@ func handleActivate(ctx *ExecutionContext, params map[string]interface{}) (inter
 		result, err := ctx.Client().Activate(ctx.Context(), objectURL, obj.Name)
 		if err != nil {
 			return nil, err
+		}
+		if err := adt.ActivationResultError(result); err != nil {
+			return nil, fmt.Errorf("activating %s: %w", obj.Name, err)
 		}
 		results = append(results, map[string]interface{}{
 			"object":  obj.Name,

--- a/pkg/scripting/bindings.go
+++ b/pkg/scripting/bindings.go
@@ -179,16 +179,52 @@ func (e *LuaEngine) luaWriteSource(L *lua.LState) int {
 	objType := getString(L, 1)
 	name := getString(L, 2)
 	source := getString(L, 3)
+	var opts *adt.WriteSourceOptions
+	if L.GetTop() >= 4 && L.Get(4) != lua.LNil {
+		table, ok := L.Get(4).(*lua.LTable)
+		if !ok {
+			L.Push(lua.LBool(false))
+			L.Push(lua.LString("writeSource options must be a table"))
+			return 2
+		}
+		opts = &adt.WriteSourceOptions{
+			Mode:        adt.WriteSourceMode(strings.ToLower(luaTableString(table, "mode"))),
+			Description: luaTableString(table, "description"),
+			Package:     luaTableString(table, "package"),
+			TestSource:  luaTableString(table, "test_source"),
+			Transport:   luaTableString(table, "transport"),
+			Method:      luaTableString(table, "method"),
+		}
+	}
 
-	result, err := e.client.WriteSource(e.ctx, objType, name, source, nil)
+	if e.writeSource == nil {
+		L.Push(lua.LBool(false))
+		L.Push(lua.LString("writeSource is unavailable: ADT client is not configured"))
+		return 2
+	}
+
+	result, err := e.writeSource(e.ctx, objType, name, source, opts)
 	if err != nil {
 		L.Push(lua.LBool(false))
 		L.Push(lua.LString(err.Error()))
 		return 2
 	}
+	if err := adt.WriteSourceResultError(result); err != nil {
+		L.Push(lua.LBool(false))
+		L.Push(lua.LString(err.Error()))
+		return 2
+	}
 
-	L.Push(lua.LBool(result.Success))
+	L.Push(lua.LBool(true))
 	return 1
+}
+
+func luaTableString(table *lua.LTable, key string) string {
+	value := table.RawGetString(key)
+	if value == lua.LNil {
+		return ""
+	}
+	return lua.LVAsString(value)
 }
 
 func (e *LuaEngine) luaEditSource(L *lua.LState) int {

--- a/pkg/scripting/lua.go
+++ b/pkg/scripting/lua.go
@@ -18,10 +18,11 @@ import (
 
 // LuaEngine wraps a Lua VM with vsp bindings.
 type LuaEngine struct {
-	L      *lua.LState
-	client *adt.Client
-	ctx    context.Context
-	output io.Writer
+	L           *lua.LState
+	client      *adt.Client
+	writeSource func(context.Context, string, string, string, *adt.WriteSourceOptions) (*adt.WriteSourceResult, error)
+	ctx         context.Context
+	output      io.Writer
 
 	// Checkpoints (for Force Replay)
 	checkpoints map[string]map[string]interface{}
@@ -53,6 +54,9 @@ func NewLuaEngine(client *adt.Client) *LuaEngine {
 		ctx:         context.Background(),
 		output:      os.Stdout,
 		checkpoints: make(map[string]map[string]interface{}),
+	}
+	if client != nil {
+		engine.writeSource = client.WriteSource
 	}
 
 	engine.registerBuiltins()
@@ -138,7 +142,7 @@ Search & Source:
   searchObject(query, [type])     Search for ABAP objects
   grepObjects(pattern, [type])    Grep in object sources
   getSource(type, name)           Get source code
-  writeSource(type, name, src)    Write source code
+  writeSource(type, name, src, [options]) Write source (mode, transport, package, description)
   editSource(type, name, old, new) Edit source code
 
 Debugging - Breakpoints:

--- a/pkg/scripting/write_source_test.go
+++ b/pkg/scripting/write_source_test.go
@@ -1,0 +1,109 @@
+package scripting
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/oisee/vibing-steampunk/pkg/adt"
+	lua "github.com/yuin/gopher-lua"
+)
+
+func TestLuaWriteSourceLegacyCallPreservesNilOptions(t *testing.T) {
+	engine := NewLuaEngine(nil)
+	defer engine.Close()
+
+	engine.writeSource = func(_ context.Context, objectType, name, source string, opts *adt.WriteSourceOptions) (*adt.WriteSourceResult, error) {
+		if objectType != "PROG" || name != "Z_SYNTHETIC" || source != "REPORT z_synthetic." {
+			t.Fatalf("unexpected arguments: %q %q %q", objectType, name, source)
+		}
+		if opts != nil {
+			t.Fatalf("legacy three-argument call supplied options: %#v", opts)
+		}
+		return &adt.WriteSourceResult{Success: true}, nil
+	}
+
+	if err := engine.Execute(`ok, message = writeSource("PROG", "Z_SYNTHETIC", "REPORT z_synthetic.")`); err != nil {
+		t.Fatal(err)
+	}
+	if engine.L.GetGlobal("ok") != lua.LTrue {
+		t.Fatalf("ok = %v, want true", engine.L.GetGlobal("ok"))
+	}
+	if engine.L.GetGlobal("message") != lua.LNil {
+		t.Fatalf("message = %v, want nil", engine.L.GetGlobal("message"))
+	}
+}
+
+func TestLuaWriteSourceForwardsOptions(t *testing.T) {
+	engine := NewLuaEngine(nil)
+	defer engine.Close()
+
+	engine.writeSource = func(_ context.Context, _, _, _ string, opts *adt.WriteSourceOptions) (*adt.WriteSourceResult, error) {
+		if opts == nil {
+			t.Fatal("options were not forwarded")
+		}
+		want := adt.WriteSourceOptions{
+			Mode:        adt.WriteModeUpdate,
+			Description: "Synthetic description",
+			Package:     "$TMP",
+			TestSource:  "test source",
+			Transport:   "REQ-TEST-001",
+			Method:      "RUN",
+		}
+		if *opts != want {
+			t.Fatalf("options = %#v, want %#v", *opts, want)
+		}
+		return &adt.WriteSourceResult{Success: true}, nil
+	}
+
+	script := `ok, message = writeSource("CLAS", "ZCL_SYNTHETIC", "source", {
+		mode = "UPDATE",
+		description = "Synthetic description",
+		package = "$TMP",
+		test_source = "test source",
+		transport = "REQ-TEST-001",
+		method = "RUN"
+	})`
+	if err := engine.Execute(script); err != nil {
+		t.Fatal(err)
+	}
+	if engine.L.GetGlobal("ok") != lua.LTrue {
+		t.Fatalf("ok = %v, want true", engine.L.GetGlobal("ok"))
+	}
+}
+
+func TestLuaWriteSourceReturnsDiagnosticForUnsuccessfulResult(t *testing.T) {
+	engine := NewLuaEngine(nil)
+	defer engine.Close()
+	engine.writeSource = func(context.Context, string, string, string, *adt.WriteSourceOptions) (*adt.WriteSourceResult, error) {
+		return &adt.WriteSourceResult{Success: false, Message: "synthetic activation failure"}, nil
+	}
+
+	if err := engine.Execute(`ok, message = writeSource("PROG", "Z_SYNTHETIC", "source", {})`); err != nil {
+		t.Fatal(err)
+	}
+	if engine.L.GetGlobal("ok") != lua.LFalse {
+		t.Fatalf("ok = %v, want false", engine.L.GetGlobal("ok"))
+	}
+	if got := lua.LVAsString(engine.L.GetGlobal("message")); got != "WriteSource failed: synthetic activation failure" {
+		t.Fatalf("message = %q", got)
+	}
+}
+
+func TestLuaWriteSourceReturnsGoError(t *testing.T) {
+	engine := NewLuaEngine(nil)
+	defer engine.Close()
+	engine.writeSource = func(context.Context, string, string, string, *adt.WriteSourceOptions) (*adt.WriteSourceResult, error) {
+		return nil, errors.New("synthetic request error")
+	}
+
+	if err := engine.Execute(`ok, message = writeSource("PROG", "Z_SYNTHETIC", "source")`); err != nil {
+		t.Fatal(err)
+	}
+	if engine.L.GetGlobal("ok") != lua.LFalse {
+		t.Fatalf("ok = %v, want false", engine.L.GetGlobal("ok"))
+	}
+	if got := lua.LVAsString(engine.L.GetGlobal("message")); got != "synthetic request error" {
+		t.Fatalf("message = %q", got)
+	}
+}

--- a/pkg/scripting/write_source_test.go
+++ b/pkg/scripting/write_source_test.go
@@ -5,8 +5,9 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/oisee/vibing-steampunk/pkg/adt"
 	lua "github.com/yuin/gopher-lua"
+
+	"github.com/oisee/vibing-steampunk/pkg/adt"
 )
 
 func TestLuaWriteSourceLegacyCallPreservesNilOptions(t *testing.T) {


### PR DESCRIPTION
## Summary

- convert logical `WriteSource` and activation failures into errors at MCP, DSL, Lua, installer, and copy boundaries
- stop failed-create reconciliation from touching an object that SAP reports as already existing
- fail closed when object or package existence checks are inconclusive
- verify package creation, structured write results, activation state, and source read-back before installers report success
- reject unsupported or partial copy deployments instead of advertising unimplemented WebSocket coverage
- let Lua callers pass package, transport, mode, description, method, and test-source options to `writeSource`

## Scope

This is the focused replacement for the still-wanted write-safety and result-verification hunks from #156.

Per the maintainer triage, it deliberately omits the old `fetchCSRFToken` rewrite, session-affinity changes, and overlapping CLI safety-flag work. Those paths have been superseded by #167 and subsequent `main` changes.

All fixtures and examples in this PR use synthetic or example-only values.

## Verification

- `go vet ./...`
- `go test ./internal/install ./pkg/scripting ./internal/mcp ./cmd/vsp ./pkg/dsl -count=1`
- focused ADT tests for logical results, already-exists reconciliation, invalid modes, activation refusal, and inconclusive existence probes

The full Windows suite also reaches pre-existing platform-specific failures in `pkg/adt`, `pkg/cache`, and `pkg/jseval`; none are in files changed by this PR. GitHub Actions remains the authoritative Linux run.

Supersedes #156.