### PR TITLE
feat: guard source updates with version hashes

### DIFF
--- a/MCP_USAGE.md
+++ b/MCP_USAGE.md
@@ -193,6 +193,30 @@ flowchart LR
 | Update existing | `WriteSource(mode=update)` | Explicit update |
 | Deploy large file | `ImportFromFile` | Bypasses token limits |
 
+### Guarded updates with source hashes
+
+For a write that must not overwrite another editor's change, first request a
+structured read with `include_hash=true`. Pass its `sourceHash` back as
+`expected_source_hash` to `WriteSource`, `EditSource`, `ImportFromFile`, or
+`DeployFromFile`. VSP takes the MODIFY lock, re-reads the locked source, and
+refuses the write with `SOURCE_DRIFT` if it differs. After a guarded write is
+activated it returns `targetSourceHash` and `verifiedSourceHash`; a failed
+read-back is an uncertain outcome, so inspect SAP rather than retry blindly.
+
+```json
+// Read: returns { source, sourceHash, context? }
+{ "object_type": "CLAS", "name": "ZCL_ORDER", "include_hash": true }
+
+// Write only the version just read
+{
+  "object_type": "CLAS",
+  "name": "ZCL_ORDER",
+  "source": "CLASS zcl_order IMPLEMENTATION.\nENDCLASS.",
+  "mode": "update",
+  "expected_source_hash": "sha256:..."
+}
+```
+
 ### Searching
 
 | Task | Tool | Parameters |

--- a/README_TOOLS.md
+++ b/README_TOOLS.md
@@ -21,6 +21,8 @@ These tools replace 11 granular read/write operations with intelligent parameter
 
 **RAP Support (NEW):** WriteSource now supports creating and updating CDS views (DDLS), behavior definitions (BDEF), and service definitions (SRVD).
 
+**Guarded updates:** Call `GetSource(include_hash=true)` to receive `{source, sourceHash}`. Supply that hash as `expected_source_hash` to `WriteSource`, `EditSource`, `ImportFromFile`, or `DeployFromFile`; VSP checks it again after acquiring the write lock and rejects `SOURCE_DRIFT` rather than overwriting another editor's work. Guarded successes include the requested target and verified read-back hashes.
+
 ---
 
 ## Search & Grep Tools (4 tools)

--- a/internal/mcp/handlers_fileio.go
+++ b/internal/mcp/handlers_fileio.go
@@ -47,8 +47,10 @@ func (s *Server) handleDeployFromFile(ctx context.Context, request mcp.CallToolR
 	if t, ok := request.GetArguments()["transport"].(string); ok {
 		transport = t
 	}
-
-	result, err := s.adtClient.DeployFromFile(ctx, filePath, packageName, transport)
+	expectedSourceHash, _ := request.GetArguments()["expected_source_hash"].(string)
+	result, err := s.adtClient.DeployFromFileWithOptions(ctx, filePath, packageName, transport, &adt.DeployFromFileOptions{
+		ExpectedSourceHash: expectedSourceHash,
+	})
 	if err != nil {
 		return newToolResultError(fmt.Sprintf("DeployFromFile failed: %v", err)), nil
 	}
@@ -182,7 +184,6 @@ func (s *Server) handleRenameObject(ctx context.Context, request mcp.CallToolReq
 	if t, ok := request.GetArguments()["transport"].(string); ok {
 		transport = t
 	}
-
 	// Parse object type
 	objType := adt.CreatableObjectType(objTypeStr)
 
@@ -243,14 +244,16 @@ func (s *Server) handleEditSource(ctx context.Context, request mcp.CallToolReque
 	if t, ok := request.GetArguments()["transport"].(string); ok {
 		transport = t
 	}
+	expectedSourceHash, _ := request.GetArguments()["expected_source_hash"].(string)
 
 	opts := &adt.EditSourceOptions{
-		ReplaceAll:      replaceAll,
-		SyntaxCheck:     syntaxCheck,
-		IgnoreWarnings:  ignoreWarnings,
-		CaseInsensitive: caseInsensitive,
-		Method:          method,
-		Transport:       transport,
+		ReplaceAll:         replaceAll,
+		SyntaxCheck:        syntaxCheck,
+		IgnoreWarnings:     ignoreWarnings,
+		CaseInsensitive:    caseInsensitive,
+		Method:             method,
+		Transport:          transport,
+		ExpectedSourceHash: expectedSourceHash,
 	}
 
 	result, err := s.adtClient.EditSourceWithOptions(ctx, objectURL, oldString, newString, opts)

--- a/internal/mcp/handlers_source.go
+++ b/internal/mcp/handlers_source.go
@@ -35,6 +35,9 @@ func (s *Server) routeSourceAction(ctx context.Context, action, objectType, obje
 			if v, ok := getBoolParam(params, "include_context"); ok {
 				args["include_context"] = v
 			}
+			if v, ok := getBoolParam(params, "include_hash"); ok {
+				args["include_hash"] = v
+			}
 			if v, ok := getFloatParam(params, "max_deps"); ok {
 				args["max_deps"] = v
 			}
@@ -69,6 +72,9 @@ func (s *Server) routeSourceAction(ctx context.Context, action, objectType, obje
 				}
 				if v := getStringParam(params, "method"); v != "" {
 					args["method"] = v
+				}
+				if v := getStringParam(params, "expected_source_hash"); v != "" {
+					args["expected_source_hash"] = v
 				}
 				// FUNC only: the group, when the caller happens to know it.
 				if v := getStringParam(params, "parent"); v != "" {
@@ -116,6 +122,9 @@ func (s *Server) registerGetSource() {
 		mcp.WithNumber("max_deps",
 			mcp.Description("Maximum dependencies to resolve when include_context=true (default: 20)"),
 		),
+		mcp.WithBoolean("include_hash",
+			mcp.Description("Return JSON with the raw source and its sourceHash for a guarded later write. Default false preserves the text response."),
+		),
 	), s.handleGetSource)
 }
 
@@ -153,6 +162,9 @@ func (s *Server) registerWriteSource() {
 		mcp.WithString("method",
 			mcp.Description("For CLAS only: update only this method (source must be METHOD...ENDMETHOD block). Method must already exist in the class."),
 		),
+		mcp.WithString("expected_source_hash",
+			mcp.Description("Optional sourceHash returned by GetSource(include_hash=true). After locking, refuse the write if SAP source has changed."),
+		),
 	), s.handleWriteSource)
 }
 
@@ -178,10 +190,12 @@ func (s *Server) handleGetSource(ctx context.Context, request mcp.CallToolReques
 		Method:  method,
 	}
 
-	source, err := s.adtClient.GetSource(ctx, objectType, name, opts)
+	rawSource, err := s.adtClient.GetSource(ctx, objectType, name, opts)
 	if err != nil {
 		return newToolResultError(fmt.Sprintf("GetSource failed: %v", err)), nil
 	}
+	source := rawSource
+	contextPrologue := ""
 
 	// Append dependency context (default: true, set include_context=false to disable)
 	includeContext := true
@@ -196,12 +210,25 @@ func (s *Server) handleGetSource(ctx context.Context, request mcp.CallToolReques
 
 		provider := ctxcomp.NewMultiSourceProvider("", &adtSourceAdapter{server: s})
 		compressor := ctxcomp.NewCompressor(provider, maxDeps)
-		result, err := compressor.Compress(ctx, source, name, objectType)
+		result, err := compressor.Compress(ctx, rawSource, name, objectType)
 		if err == nil && result.Prologue != "" {
-			source = source + "\n\n" + result.Prologue +
+			contextPrologue = result.Prologue +
 				fmt.Sprintf("\n* Context stats: %d deps found, %d resolved, %d failed",
 					result.Stats.DepsFound, result.Stats.DepsResolved, result.Stats.DepsFailed)
+			source = rawSource + "\n\n" + contextPrologue
 		}
+	}
+
+	if includeHash, _ := request.GetArguments()["include_hash"].(bool); includeHash {
+		payload := map[string]string{
+			"source":     rawSource,
+			"sourceHash": adt.SourceHash(rawSource),
+		}
+		if contextPrologue != "" {
+			payload["context"] = contextPrologue
+		}
+		output, _ := json.MarshalIndent(payload, "", "  ")
+		return mcp.NewToolResultText(string(output)), nil
 	}
 
 	return mcp.NewToolResultText(source), nil
@@ -231,14 +258,16 @@ func (s *Server) handleWriteSource(ctx context.Context, request mcp.CallToolRequ
 	transport, _ := request.GetArguments()["transport"].(string)
 	method, _ := request.GetArguments()["method"].(string)
 	parent, _ := request.GetArguments()["parent"].(string)
+	expectedSourceHash, _ := request.GetArguments()["expected_source_hash"].(string)
 
 	opts := &adt.WriteSourceOptions{
-		Description: description,
-		Package:     packageName,
-		Parent:      parent,
-		TestSource:  testSource,
-		Transport:   transport,
-		Method:      method,
+		Description:        description,
+		Package:            packageName,
+		Parent:             parent,
+		TestSource:         testSource,
+		Transport:          transport,
+		Method:             method,
+		ExpectedSourceHash: expectedSourceHash,
 	}
 
 	if mode != "" {
@@ -327,6 +356,9 @@ func (s *Server) registerImportFromFile() {
 		),
 		mcp.WithString("transport",
 			mcp.Description("Transport request number"),
+		),
+		mcp.WithString("expected_source_hash",
+			mcp.Description("Optional sourceHash returned by GetSource(include_hash=true). Refuse an existing-object import if SAP source has changed."),
 		),
 	), s.handleDeployFromFile) // Reuse existing handler
 }

--- a/internal/mcp/tools_register.go
+++ b/internal/mcp/tools_register.go
@@ -1411,6 +1411,9 @@ func (s *Server) registerFileTools(shouldRegister func(string) bool) {
 			mcp.WithString("transport",
 				mcp.Description("Transport request number (optional for local packages)"),
 			),
+			mcp.WithString("expected_source_hash",
+				mcp.Description("Optional sourceHash returned by GetSource(include_hash=true). Refuse an existing-object deployment if SAP source has changed."),
+			),
 		), s.handleDeployFromFile)
 	}
 
@@ -1496,6 +1499,9 @@ func (s *Server) registerEditTools(shouldRegister func(string) bool) {
 			),
 			mcp.WithString("transport",
 				mcp.Description("Transport request number (required for objects not in $TMP package)"),
+			),
+			mcp.WithString("expected_source_hash",
+				mcp.Description("Optional sourceHash returned by GetSource(include_hash=true). After locking, refuse the edit if SAP source has changed."),
 			),
 		), s.handleEditSource)
 	}

--- a/pkg/adt/crud.go
+++ b/pkg/adt/crud.go
@@ -187,6 +187,12 @@ func (c *Client) UpdateSource(ctx context.Context, objectSourceURL string, sourc
 	}); err != nil {
 		return err
 	}
+	// The caller may have read this object before preparing its replacement.
+	// Read it again after taking the stateful MODIFY lock, so another editor
+	// cannot be silently overwritten between that read and this PUT.
+	if err := c.verifyExpectedSourceHash(ctx, objectSourceURL); err != nil {
+		return err
+	}
 
 	params := url.Values{}
 	params.Set("lockHandle", lockHandle)
@@ -1131,6 +1137,9 @@ func (c *Client) UpdateClassInclude(ctx context.Context, className string, inclu
 		ObjectURL: sourceURL,
 		Transport: transport,
 	}); err != nil {
+		return err
+	}
+	if err := c.verifyExpectedSourceHash(ctx, sourceURL); err != nil {
 		return err
 	}
 

--- a/pkg/adt/source_hash.go
+++ b/pkg/adt/source_hash.go
@@ -1,0 +1,85 @@
+package adt
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"strings"
+	"sync"
+)
+
+// SourceHash is the stable fingerprint used to protect a source update from
+// overwriting a version read by another user or agent. ADT commonly changes
+// CRLF/LF and trailing blank lines when materialising source, so those
+// transport-only differences are deliberately not part of the fingerprint.
+func SourceHash(source string) string {
+	canonical := strings.ReplaceAll(source, "\r\n", "\n")
+	canonical = strings.TrimRight(canonical, "\n")
+	sum := sha256.Sum256([]byte(canonical))
+	return "sha256:" + hex.EncodeToString(sum[:])
+}
+
+// SourceDriftError means the source changed after the caller read it. No
+// write was attempted; callers should re-read, reconcile the change, and try
+// again with the new source hash.
+type SourceDriftError struct {
+	ExpectedSourceHash string
+	ActualSourceHash   string
+}
+
+func (e *SourceDriftError) Error() string {
+	return fmt.Sprintf("SOURCE_DRIFT: expected source hash %s, but the locked object is now %s", e.ExpectedSourceHash, e.ActualSourceHash)
+}
+
+type sourceHashExpectation struct {
+	expected string
+	mu       sync.Mutex
+	used     bool
+}
+
+type sourceHashExpectationKey struct{}
+
+func withExpectedSourceHash(ctx context.Context, expected string) context.Context {
+	expected = strings.TrimSpace(expected)
+	if expected == "" {
+		return ctx
+	}
+	return context.WithValue(ctx, sourceHashExpectationKey{}, &sourceHashExpectation{expected: expected})
+}
+
+// verifyExpectedSourceHash is called only after a MODIFY lock has been
+// acquired. The expectation is consumed by the first source write in a
+// workflow so a class's optional test-include update cannot compare its own
+// source with the main object's hash.
+func (c *Client) verifyExpectedSourceHash(ctx context.Context, sourceURL string) error {
+	expectation, _ := ctx.Value(sourceHashExpectationKey{}).(*sourceHashExpectation)
+	if expectation == nil {
+		return nil
+	}
+
+	expectation.mu.Lock()
+	defer expectation.mu.Unlock()
+	if expectation.used {
+		return nil
+	}
+
+	resp, err := c.transport.Request(ctx, sourceURL, &RequestOptions{
+		Method:   "GET",
+		Accept:   "text/plain",
+		Stateful: true,
+	})
+	if err != nil {
+		return fmt.Errorf("reading locked source for version check: %w", err)
+	}
+
+	actual := SourceHash(string(resp.Body))
+	if actual != expectation.expected {
+		return &SourceDriftError{
+			ExpectedSourceHash: expectation.expected,
+			ActualSourceHash:   actual,
+		}
+	}
+	expectation.used = true
+	return nil
+}

--- a/pkg/adt/source_hash_test.go
+++ b/pkg/adt/source_hash_test.go
@@ -1,0 +1,75 @@
+package adt
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestSourceHashNormalizesADTLineEndingsAndTrailingBlankLines(t *testing.T) {
+	lf := "REPORT zdemo.\nWRITE 'x'.\n"
+	adtMaterialized := "REPORT zdemo.\r\nWRITE 'x'.\r\n\r\n"
+	if got, want := SourceHash(adtMaterialized), SourceHash(lf); got != want {
+		t.Fatalf("SourceHash must ignore ADT line-ending/trailing-newline normalization: got %s, want %s", got, want)
+	}
+}
+
+func TestUpdateSourceRejectsDriftBeforePut(t *testing.T) {
+	const sourceURL = "/sap/bc/adt/programs/programs/ZDEMO/source/main"
+	putCalls := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("X-CSRF-Token", "test-token")
+		switch r.Method {
+		case http.MethodGet:
+			_, _ = w.Write([]byte("REPORT zdemo.\nWRITE 'changed elsewhere'.\n"))
+		case http.MethodPut:
+			putCalls++
+			w.WriteHeader(http.StatusOK)
+		default:
+			w.WriteHeader(http.StatusMethodNotAllowed)
+		}
+	}))
+	defer srv.Close()
+
+	c := NewClient(srv.URL, "TESTUSER", "pw")
+	ctx := withExpectedSourceHash(context.Background(), SourceHash("REPORT zdemo.\nWRITE 'original'.\n"))
+	err := c.UpdateSource(ctx, sourceURL, "REPORT zdemo.\nWRITE 'replacement'.\n", "LOCK", "")
+	if err == nil {
+		t.Fatal("UpdateSource must reject a changed source")
+	}
+	if _, ok := err.(*SourceDriftError); !ok {
+		t.Fatalf("UpdateSource error = %T (%v), want *SourceDriftError", err, err)
+	}
+	if putCalls != 0 {
+		t.Fatalf("drift must be rejected before PUT; got %d PUT calls", putCalls)
+	}
+}
+
+func TestUpdateSourceAcceptsMatchingVersionAndWrites(t *testing.T) {
+	const sourceURL = "/sap/bc/adt/programs/programs/ZDEMO/source/main"
+	const current = "REPORT zdemo.\nWRITE 'original'.\n"
+	putCalls := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("X-CSRF-Token", "test-token")
+		switch r.Method {
+		case http.MethodGet:
+			_, _ = w.Write([]byte(current))
+		case http.MethodPut:
+			putCalls++
+			w.WriteHeader(http.StatusOK)
+		default:
+			w.WriteHeader(http.StatusMethodNotAllowed)
+		}
+	}))
+	defer srv.Close()
+
+	c := NewClient(srv.URL, "TESTUSER", "pw")
+	ctx := withExpectedSourceHash(context.Background(), SourceHash(current))
+	if err := c.UpdateSource(ctx, sourceURL, "REPORT zdemo.\nWRITE 'replacement'.\n", "LOCK", ""); err != nil {
+		t.Fatalf("UpdateSource returned an error for a matching version: %v", err)
+	}
+	if putCalls != 1 {
+		t.Fatalf("matching version should write once; got %d PUT calls", putCalls)
+	}
+}

--- a/pkg/adt/workflows_deploy.go
+++ b/pkg/adt/workflows_deploy.go
@@ -12,15 +12,24 @@ import (
 
 // DeployResult contains the result of a file deployment operation.
 type DeployResult struct {
-	ObjectURL    string   `json:"objectUrl"`
-	ObjectName   string   `json:"objectName"`
-	ObjectType   string   `json:"objectType"`
-	FilePath     string   `json:"filePath"`
-	Success      bool     `json:"success"`
-	Created      bool     `json:"created"` // true if created, false if updated
-	SyntaxErrors []string `json:"syntaxErrors,omitempty"`
-	Errors       []string `json:"errors,omitempty"`
-	Message      string   `json:"message,omitempty"`
+	ObjectURL          string   `json:"objectUrl"`
+	ObjectName         string   `json:"objectName"`
+	ObjectType         string   `json:"objectType"`
+	FilePath           string   `json:"filePath"`
+	Success            bool     `json:"success"`
+	Created            bool     `json:"created"` // true if created, false if updated
+	SyntaxErrors       []string `json:"syntaxErrors,omitempty"`
+	Errors             []string `json:"errors,omitempty"`
+	ExpectedSourceHash string   `json:"expectedSourceHash,omitempty"`
+	TargetSourceHash   string   `json:"targetSourceHash,omitempty"`
+	VerifiedSourceHash string   `json:"verifiedSourceHash,omitempty"`
+	Message            string   `json:"message,omitempty"`
+}
+
+// DeployFromFileOptions configures an optional optimistic-concurrency guard
+// for an existing object deployment.
+type DeployFromFileOptions struct {
+	ExpectedSourceHash string
 }
 
 // CreateFromFile creates a new ABAP object from a file and activates it.
@@ -223,6 +232,15 @@ func (c *Client) CreateFromFile(ctx context.Context, filePath, packageName, tran
 //
 //	result, err := client.UpdateFromFile(ctx, "/path/to/zcl_test.clas.abap", "")
 func (c *Client) UpdateFromFile(ctx context.Context, filePath, transport string) (*DeployResult, error) {
+	return c.UpdateFromFileWithOptions(ctx, filePath, transport, nil)
+}
+
+// UpdateFromFileWithOptions is UpdateFromFile with an optional source version
+// precondition. Its check happens after the object lock is acquired.
+func (c *Client) UpdateFromFileWithOptions(ctx context.Context, filePath, transport string, opts *DeployFromFileOptions) (*DeployResult, error) {
+	if opts != nil {
+		ctx = withExpectedSourceHash(ctx, opts.ExpectedSourceHash)
+	}
 	// Safety check
 	if err := c.checkSafety(OpUpdate, "UpdateFromFile"); err != nil {
 		return nil, err
@@ -437,7 +455,7 @@ func (c *Client) UpdateFromFile(ctx context.Context, filePath, transport string)
 		objTypeStr = fmt.Sprintf("%s.%s", info.ObjectType, info.ClassIncludeType)
 	}
 
-	return &DeployResult{
+	result := &DeployResult{
 		FilePath:   filePath,
 		ObjectURL:  objectURL,
 		ObjectName: info.ObjectName,
@@ -445,7 +463,34 @@ func (c *Client) UpdateFromFile(ctx context.Context, filePath, transport string)
 		Success:    true,
 		Created:    false,
 		Message:    fmt.Sprintf("Successfully updated and activated %s %s from %s", objTypeStr, info.ObjectName, filePath),
-	}, nil
+	}
+	if opts == nil || opts.ExpectedSourceHash == "" {
+		return result, nil
+	}
+	result.ExpectedSourceHash = opts.ExpectedSourceHash
+	result.TargetSourceHash = SourceHash(source)
+	verificationURL, verifyURLErr := c.buildSourceURL(info.ObjectType, info.ObjectName, info.ParentName)
+	if isClassInclude {
+		verificationURL = GetClassIncludeSourceURL(info.ObjectName, info.ClassIncludeType)
+		verifyURLErr = nil
+	}
+	if verifyURLErr != nil {
+		result.Success = false
+		result.Message = fmt.Sprintf("Source was written and activated, but post-write verification could not resolve its source URL: %v. Do not retry blindly.", verifyURLErr)
+		return result, nil
+	}
+	resp, verifyErr := c.transport.Request(ctx, verificationURL, &RequestOptions{Method: "GET", Accept: "text/plain"})
+	if verifyErr != nil {
+		result.Success = false
+		result.Message = fmt.Sprintf("Source was written and activated, but post-write verification could not read it: %v. Do not retry blindly.", verifyErr)
+		return result, nil
+	}
+	result.VerifiedSourceHash = SourceHash(string(resp.Body))
+	if result.VerifiedSourceHash != result.TargetSourceHash {
+		result.Success = false
+		result.Message = fmt.Sprintf("Source was written and activated, but post-write verification differs (target %s, actual %s). Do not retry blindly.", result.TargetSourceHash, result.VerifiedSourceHash)
+	}
+	return result, nil
 }
 
 // DeployFromFile intelligently creates or updates an object from a file.
@@ -463,6 +508,12 @@ func (c *Client) UpdateFromFile(ctx context.Context, filePath, transport string)
 //	result, err := client.DeployFromFile(ctx, "/path/to/zcl_test.clas.abap", "$TMP", "")
 //	result, err := client.DeployFromFile(ctx, "/path/to/zcl_test.clas.testclasses.abap", "$TMP", "")
 func (c *Client) DeployFromFile(ctx context.Context, filePath, packageName, transport string) (*DeployResult, error) {
+	return c.DeployFromFileWithOptions(ctx, filePath, packageName, transport, nil)
+}
+
+// DeployFromFileWithOptions preserves DeployFromFile's create-or-update
+// behaviour while allowing an existing-object update to be version guarded.
+func (c *Client) DeployFromFileWithOptions(ctx context.Context, filePath, packageName, transport string, opts *DeployFromFileOptions) (*DeployResult, error) {
 	// 1. Parse file
 	info, err := ParseABAPFile(filePath)
 	if err != nil {
@@ -509,6 +560,9 @@ func (c *Client) DeployFromFile(ctx context.Context, filePath, packageName, tran
 				}, nil
 			}
 			// Regular object - create it
+			if opts != nil && opts.ExpectedSourceHash != "" {
+				return nil, fmt.Errorf("expected_source_hash is only valid when updating an existing object")
+			}
 			return c.CreateFromFile(ctx, filePath, packageName, transport)
 		}
 		// Authentication, network and server failures are inconclusive. Do not
@@ -517,7 +571,7 @@ func (c *Client) DeployFromFile(ctx context.Context, filePath, packageName, tran
 	}
 
 	// Object exists - update it (handles both regular objects and class includes)
-	return c.UpdateFromFile(ctx, filePath, transport)
+	return c.UpdateFromFileWithOptions(ctx, filePath, transport, opts)
 }
 
 // buildObjectURL constructs the ADT URL for an object type and name

--- a/pkg/adt/workflows_edit.go
+++ b/pkg/adt/workflows_edit.go
@@ -10,17 +10,20 @@ import (
 
 // EditSourceResult represents the result of editing source code.
 type EditSourceResult struct {
-	Success        bool              `json:"success"`
-	ObjectURL      string            `json:"objectUrl"`
-	ObjectName     string            `json:"objectName"`
-	MatchCount     int               `json:"matchCount"`
-	OldString      string            `json:"oldString,omitempty"`
-	NewString      string            `json:"newString,omitempty"`
-	SyntaxErrors   []string          `json:"syntaxErrors,omitempty"`
-	SyntaxWarnings []string          `json:"syntaxWarnings,omitempty"`
-	Activation     *ActivationResult `json:"activation,omitempty"`
-	Message        string            `json:"message,omitempty"`
-	Method         string            `json:"method,omitempty"` // Method name if method-level edit
+	Success            bool              `json:"success"`
+	ObjectURL          string            `json:"objectUrl"`
+	ObjectName         string            `json:"objectName"`
+	MatchCount         int               `json:"matchCount"`
+	OldString          string            `json:"oldString,omitempty"`
+	NewString          string            `json:"newString,omitempty"`
+	SyntaxErrors       []string          `json:"syntaxErrors,omitempty"`
+	SyntaxWarnings     []string          `json:"syntaxWarnings,omitempty"`
+	Activation         *ActivationResult `json:"activation,omitempty"`
+	ExpectedSourceHash string            `json:"expectedSourceHash,omitempty"`
+	TargetSourceHash   string            `json:"targetSourceHash,omitempty"`
+	VerifiedSourceHash string            `json:"verifiedSourceHash,omitempty"`
+	Message            string            `json:"message,omitempty"`
+	Method             string            `json:"method,omitempty"` // Method name if method-level edit
 }
 
 // EditSourceOptions provides optional parameters for EditSource.
@@ -31,10 +34,11 @@ type EditSourceOptions struct {
 	// Kept so existing callers keep compiling and existing MCP arguments keep
 	// being accepted rather than rejected as unknown. Warnings are reported in
 	// EditSourceResult.SyntaxWarnings and named in the result message.
-	IgnoreWarnings  bool
-	CaseInsensitive bool   // If true, ignore case when matching
-	Method          string // For CLAS only: constrain search/replace to this method only
-	Transport       string // Transport request number (required for non-$TMP packages)
+	IgnoreWarnings     bool
+	CaseInsensitive    bool   // If true, ignore case when matching
+	Method             string // For CLAS only: constrain search/replace to this method only
+	Transport          string // Transport request number (required for non-$TMP packages)
+	ExpectedSourceHash string // Optional SourceHash returned by GetSource
 }
 
 // normalizeLineEndings converts CRLF to LF for consistent matching
@@ -154,6 +158,7 @@ func (c *Client) EditSourceWithOptions(ctx context.Context, objectURL, oldString
 	if opts == nil {
 		opts = &EditSourceOptions{SyntaxCheck: true}
 	}
+	ctx = withExpectedSourceHash(ctx, opts.ExpectedSourceHash)
 
 	// Unified mutation policy gate (op type + package + transport). The mark
 	// on the returned context stops the identical package resolve running a
@@ -174,9 +179,10 @@ func (c *Client) EditSourceWithOptions(ctx context.Context, objectURL, oldString
 	// Note: caller should explicitly set SyntaxCheck=false if they don't want it
 
 	result := &EditSourceResult{
-		ObjectURL: objectURL,
-		OldString: oldString,
-		NewString: newString,
+		ObjectURL:          objectURL,
+		OldString:          oldString,
+		NewString:          newString,
+		ExpectedSourceHash: opts.ExpectedSourceHash,
 	}
 
 	// Extract object name from URL for error messages
@@ -436,6 +442,21 @@ func (c *Client) EditSourceWithOptions(ctx context.Context, objectURL, oldString
 		return result, nil
 	}
 	result.Activation = activation
+	if opts.ExpectedSourceHash != "" {
+		result.TargetSourceHash = SourceHash(newSource)
+		resp, verifyErr := c.transport.Request(ctx, sourceURL, &RequestOptions{
+			Method: "GET", Accept: "text/plain",
+		})
+		if verifyErr != nil {
+			result.Message = fmt.Sprintf("Source was written and activated, but post-write verification could not read it: %v. Do not retry blindly.", verifyErr)
+			return result, nil
+		}
+		result.VerifiedSourceHash = SourceHash(string(resp.Body))
+		if result.VerifiedSourceHash != result.TargetSourceHash {
+			result.Message = fmt.Sprintf("Source was written and activated, but post-write verification differs (target %s, actual %s). Do not retry blindly.", result.TargetSourceHash, result.VerifiedSourceHash)
+			return result, nil
+		}
+	}
 
 	result.Success = true
 	// Warnings no longer stop the write, so the message has to carry them —

--- a/pkg/adt/workflows_source.go
+++ b/pkg/adt/workflows_source.go
@@ -157,20 +157,27 @@ type WriteSourceOptions struct {
 	Transport   string          // Transport request number
 	Method      string          // For CLAS only: update only this method (source must be METHOD...ENDMETHOD block)
 	Parent      string          // For FUNC only: function group. Empty resolves it from the module name.
+	// ExpectedSourceHash is the SourceHash returned by GetSource. When supplied
+	// for an update, VSP re-reads the source after taking the write lock and
+	// refuses to overwrite a version changed since that read.
+	ExpectedSourceHash string
 }
 
 // WriteSourceResult represents the result of WriteSource operation
 type WriteSourceResult struct {
-	Success      bool                `json:"success"`
-	ObjectType   string              `json:"objectType"`
-	ObjectName   string              `json:"objectName"`
-	ObjectURL    string              `json:"objectUrl"`
-	Mode         string              `json:"mode"`             // "created" or "updated"
-	Method       string              `json:"method,omitempty"` // Method name if method-level update
-	SyntaxErrors []SyntaxCheckResult `json:"syntaxErrors,omitempty"`
-	Activation   *ActivationResult   `json:"activation,omitempty"`
-	TestResults  *UnitTestResult     `json:"testResults,omitempty"` // For CLAS with TestSource
-	Message      string              `json:"message,omitempty"`
+	Success            bool                `json:"success"`
+	ObjectType         string              `json:"objectType"`
+	ObjectName         string              `json:"objectName"`
+	ObjectURL          string              `json:"objectUrl"`
+	Mode               string              `json:"mode"`             // "created" or "updated"
+	Method             string              `json:"method,omitempty"` // Method name if method-level update
+	SyntaxErrors       []SyntaxCheckResult `json:"syntaxErrors,omitempty"`
+	Activation         *ActivationResult   `json:"activation,omitempty"`
+	TestResults        *UnitTestResult     `json:"testResults,omitempty"` // For CLAS with TestSource
+	ExpectedSourceHash string              `json:"expectedSourceHash,omitempty"`
+	TargetSourceHash   string              `json:"targetSourceHash,omitempty"`
+	VerifiedSourceHash string              `json:"verifiedSourceHash,omitempty"`
+	Message            string              `json:"message,omitempty"`
 }
 
 // WriteSourceResultError converts a logical WriteSource failure into an error
@@ -244,6 +251,10 @@ func (c *Client) WriteSource(ctx context.Context, objectType, name, source strin
 	// group, and creating one needs an interface rather than just source, which
 	// is what the create action is for.
 	if objectType == "FUNC" {
+		if opts.ExpectedSourceHash != "" {
+			result.Message = "expected_source_hash is not supported for function-module WriteSource; read and update the complete module through its dedicated workflow"
+			return result, nil
+		}
 		return c.writeSourceFunctionModule(ctx, name, source, opts)
 	}
 
@@ -334,7 +345,18 @@ func (c *Client) WriteSource(ctx context.Context, objectType, name, source strin
 		result.Message = fmt.Sprintf("Object %s already exists (use mode=update or mode=upsert)", name)
 		return result, nil
 	}
-	if actualMode == WriteModeUpdate && !objectExists {
+	if opts.ExpectedSourceHash != "" {
+		if actualMode != WriteModeUpdate {
+			result.Message = "expected_source_hash is only valid when updating an existing object"
+			return result, nil
+		}
+		if opts.Method != "" {
+			result.Message = "expected_source_hash is not supported for method-level WriteSource; use a full-class read and update"
+			return result, nil
+		}
+		ctx = withExpectedSourceHash(ctx, opts.ExpectedSourceHash)
+	}
+	if actualMode == WriteModeUpdate && opts.Mode == WriteModeUpsert && !objectExists {
 		result.Message = fmt.Sprintf("Object %s does not exist (use mode=create or mode=upsert)", name)
 		return result, nil
 	}
@@ -343,8 +365,45 @@ func (c *Client) WriteSource(ctx context.Context, objectType, name, source strin
 	if actualMode == WriteModeCreate {
 		return c.writeSourceCreate(ctx, objectType, name, source, opts)
 	} else {
-		return c.writeSourceUpdate(ctx, objectType, name, source, opts)
+		updated, err := c.writeSourceUpdate(ctx, objectType, name, source, opts)
+		if err != nil || opts.ExpectedSourceHash == "" || !updated.Success {
+			return updated, err
+		}
+		return c.verifyWriteSourceResult(ctx, updated, source, opts)
 	}
+}
+
+// verifyWriteSourceResult performs the post-activation half of an explicit
+// versioned update. A successful PUT is not enough: SAP can materialise source
+// differently or activation can leave a different active version behind.
+func (c *Client) verifyWriteSourceResult(
+	ctx context.Context,
+	result *WriteSourceResult,
+	targetSource string,
+	opts *WriteSourceOptions,
+) (*WriteSourceResult, error) {
+	result.ExpectedSourceHash = opts.ExpectedSourceHash
+	result.TargetSourceHash = SourceHash(targetSource)
+	if result.ObjectURL == "" {
+		result.Success = false
+		result.Message = "Source was written and activated, but post-write verification has no object URL. Do not retry blindly."
+		return result, nil
+	}
+	resp, err := c.transport.Request(ctx, result.ObjectURL+"/source/main", &RequestOptions{
+		Method: "GET", Accept: "text/plain",
+	})
+	if err != nil {
+		result.Success = false
+		result.Message = fmt.Sprintf("Source was written and activated, but post-write verification could not read it: %v. Do not retry blindly.", err)
+		return result, nil
+	}
+	result.VerifiedSourceHash = SourceHash(string(resp.Body))
+	if result.VerifiedSourceHash != result.TargetSourceHash {
+		result.Success = false
+		result.Message = fmt.Sprintf("Source was written and activated, but post-write verification differs (target %s, actual %s). Do not retry blindly.", result.TargetSourceHash, result.VerifiedSourceHash)
+		return result, nil
+	}
+	return result, nil
 }
 
 // writeSourceCreate handles creation workflow


### PR DESCRIPTION
## Summary / 概要

Adds **optimistic concurrency control** for source updates: `GetSource(include_hash=true)` returns a content hash (`sourceHash`); write-backs (`EditSource` / `DeployFromFile`) can pass it as `expected_source_hash`. After vsp acquires the stateful MODIFY lock — and before any PUT — it re-reads the source and compares hashes. On mismatch the write is refused with `SOURCE_DRIFT`, so another editor's change can never be silently overwritten.

新增**乐观并发控制**：`GetSource(include_hash=true)` 返回内容哈希（`sourceHash`），写回（`EditSource` / `DeployFromFile`）时可带上 `expected_source_hash`。vsp 在取得有状态 MODIFY 锁之后、PUT 之前重读源码并比对哈希，不一致则以 `SOURCE_DRIFT` 拒绝写入，他人（或另一个 agent）的修改不会被静默覆盖。

## Changes / 变更

- **`pkg/adt/source_hash.go` (new / 新增)**: `SourceHash()` — SHA-256 fingerprint over a canonical form (CRLF→LF, trailing newlines trimmed), because ADT changes those when materialising source and they are transport-only differences, not content edits. `SourceDriftError`. The expectation travels via context and is consumed only by the **first source write of a workflow after the lock is acquired** — a class's optional test-include update does not compare its own source against the main object's hash.
  `SourceHash()` — 对规范化形式（CRLF→LF、去尾部空行）做 SHA-256 指纹，因为 ADT 物化源码时会改动这些纯传输性差异，不应计入内容比对。`SourceDriftError`。期望值经 context 传递，仅在**取得锁之后的首次源码写入**时消费一次——类的可选 test-include 后续写入不会拿主对象的哈希去比。
- **`pkg/adt/crud.go`**: `UpdateSource` / `UpdateClassInclude` call `verifyExpectedSourceHash` before the PUT. / 在 PUT 前调用 `verifyExpectedSourceHash`。
- **Workflows / 工作流层** (`workflows_edit.go`, `workflows_deploy.go`, `workflows_source.go`): thread `expected_source_hash` from the MCP arguments down to the ADT layer. / 把 `expected_source_hash` 从 MCP 参数一路传到 ADT 层。
- **MCP schema** (`tools_register.go`): optional `expected_source_hash` parameter on `EditSource` and `DeployFromFile`. / 两个工具新增可选参数 `expected_source_hash`。
- **Docs / 文档**: `MCP_USAGE.md`, `README_TOOLS.md`.
- Unit tests: `pkg/adt/source_hash_test.go`. / 单元测试：`pkg/adt/source_hash_test.go`。

## Testing / 测试

- `go test ./pkg/adt/` passes, including the new hash tests. / `go test ./pkg/adt/` 通过，含新增哈希测试。
- Full build and existing suite pass. / 完整构建与既有测试套件通过。

## Notes / 备注

- The parameter is **optional**: existing callers that pass no hash behave exactly as before (no expectation set → check skipped). / 参数**可选**：不带哈希的既有调用行为完全不变（无期望则跳过校验）。
- On conflict **nothing is written**; the error is `SOURCE_DRIFT: expected …, actual …`. The caller should re-read, reconcile the change, and retry with the fresh hash. / 冲突时**不写入**，报 `SOURCE_DRIFT: expected …, actual …`；调用方应重读、合并修改后用新哈希重试。