### PR TITLE
feat(debug): the UI opens on an object and stops in it

### DIFF
--- a/cmd/vsp/debug.go
+++ b/cmd/vsp/debug.go
@@ -11,8 +11,9 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/oisee/vibing-steampunk/pkg/adt"
 	"github.com/spf13/cobra"
+
+	"github.com/oisee/vibing-steampunk/pkg/adt"
 )
 
 var debugCmd = &cobra.Command{
@@ -81,18 +82,20 @@ func runDebug(cmd *cobra.Command, args []string) error {
 	// Resolve configuration (same as MCP server)
 	resolveConfig(cmd.Parent())
 
-	// Validate we have auth
-	if err := validateConfig(); err != nil {
-		return err
-	}
+	// No validateConfig() here on purpose: it checks the global cfg.BaseURL,
+	// which a named system (-s / .vsp.json) never populates, so it rejected
+	// `-s a4h` before the resolver ever ran. createADTClientFor resolves the
+	// system and reports a real error if none can be found.
 
-	// Process cookie auth
-	if err := processCookieAuth(cmd.Parent()); err != nil {
-		return err
-	}
+	// No processCookieAuth here either: it reads the same global cfg. A named
+	// system carries its own credentials through resolveSystemParams, which is
+	// how deploy, deps and every other -s-aware command already work.
 
 	// Create ADT client
-	client := createADTClient()
+	client, err := createADTClientFor(cmd)
+	if err != nil {
+		return err
+	}
 
 	// Get user for debugging
 	user := debugUser

--- a/cmd/vsp/debug_ui.go
+++ b/cmd/vsp/debug_ui.go
@@ -9,97 +9,139 @@ import (
 	"net/http"
 	"os"
 	"strconv"
+	"strings"
+	"sync"
 	"time"
 
 	"github.com/spf13/cobra"
 
+	"github.com/oisee/open-rfc-go/rfc"
+
 	"github.com/oisee/vibing-steampunk/pkg/adt"
+	"github.com/oisee/vibing-steampunk/pkg/saprfc"
 )
 
 //go:embed debug_ui.html
 var debugUIAssets embed.FS
 
-// The debugger has had a working session layer since Phase 1 of #2 — a session
-// that survives across tool calls, a stack, variables, stepping. What it never
-// had was something to look at, and #2 was closed with two thirds of its design
-// unbuilt (now #184).
+// A local face for the debugger.
 //
-// This is the smallest honest answer to "show me": a local page, served by vsp
-// itself, driving the same pkg/adt debugger client the MCP tools drive. No DAP
-// layer, no framework, no build step. It is a prototype for the Phase 3
-// question — should vsp ship a UI at all, or stop at DAP and let editors be the
-// front end — and it exists so that question can be answered by looking rather
-// than by imagining.
+// It rides on the same pinned RFC conversation `vsp rfc debug` uses, and that
+// is not an implementation detail: a breakpoint registered by one process does
+// not survive it, and a listener registered through the Z facade never receives
+// a debuggee whose breakpoint was registered through ADT. Both were learned the
+// hard way. One session sets the breakpoint, listens, attaches and steps, which
+// is the only arrangement that actually stops.
+//
+// Phase 1 of #2 built the session layer; this is the "show me" for #184, where
+// the open question is whether vsp should ship a UI at all or stop at a DAP
+// shim and let editors be the front end.
 var debugUICmd = &cobra.Command{
-	Use:   "ui",
+	Use:   "ui [OBJECT]",
 	Short: "Serve a local debugger UI on localhost",
+	Args:  cobra.MaximumNArgs(1),
 	Long: `Serve a local web UI for the ABAP debugger.
 
-It binds to localhost only, drives the same debugger client the MCP tools use,
-and holds one session. Nothing is written to the SAP system: it listens,
-attaches, steps, and reads the stack, variables and source.
+Name an object and the page opens ready to debug it — a report, or a function
+module, which is resolved to its function group's include for you.
 
-  vsp debug ui                 # http://127.0.0.1:7799
-  vsp debug ui --port 8080
-  vsp debug ui --user DEVELOPER   # listen for that user's processes
+  vsp -s a4h debug ui                     # http://127.0.0.1:7799
+  vsp -s a4h debug ui RFC_SYSTEM_INFO     # opens on that function module
+  vsp -s a4h debug ui ZVSP_DEBUG_PLAY --http-port 8080
 
-Set a breakpoint in ADT or with 'vsp debug', run the ABAP, and the page picks
-the session up.`,
+Set the line, press Set breakpoint, then Run — for a function module the page
+calls it over a second RFC connection, so the breakpoint fires in a session it
+started itself. Standard SAP code needs "system code" switched on; SAP accepts
+a breakpoint there and silently never stops without it.`,
 	RunE: runDebugUI,
 }
 
 var (
-	debugUIPort int
-	debugUIUser string
+	debugUIPort    int
+	debugUIUser    string
+	debugUITimeout int
 )
 
 func init() {
-	debugUICmd.Flags().IntVar(&debugUIPort, "port", 7799, "Port to bind on localhost")
-	debugUICmd.Flags().StringVar(&debugUIUser, "user", "", "Listen for this user's debuggees (defaults to the configured user)")
+	// Not "port": rfcDestinationFor reads a --port flag as the RFC gateway port
+	// (rfc.go:468, declared on rfcCmd as a persistent flag). Naming the HTTP
+	// port that way made this command dial the SAP gateway on 7799 and hang
+	// before it ever printed a line.
+	debugUICmd.Flags().IntVar(&debugUIPort, "http-port", 7799, "Port to bind the UI on localhost")
+	debugUICmd.Flags().StringVar(&debugUIUser, "user", "", "Whose debuggees to listen for (default: the logon user)")
+	debugUICmd.Flags().IntVar(&debugUITimeout, "timeout", 600, "Seconds a single RFC call may take; must exceed the listen timeout")
 	debugCmd.AddCommand(debugUICmd)
 }
 
-// debugUIServer holds the one session the page talks to. A debug session is
-// single-threaded on the SAP side, so this is deliberately one session and a
-// mutex, not a pool.
+// debugUIServer owns the one pinned debug session. A pinned RFC conversation is
+// single-threaded, so every handler takes the same lock — the page can fire
+// concurrent fetches and the session must not see two calls at once.
 type debugUIServer struct {
-	client   *adt.Client
+	mu     sync.Mutex
+	dbg    *saprfc.Debugger
+	dest   saprfc.Params
+	user   string
+	target string
+	line   int
+	sysDbg bool
+
 	attached bool
-	debuggee *adt.Debuggee
+	debuggee *saprfc.ADTDebuggee
 }
 
 type uiState struct {
+	Target    string              `json:"target"`
+	Line      int                 `json:"line"`
+	SystemDbg bool                `json:"systemDebugging"`
 	Attached  bool                `json:"attached"`
-	Debuggee  *adt.Debuggee       `json:"debuggee,omitempty"`
+	Where     string              `json:"where,omitempty"`
 	Stack     *adt.DebugStackInfo `json:"stack,omitempty"`
 	Variables []adt.DebugVariable `json:"variables,omitempty"`
 	Note      string              `json:"note,omitempty"`
 }
 
 func runDebugUI(cmd *cobra.Command, args []string) error {
-	client := createADTClient()
-	srv := &debugUIServer{client: client}
-
-	mux := http.NewServeMux()
-	mux.HandleFunc("/", srv.handleIndex)
-	mux.HandleFunc("/api/state", srv.handleState)
-	mux.HandleFunc("/api/listen", srv.handleListen)
-	mux.HandleFunc("/api/step", srv.handleStep)
-	mux.HandleFunc("/api/goto", srv.handleGoTo)
-	mux.HandleFunc("/api/source", srv.handleSource)
-	mux.HandleFunc("/api/detach", srv.handleDetach)
-
-	addr := net.JoinHostPort("127.0.0.1", strconv.Itoa(debugUIPort))
-	lc := &net.ListenConfig{}
-	ln, err := lc.Listen(cmd.Context(), "tcp", addr)
-	if err != nil {
-		return fmt.Errorf("binding %s: %w", addr, err)
+	target := ""
+	if len(args) == 1 {
+		target = strings.ToUpper(strings.TrimSpace(args[0]))
 	}
 
-	fmt.Fprintf(os.Stderr, "debugger UI on http://%s\n", addr)
-	fmt.Fprintf(os.Stderr, "set a breakpoint, run the ABAP, then press Listen on the page\n")
+	return withRFCDestTimeout(cmd, time.Duration(debugUITimeout)*time.Second, func(ctx context.Context, c *rfc.Client, dest saprfc.Params) error {
+		user := debugUIUser
+		if user == "" {
+			user = dest.User
+		}
+		dbg, err := saprfc.NewDebugger(ctx, c, user)
+		if err != nil {
+			return err
+		}
+		defer func() { _ = dbg.Close(ctx) }()
 
-	return (&http.Server{Handler: mux, ReadHeaderTimeout: 10 * time.Second}).Serve(ln)
+		srv := &debugUIServer{dbg: dbg, dest: dest, user: user, target: target, line: 1}
+
+		mux := http.NewServeMux()
+		mux.HandleFunc("/", srv.handleIndex)
+		mux.HandleFunc("/api/state", srv.handleState)
+		mux.HandleFunc("/api/bp", srv.handleBreakpoint)
+		mux.HandleFunc("/api/sys", srv.handleSystemDebugging)
+		mux.HandleFunc("/api/listen", srv.handleListen)
+		mux.HandleFunc("/api/run", srv.handleRun)
+		mux.HandleFunc("/api/step", srv.handleStep)
+		mux.HandleFunc("/api/source", srv.handleSource)
+		mux.HandleFunc("/api/detach", srv.handleDetach)
+
+		addr := net.JoinHostPort("127.0.0.1", strconv.Itoa(debugUIPort))
+		lc := &net.ListenConfig{}
+		ln, err := lc.Listen(ctx, "tcp", addr)
+		if err != nil {
+			return fmt.Errorf("binding %s: %w", addr, err)
+		}
+		fmt.Fprintf(os.Stderr, "debugger UI on http://%s (user %s)\n", addr, user)
+		if target != "" {
+			fmt.Fprintf(os.Stderr, "target: %s\n", target)
+		}
+		return (&http.Server{Handler: mux, ReadHeaderTimeout: 10 * time.Second}).Serve(ln)
+	})
 }
 
 func (s *debugUIServer) handleIndex(w http.ResponseWriter, r *http.Request) {
@@ -121,136 +163,199 @@ func writeJSON(w http.ResponseWriter, v any) {
 	_ = json.NewEncoder(w).Encode(v)
 }
 
-func writeErr(w http.ResponseWriter, err error) {
-	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(http.StatusBadGateway)
-	_ = json.NewEncoder(w).Encode(map[string]string{"error": err.Error()})
-}
-
-// collect returns the whole picture in one response. The page is a view of a
-// stopped process, so a partial answer is worse than a slow one.
-func (s *debugUIServer) collect(ctx context.Context) *uiState {
-	st := &uiState{Attached: s.attached, Debuggee: s.debuggee}
+// snapshot builds the whole picture. Callers hold the lock.
+func (s *debugUIServer) snapshot(ctx context.Context, note string) *uiState {
+	st := &uiState{Target: s.target, Line: s.line, SystemDbg: s.sysDbg, Attached: s.attached, Note: note}
+	if s.debuggee != nil {
+		st.Where = fmt.Sprintf("%s/%s:%d", s.debuggee.Program, s.debuggee.Include, s.debuggee.Line)
+	}
 	if !s.attached {
-		st.Note = "not attached — press Listen, then trigger the breakpoint"
+		if st.Note == "" {
+			st.Note = "not attached — set a breakpoint, press Run, then Listen"
+		}
 		return st
 	}
 
-	stack, err := s.client.DebuggerGetStack(ctx, true)
-	if err != nil {
-		st.Note = fmt.Sprintf("stack unavailable: %v", err)
-		return st
+	if res, err := s.dbg.ADTStack(ctx); err == nil {
+		if info, perr := adt.ParseStackXML(res.Body); perr == nil {
+			st.Stack = info
+		}
 	}
-	st.Stack = stack
-
-	vars, err := s.client.DebuggerGetVariables(ctx, nil)
-	if err != nil {
-		// A missing stack is fatal to the view; missing variables are not.
-		st.Note = fmt.Sprintf("variables unavailable: %v", err)
-		return st
+	if vars, err := s.dbg.Locals(ctx); err == nil {
+		st.Variables = vars
 	}
-	st.Variables = vars
 	return st
 }
 
 func (s *debugUIServer) handleState(w http.ResponseWriter, r *http.Request) {
-	writeJSON(w, s.collect(r.Context()))
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	writeJSON(w, s.snapshot(r.Context(), ""))
+}
+
+func (s *debugUIServer) handleSystemDebugging(w http.ResponseWriter, r *http.Request) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.sysDbg = r.URL.Query().Get("on") == "true"
+	s.dbg.SystemDebugging(s.sysDbg)
+	note := "breakpoints in SAP standard code: off"
+	if s.sysDbg {
+		note = "breakpoints in SAP standard code: on"
+	}
+	writeJSON(w, s.snapshot(r.Context(), note))
+}
+
+func (s *debugUIServer) handleBreakpoint(w http.ResponseWriter, r *http.Request) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if obj := strings.ToUpper(strings.TrimSpace(r.URL.Query().Get("object"))); obj != "" {
+		s.target = obj
+	}
+	if n, err := strconv.Atoi(r.URL.Query().Get("line")); err == nil && n > 0 {
+		s.line = n
+	}
+	if s.target == "" {
+		writeJSON(w, s.snapshot(r.Context(), "name an object first"))
+		return
+	}
+
+	bps, err := s.dbg.ADTAddBreakpoint(r.Context(), s.target, s.line, "")
+	if err != nil {
+		writeJSON(w, s.snapshot(r.Context(), fmt.Sprintf("breakpoint refused: %v", err)))
+		return
+	}
+	// SAP accepts the request and reports per-breakpoint refusals separately;
+	// a caller that only checks err believes it set something it did not.
+	for _, rej := range s.dbg.Rejected() {
+		writeJSON(w, s.snapshot(r.Context(), fmt.Sprintf("not placed at %s:%d — %s", s.target, s.line, rej.ErrorMessage)))
+		return
+	}
+	where := fmt.Sprintf("%s:%d", s.target, s.line)
+	if len(bps) > 0 && bps[0].URI != "" {
+		where = bps[0].URI
+	}
+	writeJSON(w, s.snapshot(r.Context(), "breakpoint set at "+where))
 }
 
 func (s *debugUIServer) handleListen(w http.ResponseWriter, r *http.Request) {
-	user := debugUIUser
-	if user == "" {
-		user = cfg.Username
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	seconds := 60
+	if n, err := strconv.Atoi(r.URL.Query().Get("seconds")); err == nil && n > 0 {
+		seconds = n
 	}
 
-	res, err := s.client.DebuggerListen(r.Context(), &adt.ListenOptions{
-		DebuggingMode:  adt.DebuggingModeUser,
-		User:           user,
-		TimeoutSeconds: 60,
-	})
-	if err != nil {
-		writeErr(w, err)
+	who, _, err := s.dbg.ADTCatch(r.Context(), s.user, "vsp", adtTerminalID, seconds)
+	if err != nil && who == nil {
+		writeJSON(w, s.snapshot(r.Context(), fmt.Sprintf("listen failed: %v", err)))
 		return
 	}
-	if res.TimedOut || res.Debuggee == nil {
-		writeJSON(w, &uiState{Note: "no debuggee within 60s — is the breakpoint set, and did the ABAP run?"})
-		return
-	}
-
-	if _, err := s.client.DebuggerAttach(r.Context(), res.Debuggee.ID, user); err != nil {
-		writeErr(w, err)
+	if who == nil {
+		writeJSON(w, s.snapshot(r.Context(), fmt.Sprintf("nobody stopped within %ds — is the breakpoint on an executable line?", seconds)))
 		return
 	}
 	s.attached = true
-	s.debuggee = res.Debuggee
-	writeJSON(w, s.collect(r.Context()))
+	s.debuggee = who
+	note := ""
+	if err != nil {
+		note = fmt.Sprintf("attached, but the stack could not be read: %v", err)
+	}
+	writeJSON(w, s.snapshot(r.Context(), note))
+}
+
+// handleRun triggers the target over a SECOND RFC connection. It has to be a
+// second one: this process's own conversation is pinned to the debug session,
+// and calling through it would deadlock against the breakpoint it is waiting on.
+func (s *debugUIServer) handleRun(w http.ResponseWriter, r *http.Request) {
+	s.mu.Lock()
+	target := s.target
+	dest := s.dest
+	s.mu.Unlock()
+
+	if target == "" {
+		s.mu.Lock()
+		defer s.mu.Unlock()
+		writeJSON(w, s.snapshot(r.Context(), "name an object first"))
+		return
+	}
+
+	go func() {
+		ctx := context.WithoutCancel(r.Context())
+		c, err := saprfc.OpenWithTimeout(ctx, dest, 120*time.Second)
+		if err != nil {
+			return
+		}
+		defer c.Close(ctx)
+		// The result is deliberately discarded: this call exists to make the
+		// breakpoint fire, and while it is stopped it will not return anyway.
+		_, _ = c.Call(ctx, target, rfc.Params{})
+	}()
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	writeJSON(w, s.snapshot(r.Context(), "called "+target+" on a second connection — press Listen"))
 }
 
 func (s *debugUIServer) handleStep(w http.ResponseWriter, r *http.Request) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
 	if !s.attached {
-		writeJSON(w, s.collect(r.Context()))
+		writeJSON(w, s.snapshot(r.Context(), "not attached"))
 		return
 	}
-	stepType := adt.DebugStepType(r.URL.Query().Get("type"))
-	switch stepType {
-	case adt.DebugStepInto, adt.DebugStepOver, adt.DebugStepReturn, adt.DebugStepContinue:
-	default:
-		http.Error(w, "unsupported step type", http.StatusBadRequest)
+	kind := map[string]string{
+		"into": "stepInto", "over": "stepOver",
+		"out": "stepReturn", "continue": "stepContinue",
+	}[strings.ToLower(r.URL.Query().Get("type"))]
+	if kind == "" {
+		http.Error(w, "step kinds: into, over, out, continue", http.StatusBadRequest)
 		return
 	}
 
-	if _, err := s.client.DebuggerStep(r.Context(), stepType, ""); err != nil {
-		// Continue ends the session when nothing else is hit, and that is a
-		// normal outcome rather than a failure.
+	if _, err := s.dbg.ADTStep(r.Context(), kind); err != nil {
 		s.attached = false
-		writeJSON(w, &uiState{Note: fmt.Sprintf("session ended after %s: %v", stepType, err)})
+		s.debuggee = nil
+		writeJSON(w, s.snapshot(r.Context(), fmt.Sprintf("session ended after %s: %v", kind, err)))
 		return
 	}
-	writeJSON(w, s.collect(r.Context()))
+	writeJSON(w, s.snapshot(r.Context(), ""))
 }
 
-func (s *debugUIServer) handleGoTo(w http.ResponseWriter, r *http.Request) {
-	uri := r.URL.Query().Get("uri")
-	if uri == "" || !s.attached {
-		writeJSON(w, s.collect(r.Context()))
-		return
-	}
-	if err := s.client.DebuggerGoToStack(r.Context(), uri); err != nil {
-		writeErr(w, err)
-		return
-	}
-	writeJSON(w, s.collect(r.Context()))
-}
-
-// handleSource fetches the source of the frame being shown. An include is
-// fetched as an include; anything else is read as a program, which is what the
-// debugger's own stack entries name.
+// handleSource reads a frame's source through the same pinned session, so no
+// second HTTP client and no second logon are needed.
 func (s *debugUIServer) handleSource(w http.ResponseWriter, r *http.Request) {
-	program := r.URL.Query().Get("program")
-	include := r.URL.Query().Get("include")
-
-	name, src, err := program, "", error(nil)
-	if include != "" && include != program {
-		name = include
-		src, err = s.client.GetInclude(r.Context(), include)
-	} else if program != "" {
-		src, err = s.client.GetProgram(r.Context(), program)
-	} else {
+	object := strings.TrimSpace(r.URL.Query().Get("object"))
+	if object == "" {
 		writeJSON(w, map[string]string{"source": "", "name": ""})
 		return
 	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	uri, err := s.dbg.ResolveSourceURI(r.Context(), object)
 	if err != nil {
-		writeJSON(w, map[string]string{"source": "", "name": name, "error": err.Error()})
+		writeJSON(w, map[string]string{"source": "", "name": object, "error": err.Error()})
 		return
 	}
-	writeJSON(w, map[string]string{"source": src, "name": name})
+	res, err := s.dbg.ADT(r.Context(), "GET", uri, []saprfc.ADTHeader{{Name: "Accept", Value: "text/plain"}}, nil)
+	if err != nil {
+		writeJSON(w, map[string]string{"source": "", "name": object, "error": err.Error()})
+		return
+	}
+	writeJSON(w, map[string]string{"source": string(res.Body), "name": object})
 }
 
 func (s *debugUIServer) handleDetach(w http.ResponseWriter, r *http.Request) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
 	if s.attached {
-		_ = s.client.DebuggerDetach(r.Context())
+		_ = s.dbg.ADTDetach(r.Context())
 	}
 	s.attached = false
 	s.debuggee = nil
-	writeJSON(w, s.collect(r.Context()))
+	writeJSON(w, s.snapshot(r.Context(), "detached"))
 }

--- a/cmd/vsp/debug_ui.html
+++ b/cmd/vsp/debug_ui.html
@@ -25,6 +25,14 @@ header{display:flex;align-items:center;gap:14px;padding:9px 14px;background:var(
 .dot.on{background:var(--good);box-shadow:0 0 0 3px rgba(87,191,146,.15)}
 .dot.stop{background:var(--stop);box-shadow:0 0 0 3px rgba(238,133,120,.15)}
 .spacer{flex:1}
+.bar{display:flex;align-items:center;gap:10px;padding:7px 14px;background:var(--sunk);border-bottom:1px solid var(--rule);flex-shrink:0;flex-wrap:wrap}
+.fld{display:flex;align-items:center;gap:6px;font-size:11px;letter-spacing:.1em;text-transform:uppercase;color:var(--ink-3)}
+.fld input{font-family:var(--mono);font-size:12px;background:var(--panel);color:var(--ink);border:1px solid var(--rule-2);
+  border-radius:3px;padding:4px 8px;letter-spacing:0;text-transform:none}
+.fld input:focus{outline:none;border-color:var(--accent)}
+#target{width:210px} #line{width:74px;text-align:right}
+.chk{display:flex;align-items:center;gap:6px;font-size:11px;letter-spacing:.1em;text-transform:uppercase;color:var(--ink-3);cursor:pointer}
+.chk input{accent-color:var(--brass)}
 button{font-family:var(--ui);font-size:12px;font-weight:500;padding:5px 11px;background:var(--panel-2);color:var(--ink-2);
   border:1px solid var(--rule-2);border-radius:3px;cursor:pointer}
 button:hover:not(:disabled){border-color:var(--accent);color:var(--ink)}
@@ -86,13 +94,22 @@ main{flex:1;display:grid;grid-template-columns:minmax(0,1fr) 320px;min-height:0}
   <span class="brand">vsp <span>debugger</span></span>
   <span class="status"><span class="dot" id="dot"></span><span id="who">detached</span></span>
   <span class="spacer"></span>
-  <button id="listen" class="primary">Listen</button>
-  <button id="into" disabled>Step into <kbd>F11</kbd></button>
+  <button id="into" disabled>Into <kbd>F11</kbd></button>
   <button id="over" disabled>Over <kbd>F10</kbd></button>
   <button id="out" disabled>Out</button>
   <button id="cont" disabled>Continue <kbd>F8</kbd></button>
   <button id="detach" disabled>Detach</button>
 </header>
+
+<div class="bar">
+  <label class="fld">object <input id="target" placeholder="RFC_SYSTEM_INFO" spellcheck="false"></label>
+  <label class="fld">line <input id="line" type="number" min="1" value="1"></label>
+  <button id="setbp">Set breakpoint</button>
+  <label class="chk"><input type="checkbox" id="sys"> system code</label>
+  <span class="spacer"></span>
+  <button id="run">Run</button>
+  <button id="listen" class="primary">Listen</button>
+</div>
 
 <main>
   <div class="left">
@@ -112,36 +129,40 @@ main{flex:1;display:grid;grid-template-columns:minmax(0,1fr) 320px;min-height:0}
 
 <script>
 const $ = id => document.getElementById(id);
-let state = {attached:false}, srcCache = new Map(), currentFrame = null, busy = false;
+let state = {}, srcCache = new Map(), busy = false;
 
 async function call(path){
   if (busy) return;
-  busy = true;
-  document.body.style.cursor = 'progress';
+  busy = true; document.body.style.cursor = 'progress';
+  for (const b of ['setbp','run','listen','into','over','out','cont','detach']) $(b).disabled = true;
   try {
     const r = await fetch(path, {method:'POST'});
-    const j = await r.json();
-    if (j.error) { note(j.error); }
-    else { state = j; await render(); }
+    state = await r.json();
+    await render();
   } catch (e) { note(String(e)); }
-  finally { busy = false; document.body.style.cursor = ''; }
+  finally { busy = false; document.body.style.cursor = ''; await buttons(); }
 }
 function note(t){ $('note').textContent = t || ''; }
+
+async function buttons(){
+  const on = !!state.attached;
+  for (const b of ['into','over','out','cont','detach']) $(b).disabled = !on;
+  for (const b of ['setbp','run','listen']) $(b).disabled = false;
+}
 
 function frameLabel(f){ return f.includeName && f.includeName !== f.programName ? f.includeName : f.programName; }
 
 async function render(){
   const on = !!state.attached;
   $('dot').className = 'dot ' + (on ? 'stop' : '');
-  $('who').textContent = on
-    ? `${state.debuggee?.debuggeeUser || '?'} · ${state.debuggee?.program || ''} · stopped`
-    : 'detached';
-  for (const b of ['into','over','out','cont','detach']) $(b).disabled = !on;
-  $('listen').disabled = on;
+  $('who').textContent = on ? (state.where || 'stopped') : 'detached';
+  if (document.activeElement !== $('target') && state.target) $('target').value = state.target;
+  if (document.activeElement !== $('line') && state.line) $('line').value = state.line;
+  $('sys').checked = !!state.systemDebugging;
   note(state.note);
 
   const frames = state.stack?.stack || [];
-  $('stackn').textContent = frames.length ? frames.length : '';
+  $('stackn').textContent = frames.length || '';
   const cur = state.stack?.debugCursorStackIndex ?? 0;
   $('stack').innerHTML = frames.length ? '' : '<div class="empty">—</div>';
   frames.forEach((f, i) => {
@@ -149,14 +170,13 @@ async function render(){
     el.className = 'frame' + (i === cur ? ' cur' : '') + (f.systemProgram ? ' sys' : '');
     el.innerHTML = `<span class="i">${f.stackPosition ?? i}</span><span>
         <span class="nm">${esc(frameLabel(f) || '?')}</span>
-        <div class="meta">line ${f.line ?? '?'}${f.eventName ? ' · ' + esc(f.eventName) : ''}${f.stackType && f.stackType !== 'ABAP' ? ' · ' + esc(f.stackType) : ''}</div>
+        <div class="meta">line ${f.line ?? '?'}${f.eventName ? ' · ' + esc(f.eventName) : ''}</div>
       </span>`;
-    el.onclick = () => { if (f.stackUri) call('/api/goto?uri=' + encodeURIComponent(f.stackUri)); };
     $('stack').appendChild(el);
   });
 
   const vars = state.variables || [];
-  $('varn').textContent = vars.length ? vars.length : '';
+  $('varn').textContent = vars.length || '';
   $('vars').innerHTML = vars.length ? '' : '<div class="empty">—</div>';
   vars.forEach(v => {
     const el = document.createElement('div');
@@ -169,38 +189,47 @@ async function render(){
   });
 
   const f = frames[cur];
-  if (f) await showSource(f);
+  if (f) await showSource(frameLabel(f), f.line);
+  else if (state.target) await showSource(state.target, state.line);
 }
 
-async function showSource(f){
-  const key = (f.programName || '') + '|' + (f.includeName || '');
-  let src = srcCache.get(key);
+async function showSource(object, hilite){
+  if (!object) return;
+  let src = srcCache.get(object);
   if (src === undefined) {
-    const r = await fetch(`/api/source?program=${encodeURIComponent(f.programName||'')}&include=${encodeURIComponent(f.includeName||'')}`);
+    const r = await fetch('/api/source?object=' + encodeURIComponent(object));
     const j = await r.json();
     src = j.source || '';
     if (j.error) note(`source for ${j.name}: ${j.error}`);
-    srcCache.set(key, src);
+    srcCache.set(object, src);
   }
-  $('srcname').textContent = frameLabel(f) || '';
-  if (!src) { $('source').innerHTML = '<div class="empty">Source not available for this frame.</div>'; return; }
-
+  $('srcname').textContent = object;
+  if (!src) { $('source').innerHTML = '<div class="empty">Source not available.</div>'; return; }
   const lines = src.split('\n');
   $('source').innerHTML = lines.map((t, i) => {
     const n = i + 1;
-    return `<div class="ln${n === f.line ? ' cur' : ''}"><span class="n">${n}</span><span class="t">${esc(t)}</span></div>`;
+    return `<div class="ln${n === hilite ? ' cur' : ''}" data-n="${n}"><span class="n">${n}</span><span class="t">${esc(t)}</span></div>`;
   }).join('');
   const el = $('source').querySelector('.ln.cur');
   if (el) el.scrollIntoView({block:'center'});
+  // Clicking a line picks it as the breakpoint line — reading a number off the
+  // gutter and retyping it is the kind of friction that makes a tool unused.
+  $('source').querySelectorAll('.ln').forEach(row => {
+    row.onclick = () => { $('line').value = row.dataset.n; };
+  });
 }
 
 function esc(s){ return String(s ?? '').replace(/[&<>"]/g, c => ({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;'}[c])); }
+const q = () => `object=${encodeURIComponent($('target').value.trim())}&line=${encodeURIComponent($('line').value)}`;
 
-$('listen').onclick = () => { note('listening for up to 60s — trigger the breakpoint now'); call('/api/listen'); };
-$('into').onclick   = () => call('/api/step?type=stepInto');
-$('over').onclick   = () => call('/api/step?type=stepOver');
-$('out').onclick    = () => call('/api/step?type=stepReturn');
-$('cont').onclick   = () => call('/api/step?type=stepContinue');
+$('setbp').onclick  = () => { srcCache.delete($('target').value.trim().toUpperCase()); call('/api/bp?' + q()); };
+$('sys').onchange   = () => call('/api/sys?on=' + ($('sys').checked ? 'true' : 'false'));
+$('run').onclick    = () => call('/api/run?' + q());
+$('listen').onclick = () => { note('listening — trigger it now if you have not'); call('/api/listen?seconds=60'); };
+$('into').onclick   = () => call('/api/step?type=into');
+$('over').onclick   = () => call('/api/step?type=over');
+$('out').onclick    = () => call('/api/step?type=out');
+$('cont').onclick   = () => call('/api/step?type=continue');
 $('detach').onclick = () => { srcCache.clear(); call('/api/detach'); };
 
 document.addEventListener('keydown', e => {

--- a/cmd/vsp/debug_ui_test.go
+++ b/cmd/vsp/debug_ui_test.go
@@ -20,7 +20,7 @@ func TestDebugUIServesItsPage(t *testing.T) {
 		t.Fatalf("GET / = %d, want 200", rec.Code)
 	}
 	body := rec.Body.String()
-	for _, want := range []string{"<title>vsp debugger</title>", "/api/listen", "stepInto", "Call stack"} {
+	for _, want := range []string{"<title>vsp debugger</title>", "/api/listen", "/api/step?type=into", "/api/bp", "Call stack"} {
 		if !strings.Contains(body, want) {
 			t.Errorf("the served page is missing %q — is the embed resolving?", want)
 		}

--- a/cmd/vsp/lua.go
+++ b/cmd/vsp/lua.go
@@ -6,9 +6,10 @@ import (
 	"os"
 	"time"
 
+	"github.com/spf13/cobra"
+
 	"github.com/oisee/vibing-steampunk/pkg/saprfc"
 	"github.com/oisee/vibing-steampunk/pkg/scripting"
-	"github.com/spf13/cobra"
 )
 
 var luaCmd = &cobra.Command{
@@ -65,18 +66,20 @@ func runLua(cmd *cobra.Command, args []string) error {
 	// Resolve configuration (same as MCP server)
 	resolveConfig(cmd.Parent())
 
-	// Validate we have auth
-	if err := validateConfig(); err != nil {
-		return err
-	}
+	// No validateConfig() here on purpose: it checks the global cfg.BaseURL,
+	// which a named system (-s / .vsp.json) never populates, so it rejected
+	// `-s a4h` before the resolver ever ran. createADTClientFor resolves the
+	// system and reports a real error if none can be found.
 
-	// Process cookie auth
-	if err := processCookieAuth(cmd.Parent()); err != nil {
-		return err
-	}
+	// No processCookieAuth here either: it reads the same global cfg. A named
+	// system carries its own credentials through resolveSystemParams, which is
+	// how deploy, deps and every other -s-aware command already work.
 
 	// Create ADT client
-	client := createADTClient()
+	client, err := createADTClientFor(cmd)
+	if err != nil {
+		return err
+	}
 
 	// Create Lua engine
 	engine := scripting.NewLuaEngine(client)

--- a/cmd/vsp/workflow.go
+++ b/cmd/vsp/workflow.go
@@ -7,9 +7,10 @@ import (
 	"os"
 	"time"
 
+	"github.com/spf13/cobra"
+
 	"github.com/oisee/vibing-steampunk/pkg/adt"
 	"github.com/oisee/vibing-steampunk/pkg/dsl"
-	"github.com/spf13/cobra"
 )
 
 var workflowCmd = &cobra.Command{
@@ -89,10 +90,10 @@ func runWorkflow(cmd *cobra.Command, args []string) error {
 	// Resolve configuration (same as MCP server)
 	resolveConfig(cmd.Parent().Parent())
 
-	// Validate we have auth
-	if err := validateConfig(); err != nil {
-		return err
-	}
+	// No validateConfig() here on purpose: it checks the global cfg.BaseURL,
+	// which a named system (-s / .vsp.json) never populates, so it rejected
+	// `-s a4h` before the resolver ever ran. createADTClientFor resolves the
+	// system and reports a real error if none can be found.
 
 	// Process cookie auth
 	if err := processCookieAuth(cmd.Parent().Parent()); err != nil {
@@ -100,7 +101,10 @@ func runWorkflow(cmd *cobra.Command, args []string) error {
 	}
 
 	// Create ADT client
-	client := createADTClient()
+	client, err := createADTClientFor(cmd)
+	if err != nil {
+		return err
+	}
 
 	// Create workflow engine
 	engine := dsl.NewWorkflowEngine(client)
@@ -150,16 +154,15 @@ func runTestWorkflow(cmd *cobra.Command, args []string) error {
 	// Resolve configuration
 	resolveConfig(cmd.Parent().Parent())
 
-	if err := validateConfig(); err != nil {
-		return err
-	}
-
 	if err := processCookieAuth(cmd.Parent().Parent()); err != nil {
 		return err
 	}
 
 	// Create ADT client
-	client := createADTClient()
+	client, err := createADTClientFor(cmd)
+	if err != nil {
+		return err
+	}
 
 	fmt.Fprintf(os.Stderr, "Discovering tests in: %s\n", packagePattern)
 
@@ -238,6 +241,43 @@ func runTestWorkflow(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
+// createADTClientFor resolves the target system the way every other command
+// does — -s, .vsp.json, then the environment — and routes through getClient so
+// the system's declared safety reaches the client.
+//
+// createADTClient below reads the global cfg, which a named system never
+// populates. So `vsp debug -s a4h` failed with "SAP URL is required" while
+// `vsp deploy -s a4h` worked, and the five commands built this way applied no
+// safety configuration at all: a read_only system was not read-only for them.
+func createADTClientFor(cmd *cobra.Command) (*adt.Client, error) {
+	params, err := resolveSystemParams(cmd)
+	if err != nil {
+		return nil, err
+	}
+
+	// Backfill the global cfg from the resolved system. This is not elegant,
+	// and it is deliberate: the debugger, the LSP and the Lua engine read
+	// cfg.BaseURL, cfg.Username and friends directly in a dozen places each —
+	// the WebSocket URL for ZADT_VSP among them, which is why `vsp debug -s a4h`
+	// reported "dial tcp :80" and an empty user. Threading params through all of
+	// that is a larger change than this one function; leaving them reading an
+	// empty cfg is what made -s silently useless for five commands.
+	cfg.BaseURL = params.URL
+	cfg.Username = params.User
+	cfg.Password = params.Password
+	if params.Client != "" {
+		cfg.Client = params.Client
+	}
+	if params.Language != "" {
+		cfg.Language = params.Language
+	}
+	cfg.InsecureSkipVerify = cfg.InsecureSkipVerify || params.Insecure
+
+	return getClient(params)
+}
+
+// Deprecated: use createADTClientFor. Kept for the LSP path, which builds its
+// client opportunistically after its own auth step and has no command to hand.
 func createADTClient() *adt.Client {
 	opts := []adt.Option{
 		adt.WithClient(cfg.Client),

--- a/pkg/saprfc/adtbreakpoints.go
+++ b/pkg/saprfc/adtbreakpoints.go
@@ -230,6 +230,15 @@ func (d *Debugger) ResolveSourceURI(ctx context.Context, name string) (string, e
 	if err != nil {
 		return "", err
 	}
+	// A name is not unique across object types, and the first match is not
+	// necessarily the one with source in it. RFC_SYSTEM_INFO, for instance, is
+	// both a DDIC structure and a function module; resolving to the structure
+	// yields a URI a breakpoint cannot be placed on, and SAP reports that far
+	// away as "Parameter I_MAIN_PROGRAM ... is initial, and therefore invalid".
+	//
+	// So prefer a result that can actually carry a line breakpoint, and only
+	// fall back to a non-source match when there is nothing better.
+	var fallback string
 	for _, r := range results {
 		if !strings.EqualFold(strings.TrimSpace(r.Name), name) {
 			continue
@@ -241,7 +250,15 @@ func (d *Debugger) ResolveSourceURI(ctx context.Context, name string) (string, e
 		if !strings.Contains(uri, "/source/main") {
 			uri = strings.TrimSuffix(uri, "/") + "/source/main"
 		}
-		return uri, nil
+		if sourceBearingURI(uri) {
+			return uri, nil
+		}
+		if fallback == "" {
+			fallback = uri
+		}
+	}
+	if fallback != "" {
+		return fallback, nil
 	}
 	return "", fmt.Errorf("no object named %s in the repository", name)
 }
@@ -286,4 +303,25 @@ func FormatBreakpoints(bps []adt.Breakpoint) string {
 		fmt.Fprintf(&sb, "%-10s %-28s %s\n", bp.Kind, where, bp.ID)
 	}
 	return sb.String()
+}
+
+// sourceBearingURI reports whether an ADT URI names something a line
+// breakpoint can sit in. The list is the set of source-bearing resources this
+// client already knows how to read; anything else — a DDIC type, a domain, a
+// table — has no line to stop on.
+func sourceBearingURI(uri string) bool {
+	lower := strings.ToLower(uri)
+	for _, path := range []string{
+		"/functions/groups/",
+		"/programs/programs/",
+		"/programs/includes/",
+		"/oo/classes/",
+		"/oo/interfaces/",
+		"/behaviordefinitions/",
+	} {
+		if strings.Contains(lower, path) {
+			return true
+		}
+	}
+	return false
 }


### PR DESCRIPTION
Three commits, separable, all verified against a live A4H 758.

```
vsp -s a4h debug ui RFC_SYSTEM_INFO
```

Set the line, **Set breakpoint**, **Run**, **Listen**. Run calls the function module over a second RFC connection, so the breakpoint fires in a session the page started itself — nothing to arrange in Eclipse first.

## 1. `ResolveSourceURI` put the breakpoint in the wrong object

It ran a quickSearch and took the first name match. Names are not unique across types: `RFC_SYSTEM_INFO` is both a DDIC structure and a function module, and the structure won. SAP reported that a long way from the cause —

```
Parameter I_MAIN_PROGRAM in method IF_TPDAPI_BP_SERVICES~CREATE_LINE_BREAKPOINT
is initial, and therefore invalid
```

— which reads as a client bug rather than as "you asked me to breakpoint a table". Now a source-bearing result wins. Before: refused. After:

```
line RFC_SYSTEM_INFO KIND=0.SOURCETYPE=ABAP.MAIN_PROGRAM=SAPLSRFC.INCLUDE=LSRFCU06.LINE_NR=14
```

That also removes a real piece of friction: a caller naming an FM need not know its function group's main program or which `LxxxUnn` include the body landed in.

## 2. `-s <system>` reached five commands only as an empty config — refs #117

`vsp debug -s a4h` said "SAP URL is required" while `vsp deploy -s a4h` worked on the same system. `debug`, `lsp`, `lua` and both `workflow` commands built their client from the global `cfg`, which a named system never populates.

Beyond convenience: `createADTClient()` applied **no safety configuration**, so a system marked `read_only` in `.vsp.json` was not read-only for any of those five. That is the blocker that held the persistent-flags work for #117.

The backfill of the global `cfg` is deliberate and commented — the debugger, LSP and Lua engine read `cfg.BaseURL` and `cfg.Username` directly in a dozen places each, the ZADT_VSP WebSocket URL among them, which is why this reported `dial tcp :80` and an empty user.

## 3. The UI, rebuilt on the pinned session

Two facts had to be learned first, and both look like nothing in a diff:

- **A breakpoint does not outlive the process that registered it.** Setting one with `vsp debug` and listening from another process catches nothing — `rfc breakpoints` shows an empty list once the first process exits.
- **An ADT-registered breakpoint is invisible to a ZADT_VSP-facade listener.** Mixing `ebp` with `catch` waits out the whole timeout while the debuggee runs past. One session, one family, or nothing stops.

So the server holds one `saprfc.Debugger` for its lifetime and locks around every operation — a pinned RFC conversation is single-threaded and the page fires concurrent fetches. Stack and variables come back as the same `adt` types the previous version rendered, so the page needed no new model.

Also: system-code debugging as a switch (SAP accepts a breakpoint in standard code and silently never stops without it); clicking a source line picks it as the breakpoint line; and the HTTP flag is `--http-port`, because `--port` is read by `rfcDestinationFor` as the **RFC gateway port** — naming it that made the command dial SAP on 7799 and hang before printing a line.

## Verified end to end, on SAP standard code

```
attached: true   where: SAPLSRFC/LSRFCU06:14
 [4] SAPLSRFC/LSRFCU06:14   RFC_SYSTEM_INFO
 [3] SAPLSRFC/LSRFCU06:1    RFC_SYSTEM_INFO
 [2] SAPMSSY1/SAPMSSY1:189  REMOTE_FUNCTION_CALL
 [1] SAPMSSY1/SAPMSSY1:35   %_RFC_START
variables: 72
```

Stepped 14 → 19, read the source through the same session, detached, breakpoints cleared. `go build`, `go vet`, `go test ./...` green.

## Scope change to declare

#186 said the UI "writes nothing". This one **sets breakpoints and calls function modules** — that is what makes it usable without Eclipse, and it is a deliberate change of scope rather than a quiet one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LQFAhfmJxybonf53QPEe5Q