### PR TITLE
feat(debug): Run sets the breakpoint, calls the target and catches it

### DIFF
--- a/cmd/vsp/debug_ui.go
+++ b/cmd/vsp/debug_ui.go
@@ -246,43 +246,75 @@ func (s *debugUIServer) handleListen(w http.ResponseWriter, r *http.Request) {
 	if n, err := strconv.Atoi(r.URL.Query().Get("seconds")); err == nil && n > 0 {
 		seconds = n
 	}
+	// Listen stays a button of its own because the trigger is not always ours:
+	// a colleague in SE38, a scheduled job, an agent on another machine.
+	s.catchLocked(w, r, seconds, "")
+}
 
+// catchLocked waits for a debuggee and attaches. Callers hold the lock.
+func (s *debugUIServer) catchLocked(w http.ResponseWriter, r *http.Request, seconds int, prefix string) {
 	who, _, err := s.dbg.ADTCatch(r.Context(), s.user, "vsp", adtTerminalID, seconds)
 	if err != nil && who == nil {
-		writeJSON(w, s.snapshot(r.Context(), fmt.Sprintf("listen failed: %v", err)))
+		writeJSON(w, s.snapshot(r.Context(), fmt.Sprintf("%slisten failed: %v", prefix, err)))
 		return
 	}
 	if who == nil {
-		writeJSON(w, s.snapshot(r.Context(), fmt.Sprintf("nobody stopped within %ds — is the breakpoint on an executable line?", seconds)))
+		writeJSON(w, s.snapshot(r.Context(),
+			fmt.Sprintf("%snobody stopped within %ds — is the line executable, and is system code switched on if it is SAP's own?", prefix, seconds)))
 		return
 	}
 	s.attached = true
 	s.debuggee = who
-	note := ""
+	note := prefix + "stopped"
 	if err != nil {
-		note = fmt.Sprintf("attached, but the stack could not be read: %v", err)
+		note = fmt.Sprintf("%sattached, but the stack could not be read: %v", prefix, err)
 	}
 	writeJSON(w, s.snapshot(r.Context(), note))
 }
 
-// handleRun triggers the target over a SECOND RFC connection. It has to be a
-// second one: this process's own conversation is pinned to the debug session,
-// and calling through it would deadlock against the breakpoint it is waiting on.
+// handleRun is the one button: make sure a breakpoint exists, call the target
+// on a SECOND RFC connection, then listen — all in one request.
+//
+// It has to be a second connection: this process's own conversation is pinned
+// to the debug session, and calling through it would deadlock against the
+// breakpoint it is about to wait on.
+//
+// The order matters and is not obvious. Listening first and calling second
+// cannot work, because the listen blocks. Calling first and listening second
+// looks like a race and is not: the debuggee parks at the breakpoint and waits
+// to be collected, so a listener arriving a moment later still finds it.
 func (s *debugUIServer) handleRun(w http.ResponseWriter, r *http.Request) {
 	s.mu.Lock()
-	target := s.target
-	dest := s.dest
-	s.mu.Unlock()
+	defer s.mu.Unlock()
 
-	if target == "" {
-		s.mu.Lock()
-		defer s.mu.Unlock()
+	if obj := strings.ToUpper(strings.TrimSpace(r.URL.Query().Get("object"))); obj != "" {
+		s.target = obj
+	}
+	if n, err := strconv.Atoi(r.URL.Query().Get("line")); err == nil && n > 0 {
+		s.line = n
+	}
+	if s.target == "" {
 		writeJSON(w, s.snapshot(r.Context(), "name an object first"))
 		return
 	}
 
+	// Nothing stops without a breakpoint, and making someone press two buttons
+	// in a fixed order to learn that is a poor way to teach it. If this session
+	// has registered none, set one where the fields point.
+	if existing, err := s.dbg.ADTBreakpoints(r.Context()); err == nil && len(existing) == 0 {
+		if _, err := s.dbg.ADTAddBreakpoint(r.Context(), s.target, s.line, ""); err != nil {
+			writeJSON(w, s.snapshot(r.Context(), fmt.Sprintf("breakpoint refused: %v", err)))
+			return
+		}
+		for _, rej := range s.dbg.Rejected() {
+			writeJSON(w, s.snapshot(r.Context(), fmt.Sprintf("not placed at %s:%d — %s", s.target, s.line, rej.ErrorMessage)))
+			return
+		}
+	}
+
+	target, dest := s.target, s.dest
 	go func() {
-		ctx := context.WithoutCancel(r.Context())
+		ctx := context.WithoutCancel(context.Background())
 		c, err := saprfc.OpenWithTimeout(ctx, dest, 120*time.Second)
 		if err != nil {
 			return
@@ -293,9 +325,11 @@ func (s *debugUIServer) handleRun(w http.ResponseWriter, r *http.Request) {
 		_, _ = c.Call(ctx, target, rfc.Params{})
 	}()
 
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	writeJSON(w, s.snapshot(r.Context(), "called "+target+" on a second connection — press Listen"))
+	seconds := 60
+	if n, err := strconv.Atoi(r.URL.Query().Get("seconds")); err == nil && n > 0 {
+		seconds = n
+	}
+	s.catchLocked(w, r, seconds, "called "+target+" — ")
 }
 
 func (s *debugUIServer) handleStep(w http.ResponseWriter, r *http.Request) {

--- a/cmd/vsp/debug_ui.html
+++ b/cmd/vsp/debug_ui.html
@@ -107,8 +107,8 @@ main{flex:1;display:grid;grid-template-columns:minmax(0,1fr) 320px;min-height:0}
   <button id="setbp">Set breakpoint</button>
   <label class="chk"><input type="checkbox" id="sys"> system code</label>
   <span class="spacer"></span>
-  <button id="run">Run</button>
-  <button id="listen" class="primary">Listen</button>
+  <button id="run" class="primary">Run &amp; catch</button>
+  <button id="listen" title="Wait for a debuggee someone else triggers — SE38, a job, another machine">Listen only</button>
 </div>
 
 <main>
@@ -224,8 +224,8 @@ const q = () => `object=${encodeURIComponent($('target').value.trim())}&line=${e
 
 $('setbp').onclick  = () => { srcCache.delete($('target').value.trim().toUpperCase()); call('/api/bp?' + q()); };
 $('sys').onchange   = () => call('/api/sys?on=' + ($('sys').checked ? 'true' : 'false'));
-$('run').onclick    = () => call('/api/run?' + q());
-$('listen').onclick = () => { note('listening — trigger it now if you have not'); call('/api/listen?seconds=60'); };
+$('run').onclick    = () => { note('setting the breakpoint, calling it, waiting — up to 60s'); call('/api/run?' + q()); };
+$('listen').onclick = () => { note('waiting up to 60s for someone else to trigger it'); call('/api/listen?seconds=60'); };
 $('into').onclick   = () => call('/api/step?type=into');
 $('over').onclick   = () => call('/api/step?type=over');
 $('out').onclick    = () => call('/api/step?type=out');


### PR DESCRIPTION
Answers a question from using it: *can the listener start automatically when Run is pressed?* Yes — and it should also set the breakpoint, because otherwise Run is still two buttons in a fixed order.

One POST to `/api/run` now: register a breakpoint if this session has none, call the target on a second RFC connection, wait for it to stop.

## The order inside, since getting it backwards is the natural mistake

**Listening first and calling second cannot work** — the listen blocks, so the call never goes out.

**Calling first and listening second looks like a race and is not** — the debuggee parks at the breakpoint and waits to be collected, so a listener arriving a moment later still finds it.

## What stays separate, and why

**Listen remains its own button.** The trigger is not always ours: a colleague in SE38, a scheduled job, an agent on another machine. Its label and message now say so instead of implying it is step two of a sequence.

**The breakpoint is auto-registered only when the session has none.** Someone who deliberately set two does not want a third appearing because they pressed Run.

Both handlers now share one `catchLocked`, so the "nobody stopped" message is written once — and it names both reasons that actually cause it: a non-executable line, and SAP standard code with system debugging still off.

## Verified

A single POST to `/api/run` with nothing before it, on A4H 758:

```
note: called RFC_SYSTEM_INFO — stopped
attached: true   where: SAPLSRFC/LSRFCU06:14
frames: 5   variables: 72
```

`go build`, `go vet`, `go test ./...` green; `golangci-lint` clean on the changed file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LQFAhfmJxybonf53QPEe5Q