### PR TITLE
feat(inspect): variants, SE37 test data, SE61 documentation and the IMG

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -100,6 +100,8 @@ pkg/
   graph/              Dependency graph engine (in progress)
   datacluster/        EXPORT data cluster parser (BALDAT, INDX, STXL): descriptors, rows, typed values
   sapcompress/        SAP LZH (= DEFLATE + prefix, via compress/flate) and LZC (compress(1)) decoders
+  temse/              TemSe list spool format (TST03) → lines
+  itf/                SAPscript ITF (DOKTL documentation) → Markdown
   ctxcomp/            Context compression (dep resolution for read)
   abaplint/           ABAP lexer + parser (95 statement patterns; 13 lint rules, 8 on by default)
   dsl/                Fluent API, YAML workflows, batch ops

--- a/README.md
+++ b/README.md
@@ -283,6 +283,28 @@ vsp -s a4h spool list --job ZDEMO_NIGHTLY --top 20
 vsp -s a4h spool export --user TESTUSER --since 2026-09-01 --out ./spool
 ```
 
+### What is it set up to do — variants, test data, documentation, the IMG
+
+The other half of a root cause is configuration, and it sits in tables too.
+`vsp variants` reads a report variant as a table of fields with their labels,
+kinds, types and values, from VARI and the program's selection texts; that is
+what a job's step selected, without `RS_VARIANT_CONTENTS`. `vsp fmtest` reads
+the Function Builder's saved test data from EUFUNC: every set's inputs, what
+came back, the runtime, the interface as it was. `vsp docs` renders SE61
+documentation as Markdown, includes resolved — data elements, reports,
+function modules, classes, messages — and walks the IMG: `docs img` finds
+activities and folders by their titles and gives the path to each, `docs
+activity` gives the transaction and the activity's own text. MCP: `variants`,
+`fm_test_data`, `documentation`, `img_search`, `img_activity`.
+
+```bash
+vsp -s a4h variants ZDEMO_NIGHTLY_RUN                # the variants, who made them, when
+vsp -s a4h variants ZDEMO_NIGHTLY_RUN MONTH_END --json
+vsp -s a4h fmtest STRING_CONCATENATE
+vsp -s a4h docs read DE BALLEVEL
+vsp -s a4h docs activity /IWBEP/CP_DELETE_JOB
+```
+
 ### Cluster tables, decoded — BALDAT, INDX, STXL over plain ADT
 
 BALDAT is one of a family: INDX, STXL, and every table an `EXPORT ... TO
@@ -957,6 +979,10 @@ vsp -s a4h jobs log ZDEMO_NIGHTLY 22554500          # the job log, over XBP
 vsp -s a4h spool list --job ZDEMO_NIGHTLY           # what the job's steps printed
 vsp -s a4h spool read 27302                         # the list, decoded from TemSe
 vsp -s a4h spool export --since 2026-09-01 --out ./spool
+vsp -s a4h variants ZDEMO_NIGHTLY_RUN MONTH_END      # every field, its label, its value
+vsp -s a4h fmtest ZDEMO_CALCULATE_TAX                # SE37's saved test data
+vsp -s a4h docs read FU BAL_LOG_CREATE               # SE61 documentation as Markdown
+vsp -s a4h docs img "cleanup job"                    # where in the IMG, and which activity
 
 # Cluster tables — what only IMPORT could read, decoded here
 vsp -s a4h cluster read INDX --where "relid = 'ZV'" --schema

--- a/agenda/AGENDA.md
+++ b/agenda/AGENDA.md
@@ -37,6 +37,25 @@ Left on A4H: two INDX rows under `RELID = ZV` from the cluster fixture
 program, which itself was deleted after the fixtures were captured. Its
 source is `pkg/datacluster/testdata/zvsp_cluster_fixture.prog.abap`.
 
+## Done — 2026-09-05 — variants, test data, documentation, the IMG
+
+`vsp variants`, `vsp fmtest`, `vsp docs read|index|img|activity`; MCP
+`variants`, `fm_test_data`, `documentation`, `img_search`, `img_activity`.
+Facts that took finding: a variant is VARI under two RELIDs — VA the values
+(one object per field, a table for a select-option), VB the screen's shape
+(`%_VARI40C`); SE37 test data is EUFUNC with `%_I`/`%_V` objects and a 999
+directory record; an IMG activity's text is DOKIL `HY` with object
+`SIMG`+activity, its title is CUS_IMGACT (not TNODEIMGT, which has the
+folders), and TNODEIMGR ties a node to it as `COBJ`/`ACTI`. `pkg/itf`
+renders ITF — chapter markers, paragraph continuation, `<ex>/<zh>/<ds>`,
+INCLUDE commands — as Markdown; formats seen but rendered only as plain
+paragraphs: T1..T6, M1..M5, K1..K6, E1..E3, `>0`/`>1` tables.
+
+Open: select-option storage in VARI was never observed on A4H (no variant
+there has one) and is read by shape — a table object with four columns;
+verify on a system that has them. `?...` in a text pool means "no selection
+text", and `D…` means "DDIC label", read from DD04T.
+
 ## Done — 2026-09-05 — jobs and spool as tables
 
 `vsp jobs list|log`, `vsp spool list|read|export`, MCP `job_list`,

--- a/cmd/vsp/inspect.go
+++ b/cmd/vsp/inspect.go
@@ -1,0 +1,268 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/oisee/vibing-steampunk/pkg/adt"
+)
+
+// Variants, function test data, documentation: the parts of a system that
+// say what it is configured to do, read from their tables and rendered for
+// a person or a machine.
+
+var variantsCmd = &cobra.Command{
+	Use:   "variants <REPORT> [VARIANT]",
+	Short: "Report variants (SE38): list them, or show one with every field, its label and value",
+	Long: `Report variants over plain ADT: VARID and VARIT for the list, the VARI
+cluster for the values and the selection screen's shape, the program's
+selection texts for the labels. What a job's variant selects, without
+RS_VARIANT_CONTENTS.
+
+  vsp variants ZDEMO_NIGHTLY_RUN                 # the variants
+  vsp variants ZDEMO_NIGHTLY_RUN MONTH_END       # one, as a Markdown table
+  vsp variants ZDEMO_NIGHTLY_RUN MONTH_END --json`,
+	Args: cobra.RangeArgs(1, 2),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		params, err := resolveSystemParams(cmd)
+		if err != nil {
+			return err
+		}
+		client, err := getClient(params)
+		if err != nil {
+			return err
+		}
+		asJSON, _ := cmd.Flags().GetBool("json")
+		ctx := context.Background()
+		if len(args) == 1 {
+			list, err := client.Variants(ctx, args[0], params.Language)
+			if err != nil {
+				return err
+			}
+			if asJSON {
+				return printJSON(list)
+			}
+			if len(list) == 0 {
+				fmt.Fprintf(os.Stderr, "%s has no variants\n", strings.ToUpper(args[0]))
+				return nil
+			}
+			for _, v := range list {
+				line := fmt.Sprintf("%-14s %-40s %s %s", v.Name, v.Text, v.CreatedBy, v.Created.Format("2006-01-02"))
+				if v.Protected {
+					line += "  protected"
+				}
+				fmt.Println(line)
+			}
+			return nil
+		}
+		v, err := client.Variant(ctx, args[0], args[1], params.Language)
+		if err != nil {
+			return err
+		}
+		if asJSON {
+			return printJSON(v)
+		}
+		fmt.Print(adt.VariantMarkdown(v))
+		return nil
+	},
+}
+
+var fmtestCmd = &cobra.Command{
+	Use:   "fmtest <FUNCTION_MODULE>",
+	Short: "The Function Builder's saved test data (SE37): interface, every set's inputs, outputs, runtime",
+	Long: `Test data a developer saved in SE37, read from the EUFUNC cluster table:
+the directory of sets with their titles and dates, the interface as it was
+then, and each set's inputs (%_I), what came back (%_V), the runtime, the
+return code and the exception.
+
+  vsp fmtest ZDEMO_CALCULATE_TAX
+  vsp fmtest ZDEMO_CALCULATE_TAX --json`,
+	Args: cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		params, err := resolveSystemParams(cmd)
+		if err != nil {
+			return err
+		}
+		client, err := getClient(params)
+		if err != nil {
+			return err
+		}
+		data, err := client.FunctionTestData(context.Background(), args[0])
+		if err != nil {
+			return err
+		}
+		if asJSON, _ := cmd.Flags().GetBool("json"); asJSON {
+			return printJSON(data)
+		}
+		fmt.Print(adt.FunctionTestMarkdown(data))
+		return nil
+	},
+}
+
+var docsCmd = &cobra.Command{
+	Use:   "docs",
+	Short: "Documentation (SE61) and the IMG as Markdown: objects, activities, where a setting lives",
+	Long: `SAP's documentation is two tables, DOKIL and DOKTL, and the IMG hangs off
+them. This reads the ITF text and renders it as Markdown, includes resolved.
+
+  vsp docs read DE BALLEVEL                      # a data element's documentation
+  vsp docs read FU BAL_LOG_CREATE                # a function module's
+  vsp docs read RE RSPARAM --lang D              # a report's, in German
+  vsp docs index BAL_LOG_CREATE                  # every class and language that has one
+  vsp docs img "delta link"                      # IMG nodes whose text matches, with the path to each
+  vsp docs activity /IWBEP/CP_DELETE_JOB         # one activity: transaction, path, documentation
+
+Classes: DE data element, DT domain, TB table, RE report, FU function module,
+CL class, IF interface, NA message, TX general text, HY IMG activity.`,
+}
+
+var docsReadCmd = &cobra.Command{
+	Use:   "read <CLASS> <OBJECT>",
+	Short: "Render one documentation text as Markdown",
+	Args:  cobra.ExactArgs(2),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		client, lang, err := docsClient(cmd)
+		if err != nil {
+			return err
+		}
+		doc, err := client.Documentation(context.Background(), args[0], args[1], lang)
+		if err != nil {
+			return err
+		}
+		if asJSON, _ := cmd.Flags().GetBool("json"); asJSON {
+			return printJSON(doc)
+		}
+		fmt.Printf("# %s %s\n\n%s", doc.ID, doc.Object, doc.Markdown)
+		return nil
+	},
+}
+
+var docsIndexCmd = &cobra.Command{
+	Use:   "index <OBJECT>",
+	Short: "List the documentation texts that exist for an object name",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		client, _, err := docsClient(cmd)
+		if err != nil {
+			return err
+		}
+		list, err := client.DocumentationIndex(context.Background(), args[0])
+		if err != nil {
+			return err
+		}
+		if asJSON, _ := cmd.Flags().GetBool("json"); asJSON {
+			return printJSON(list)
+		}
+		for _, d := range list {
+			fmt.Printf("%-3s %-8s %-30s %s\n", d.ID, d.Language, d.Object, adt.DocumentationClasses[d.ID])
+		}
+		if len(list) == 0 {
+			fmt.Fprintln(os.Stderr, "no documentation")
+		}
+		return nil
+	},
+}
+
+var docsIMGCmd = &cobra.Command{
+	Use:   "img <TEXT>",
+	Short: "Find IMG nodes by their text, with the path to each and what it opens",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		client, lang, err := docsClient(cmd)
+		if err != nil {
+			return err
+		}
+		top, _ := cmd.Flags().GetInt("top")
+		nodes, err := client.IMGSearch(context.Background(), args[0], lang, top)
+		if err != nil {
+			return err
+		}
+		if asJSON, _ := cmd.Flags().GetBool("json"); asJSON {
+			return printJSON(nodes)
+		}
+		if len(nodes) == 0 {
+			fmt.Fprintln(os.Stderr, "no IMG node matches")
+			return nil
+		}
+		for _, n := range nodes {
+			fmt.Printf("%s\n", n.Text)
+			if n.Path != "" {
+				fmt.Printf("    %s\n", n.Path)
+			}
+			if n.RefObject != "" {
+				fmt.Printf("    %s %s", n.RefType, n.RefObject)
+				if n.Transaction != "" {
+					fmt.Printf("  (transaction %s)", n.Transaction)
+				}
+				fmt.Println()
+			}
+		}
+		return nil
+	},
+}
+
+var docsActivityCmd = &cobra.Command{
+	Use:   "activity <ACTIVITY>",
+	Short: "One IMG activity: transaction, the paths to it, its documentation",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		client, lang, err := docsClient(cmd)
+		if err != nil {
+			return err
+		}
+		a, err := client.IMGActivity(context.Background(), args[0], lang)
+		if err != nil {
+			return err
+		}
+		if asJSON, _ := cmd.Flags().GetBool("json"); asJSON {
+			return printJSON(a)
+		}
+		fmt.Printf("# IMG activity %s\n\n", a.Activity)
+		if a.Text != "" {
+			fmt.Printf("%s\n\n", a.Text)
+		}
+		if a.Transaction != "" {
+			fmt.Printf("Transaction: %s\n\n", a.Transaction)
+		}
+		for _, p := range a.Paths {
+			fmt.Printf("- %s\n", p)
+		}
+		if len(a.Paths) > 0 {
+			fmt.Println()
+		}
+		fmt.Print(a.Documentation)
+		return nil
+	},
+}
+
+func docsClient(cmd *cobra.Command) (*adt.Client, string, error) {
+	params, err := resolveSystemParams(cmd)
+	if err != nil {
+		return nil, "", err
+	}
+	client, err := getClient(params)
+	if err != nil {
+		return nil, "", err
+	}
+	lang, _ := cmd.Flags().GetString("lang")
+	if lang == "" {
+		lang = params.Language
+	}
+	return client, lang, nil
+}
+
+func init() {
+	variantsCmd.Flags().Bool("json", false, "Emit JSON")
+	fmtestCmd.Flags().Bool("json", false, "Emit JSON")
+	for _, c := range []*cobra.Command{docsReadCmd, docsIndexCmd, docsIMGCmd, docsActivityCmd} {
+		c.Flags().Bool("json", false, "Emit JSON")
+		c.Flags().String("lang", "", "Language (ISO code or SAP key); the system's logon language by default")
+	}
+	docsIMGCmd.Flags().Int("top", 40, "Maximum nodes")
+	docsCmd.AddCommand(docsReadCmd, docsIndexCmd, docsIMGCmd, docsActivityCmd)
+	rootCmd.AddCommand(variantsCmd, fmtestCmd, docsCmd)
+}

--- a/internal/mcp/handlers_docs.go
+++ b/internal/mcp/handlers_docs.go
@@ -1,0 +1,138 @@
+package mcp
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/mark3labs/mcp-go/mcp"
+
+	"github.com/oisee/vibing-steampunk/pkg/adt"
+)
+
+// Variants, function test data, documentation and the IMG: what a system is
+// set up to do, for an agent asked "what does this job's variant select",
+// "how was this module tested", "where is that setting".
+
+const noteNoLabels = "Fields carry no label: the program has no selection texts in this language, so the field names are what the screen shows too."
+
+func (s *Server) handleVariants(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	args := request.GetArguments()
+	report := firstString(args, "report", "program", "object_name")
+	if report == "" {
+		return newToolResultError("variants needs report: the program whose variants to read"), nil
+	}
+	lang := firstString(args, "language", "lang")
+	if lang == "" {
+		lang = s.adtClient.Language()
+	}
+	name := firstString(args, "variant", "name")
+	if name == "" {
+		list, err := s.adtClient.Variants(ctx, report, lang)
+		if err != nil {
+			return newToolResultError(fmt.Sprintf("Failed to list variants: %v", err)), nil
+		}
+		if list == nil {
+			list = []adt.Variant{}
+		}
+		return newToolResultJSON(map[string]any{"report": strings.ToUpper(report), "variants": list, "count": len(list)}), nil
+	}
+	v, err := s.adtClient.Variant(ctx, report, name, lang)
+	if err != nil {
+		return newToolResultError(fmt.Sprintf("Failed to read variant: %v", err)), nil
+	}
+	out := map[string]any{"variant": v, "markdown": adt.VariantMarkdown(v)}
+	labelled := false
+	for _, f := range v.Fields {
+		if f.Label != "" {
+			labelled = true
+		}
+	}
+	if !labelled && len(v.Fields) > 0 {
+		out["notes"] = []string{noteNoLabels}
+	}
+	return newToolResultJSON(out), nil
+}
+
+func (s *Server) handleFunctionTestData(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	args := request.GetArguments()
+	fm := firstString(args, "function", "function_module", "name", "object_name")
+	if fm == "" {
+		return newToolResultError("fm_test_data needs function: the function module"), nil
+	}
+	data, err := s.adtClient.FunctionTestData(ctx, fm)
+	if err != nil {
+		return newToolResultError(fmt.Sprintf("Failed to read test data: %v", err)), nil
+	}
+	return newToolResultJSON(map[string]any{"data": data, "markdown": adt.FunctionTestMarkdown(data)}), nil
+}
+
+func (s *Server) handleDocumentation(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	args := request.GetArguments()
+	id := firstString(args, "class", "id", "doc_class")
+	object := firstString(args, "object", "name", "object_name")
+	if object == "" {
+		return newToolResultError("documentation needs object (and class: DE, RE, FU, CL, TB, NA, TX, HY ...; without it the index of what exists is returned)"), nil
+	}
+	lang := firstString(args, "language", "lang")
+	if lang == "" {
+		lang = s.adtClient.Language()
+	}
+	if id == "" {
+		list, err := s.adtClient.DocumentationIndex(ctx, object)
+		if err != nil {
+			return newToolResultError(fmt.Sprintf("Failed to read the documentation index: %v", err)), nil
+		}
+		if list == nil {
+			list = []adt.Documentation{}
+		}
+		return newToolResultJSON(map[string]any{"object": strings.ToUpper(object), "texts": list, "classes": adt.DocumentationClasses}), nil
+	}
+	doc, err := s.adtClient.Documentation(ctx, id, object, lang)
+	if err != nil {
+		return newToolResultError(fmt.Sprintf("Failed to read documentation: %v", err)), nil
+	}
+	doc.Lines = nil
+	return newToolResultJSON(doc), nil
+}
+
+func (s *Server) handleIMGSearch(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	args := request.GetArguments()
+	text := firstString(args, "text", "query", "pattern")
+	if text == "" {
+		return newToolResultError("img_search needs text: a word or pattern (* wildcard) from the node's title"), nil
+	}
+	lang := firstString(args, "language", "lang")
+	if lang == "" {
+		lang = s.adtClient.Language()
+	}
+	limit := 0
+	if n, ok := firstNumber(args, "max_results", "top", "limit"); ok && n > 0 {
+		limit = int(n)
+	}
+	nodes, err := s.adtClient.IMGSearch(ctx, text, lang, limit)
+	if err != nil {
+		return newToolResultError(fmt.Sprintf("Failed to search the IMG: %v", err)), nil
+	}
+	if nodes == nil {
+		nodes = []adt.IMGNode{}
+	}
+	return newToolResultJSON(map[string]any{"nodes": nodes, "count": len(nodes)}), nil
+}
+
+func (s *Server) handleIMGActivity(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	args := request.GetArguments()
+	activity := firstString(args, "activity", "name", "object_name")
+	if activity == "" {
+		return newToolResultError("img_activity needs activity: the technical name from img_search"), nil
+	}
+	lang := firstString(args, "language", "lang")
+	if lang == "" {
+		lang = s.adtClient.Language()
+	}
+	a, err := s.adtClient.IMGActivity(ctx, activity, lang)
+	if err != nil {
+		return newToolResultError(fmt.Sprintf("Failed to read IMG activity: %v", err)), nil
+	}
+	return newToolResultJSON(a), nil
+}

--- a/internal/mcp/handlers_dumps.go
+++ b/internal/mcp/handlers_dumps.go
@@ -37,6 +37,11 @@ func (s *Server) dumpAnalysisTypes() map[string]func(context.Context, mcp.CallTo
 		"spool_read":      s.handleSpoolRead,
 		"job_list":        s.handleJobList,
 		"job_log":         s.handleJobLog,
+		"variants":        s.handleVariants,
+		"fm_test_data":    s.handleFunctionTestData,
+		"documentation":   s.handleDocumentation,
+		"img_search":      s.handleIMGSearch,
+		"img_activity":    s.handleIMGActivity,
 	}
 }
 

--- a/internal/mcp/handlers_help.go
+++ b/internal/mcp/handlers_help.go
@@ -380,6 +380,22 @@ Spool and background jobs (SP01/SM37 over free SQL; the job log and file-stored 
       each job with its steps: program, variant, user, the spool number each step wrote
   SAP(action="analyze", params={"type": "job_log", "job": "ZDEMO_NIGHTLY", "count": "22554500"})
 
+What the system is set up to do — variants, test data, documentation, the IMG (free SQL):
+  SAP(action="analyze", params={"type": "variants", "report": "ZDEMO_NIGHTLY_RUN"})
+  SAP(action="analyze", params={"type": "variants", "report": "ZDEMO_NIGHTLY_RUN", "variant": "MONTH_END"})
+      every field with its label, kind (P/S), type and value or ranges — what the job selects
+  SAP(action="analyze", params={"type": "fm_test_data", "function": "ZDEMO_CALCULATE_TAX"})
+      SE37's saved test sets: inputs, outputs, runtime, return code, and the interface as saved
+  SAP(action="analyze", params={"type": "documentation", "class": "DE", "object": "BALLEVEL"})
+  SAP(action="analyze", params={"type": "documentation", "object": "BAL_LOG_CREATE"})
+      SE61 text as Markdown, includes resolved; without class, the index of what exists.
+      classes: DE data element, DT domain, TB table, RE report, FU function module, CL class,
+      IF interface, NA message, TX general text, HY IMG activity
+  SAP(action="analyze", params={"type": "img_search", "text": "delta link"})
+      IMG nodes whose title matches, the path to each, and the activity or document it opens
+  SAP(action="analyze", params={"type": "img_activity", "activity": "/IWBEP/CP_DELETE_JOB"})
+      transaction, paths, and the activity's documentation
+
 Cluster tables (BALDAT, INDX, STXL, ... — EXPORT data clusters decoded here, no IMPORT needed):
   SAP(action="analyze", params={"type": "cluster_read", "table": "INDX", "where": "relid = 'ZV'"})
   SAP(action="analyze", params={"type": "cluster_read", "table": "INDX", "where": "relid = 'ZD'", "layout": "ZDEMO_S_HEADER"})

--- a/pkg/adt/docs.go
+++ b/pkg/adt/docs.go
@@ -1,0 +1,256 @@
+package adt
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strconv"
+	"strings"
+
+	"github.com/oisee/vibing-steampunk/pkg/itf"
+)
+
+// SAP's documentation — SE61 — is two tables. DOKIL is the index: an object
+// class (ID: DE for a data element, RE a report, FU a function module, CL a
+// class, TB a table, NA a message, HY an IMG activity, TX a free text, ...),
+// the object name, the language, the version. DOKTL is the text, one ITF
+// line per row. The IMG hangs off the same tables: an activity's text is HY
+// with the object "SIMG" + activity, and the tree that leads to it is
+// TNODEIMG (nodes), TNODEIMGT (their texts) and TNODEIMGR (what a node
+// points at: an activity, a document, a status).
+
+// Documentation is one SE61 text.
+type Documentation struct {
+	ID       string     `json:"id"`
+	Object   string     `json:"object"`
+	Language string     `json:"language"`
+	Version  int        `json:"version"`
+	Lines    []itf.Line `json:"lines,omitempty"`
+	Markdown string     `json:"markdown"`
+}
+
+// DocumentationClasses names the DOKIL IDs worth knowing.
+var DocumentationClasses = map[string]string{
+	"DE": "data element", "RE": "report", "FU": "function module", "CL": "class", "IF": "interface",
+	"TB": "table", "NA": "message", "HY": "IMG activity", "TX": "general text", "IM": "IMG chapter",
+	"DT": "domain", "TT": "transaction", "SD": "screen", "CA": "CA?", "UO": "IMG object", "IO": "IMG object",
+}
+
+// Documentation reads one text, latest version, in the language given (a
+// SAP key or ISO code), with INCLUDE commands resolved.
+func (c *Client) Documentation(ctx context.Context, id, object, lang string) (*Documentation, error) {
+	lang = spras(lang)
+	id, object = strings.ToUpper(strings.TrimSpace(id)), strings.ToUpper(strings.TrimSpace(object))
+	lines, version, err := c.docLines(ctx, id, object, lang)
+	if err != nil {
+		return nil, err
+	}
+	doc := &Documentation{ID: id, Object: object, Language: lang, Version: version, Lines: lines}
+	doc.Markdown = itf.ToMarkdown(lines, func(obj, incID string) ([]itf.Line, error) {
+		l, _, err := c.docLines(ctx, incID, obj, lang)
+		return l, err
+	})
+	return doc, nil
+}
+
+func (c *Client) docLines(ctx context.Context, id, object, lang string) ([]itf.Line, int, error) {
+	res, err := c.RunQuery(ctx, fmt.Sprintf("SELECT dokversion FROM doktl WHERE id = '%s' AND object = '%s' AND langu = '%s' ORDER BY dokversion DESCENDING", sqlQuote(id), sqlQuote(object), sqlQuote(lang)), 1)
+	if err != nil {
+		return nil, 0, fmt.Errorf("reading documentation %s %s: %w", id, object, err)
+	}
+	if res == nil || len(res.Rows) == 0 {
+		return nil, 0, fmt.Errorf("no %s documentation for %s in language %s", id, object, lang)
+	}
+	version, _ := strconv.Atoi(cell(res.Rows[0], "DOKVERSION"))
+	res, err = c.RunQuery(ctx, fmt.Sprintf("SELECT line, dokformat, doktext FROM doktl WHERE id = '%s' AND object = '%s' AND langu = '%s' AND dokversion = '%04d' ORDER BY line", sqlQuote(id), sqlQuote(object), sqlQuote(lang), version), 20000)
+	if err != nil {
+		return nil, 0, fmt.Errorf("reading documentation %s %s: %w", id, object, err)
+	}
+	var lines []itf.Line
+	for _, row := range res.Rows {
+		lines = append(lines, itf.Line{Format: cell(row, "DOKFORMAT"), Text: strings.TrimRight(cellRaw(row, "DOKTEXT"), " ")})
+	}
+	return lines, version, nil
+}
+
+// cellRaw is cell without the trim, for text whose leading blanks matter.
+func cellRaw(row map[string]interface{}, column string) string {
+	value, ok := row[column]
+	if !ok {
+		value = row[strings.ToLower(column)]
+	}
+	if value == nil {
+		return ""
+	}
+	return fmt.Sprint(value)
+}
+
+// DocumentationIndex lists the texts that exist for an object, in every
+// class and language.
+func (c *Client) DocumentationIndex(ctx context.Context, object string) ([]Documentation, error) {
+	res, err := c.RunQuery(ctx, fmt.Sprintf("SELECT id, object, langu, version, txtlines FROM dokil WHERE object = '%s' ORDER BY id, langu", sqlQuote(strings.ToUpper(object))), 200)
+	if err != nil {
+		return nil, fmt.Errorf("reading the documentation index: %w", err)
+	}
+	var out []Documentation
+	if res == nil {
+		return out, nil
+	}
+	for _, row := range res.Rows {
+		d := Documentation{ID: cell(row, "ID"), Object: cell(row, "OBJECT"), Language: cell(row, "LANGU")}
+		d.Version, _ = strconv.Atoi(cell(row, "VERSION"))
+		out = append(out, d)
+	}
+	return out, nil
+}
+
+// IMGActivity is one customizing activity: what it is, how it is reached,
+// and its documentation.
+type IMGActivity struct {
+	Activity      string   `json:"activity"`
+	Text          string   `json:"text,omitempty"`
+	Transaction   string   `json:"transaction,omitempty"`
+	DocObject     string   `json:"docObject,omitempty"`
+	Paths         []string `json:"paths,omitempty"`
+	Documentation string   `json:"documentation,omitempty"`
+}
+
+// IMGActivity reads an activity by its technical name (CUS_IMGACH).
+func (c *Client) IMGActivity(ctx context.Context, activity, lang string) (*IMGActivity, error) {
+	activity = strings.ToUpper(strings.TrimSpace(activity))
+	res, err := c.RunQuery(ctx, fmt.Sprintf("SELECT activity, tcode, docu_id FROM cus_imgach WHERE activity = '%s'", sqlQuote(activity)), 1)
+	if err != nil {
+		return nil, fmt.Errorf("reading IMG activity %s: %w", activity, err)
+	}
+	if res == nil || len(res.Rows) == 0 {
+		return nil, fmt.Errorf("IMG activity %s does not exist", activity)
+	}
+	a := &IMGActivity{Activity: activity, Transaction: cell(res.Rows[0], "TCODE"), DocObject: cell(res.Rows[0], "DOCU_ID")}
+	if t, terr := c.RunQuery(ctx, fmt.Sprintf("SELECT text FROM cus_imgact WHERE activity = '%s' AND spras = '%s'", sqlQuote(activity), sqlQuote(spras(lang))), 1); terr == nil && t != nil && len(t.Rows) > 0 {
+		a.Text = cell(t.Rows[0], "TEXT")
+	}
+	if a.Paths, err = c.imgPaths(ctx, activity, lang); err != nil {
+		return a, err
+	}
+	if a.DocObject != "" {
+		if doc, derr := c.Documentation(ctx, "HY", a.DocObject, lang); derr == nil {
+			a.Documentation = doc.Markdown
+		} else {
+			a.Documentation = "_" + derr.Error() + "_"
+		}
+	}
+	return a, nil
+}
+
+// IMGNode is one hit of an IMG search: a node's text, the path to it and
+// what it points at.
+type IMGNode struct {
+	NodeID    string `json:"nodeId"`
+	Text      string `json:"text"`
+	Path      string `json:"path,omitempty"`
+	RefType   string `json:"refType,omitempty"`
+	RefObject string `json:"refObject,omitempty"`
+	// Transaction is the activity's transaction when the node is one.
+	Transaction string `json:"transaction,omitempty"`
+}
+
+// IMGSearch finds customizing activities and IMG folders whose text matches
+// (a LIKE pattern, * as the wildcard) and says where each sits and what it
+// opens. Activities are named in CUS_IMGACT, folders in TNODEIMGT.
+func (c *Client) IMGSearch(ctx context.Context, pattern, lang string, limit int) ([]IMGNode, error) {
+	lang = spras(lang)
+	if limit <= 0 {
+		limit = 40
+	}
+	like := strings.ReplaceAll(strings.TrimSpace(pattern), "*", "%")
+	if !strings.Contains(like, "%") {
+		like = "%" + like + "%"
+	}
+	var nodes []IMGNode
+
+	acts, err := c.RunQuery(ctx, fmt.Sprintf("SELECT a~activity, a~text, h~tcode FROM cus_imgact AS a LEFT OUTER JOIN cus_imgach AS h ON h~activity = a~activity WHERE a~spras = '%s' AND a~text LIKE '%s' ORDER BY a~text", sqlQuote(lang), sqlQuote(like)), limit)
+	if err != nil {
+		return nil, fmt.Errorf("searching IMG activities: %w", err)
+	}
+	if acts != nil {
+		for _, row := range acts.Rows {
+			activity := cell(row, "ACTIVITY")
+			n := IMGNode{Text: cell(row, "TEXT"), RefType: "ACTI", RefObject: activity, Transaction: cell(row, "TCODE")}
+			if paths, perr := c.imgPaths(ctx, activity, lang); perr == nil && len(paths) > 0 {
+				n.Path = paths[0]
+				if len(paths) > 1 {
+					n.Path += fmt.Sprintf(" (+%d more)", len(paths)-1)
+				}
+			}
+			nodes = append(nodes, n)
+		}
+	}
+	if len(nodes) >= limit {
+		return nodes, nil
+	}
+
+	res, err := c.RunQuery(ctx, fmt.Sprintf("SELECT node_id, text FROM tnodeimgt WHERE spras = '%s' AND text LIKE '%s' ORDER BY text", sqlQuote(lang), sqlQuote(like)), limit-len(nodes))
+	if err != nil {
+		return nil, fmt.Errorf("searching IMG folders: %w", err)
+	}
+	if res == nil {
+		return nodes, nil
+	}
+	for _, row := range res.Rows {
+		n := IMGNode{NodeID: cell(row, "NODE_ID"), Text: cell(row, "TEXT")}
+		if refs, rerr := c.RunQuery(ctx, fmt.Sprintf("SELECT ref_type, ref_object FROM tnodeimgr WHERE node_id = '%s'", sqlQuote(n.NodeID)), 5); rerr == nil && refs != nil {
+			for _, r := range refs.Rows {
+				t := cell(r, "REF_TYPE")
+				if t == "COBJ" || t == "ACTI" || n.RefType == "" {
+					n.RefType, n.RefObject = t, cell(r, "REF_OBJECT")
+				}
+			}
+		}
+		if path, perr := c.imgPathOf(ctx, n.NodeID, lang); perr == nil {
+			n.Path = path
+		}
+		nodes = append(nodes, n)
+	}
+	return nodes, nil
+}
+
+// imgPaths finds every node pointing at an activity and renders the path to
+// each.
+func (c *Client) imgPaths(ctx context.Context, activity, lang string) ([]string, error) {
+	res, err := c.RunQuery(ctx, fmt.Sprintf("SELECT node_id FROM tnodeimgr WHERE ref_object = '%s' AND ( ref_type = 'COBJ' OR ref_type = 'ACTI' )", sqlQuote(activity)), 20)
+	if err != nil {
+		return nil, fmt.Errorf("reading IMG references: %w", err)
+	}
+	var paths []string
+	if res == nil {
+		return paths, nil
+	}
+	for _, row := range res.Rows {
+		if p, perr := c.imgPathOf(ctx, cell(row, "NODE_ID"), spras(lang)); perr == nil && p != "" {
+			paths = append(paths, p)
+		}
+	}
+	sort.Strings(paths)
+	return paths, nil
+}
+
+// imgPathOf walks TNODEIMG upwards and joins the node texts, root first.
+func (c *Client) imgPathOf(ctx context.Context, nodeID, lang string) (string, error) {
+	var texts []string
+	seen := map[string]bool{}
+	for depth := 0; nodeID != "" && depth < 12 && !seen[nodeID]; depth++ {
+		seen[nodeID] = true
+		res, err := c.RunQuery(ctx, fmt.Sprintf("SELECT n~parent_id, t~text FROM tnodeimg AS n LEFT OUTER JOIN tnodeimgt AS t ON t~node_id = n~node_id AND t~spras = '%s' WHERE n~node_id = '%s'", sqlQuote(lang), sqlQuote(nodeID)), 1)
+		if err != nil {
+			return "", err
+		}
+		if res == nil || len(res.Rows) == 0 {
+			break
+		}
+		if t := cell(res.Rows[0], "TEXT"); t != "" {
+			texts = append([]string{t}, texts...)
+		}
+		nodeID = cell(res.Rows[0], "PARENT_ID")
+	}
+	return strings.Join(texts, " > "), nil
+}

--- a/pkg/adt/fmtest.go
+++ b/pkg/adt/fmtest.go
@@ -1,0 +1,219 @@
+package adt
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/oisee/vibing-steampunk/pkg/datacluster"
+)
+
+// The Function Builder's test data live in EUFUNC, a cluster table keyed by
+// function group, module and test data number. Number 999 is the directory:
+// TE_DATADIR lists the saved sets, FDESC_COPY is the interface at the time.
+// Each set is one cluster with one object per parameter, named %_I<param>
+// for an import, %_V<param> for a value that came back, plus TIME1 (the
+// runtime in microseconds), V_RC (the return code) and VEXCEPTION.
+
+// FunctionTestSet is one saved test run.
+type FunctionTestSet struct {
+	Number string `json:"number"`
+	Title  string `json:"title,omitempty"`
+	Date   string `json:"date,omitempty"`
+	Time   string `json:"time,omitempty"`
+	// Inputs are the %_I objects, Outputs the %_V ones, by parameter name.
+	Inputs  map[string]any `json:"inputs,omitempty"`
+	Outputs map[string]any `json:"outputs,omitempty"`
+	// Others are the remaining objects — TIME1, V_RC, VEXCEPTION and
+	// anything a newer release added — by object name.
+	Others    map[string]any `json:"others,omitempty"`
+	Runtime   string         `json:"runtime,omitempty"`
+	RC        string         `json:"rc,omitempty"`
+	Exception string         `json:"exception,omitempty"`
+}
+
+// FunctionTestData is everything EUFUNC holds for one module.
+type FunctionTestData struct {
+	Function  string              `json:"function"`
+	Group     string              `json:"group,omitempty"`
+	Interface []FunctionTestParam `json:"interface,omitempty"`
+	Sets      []FunctionTestSet   `json:"sets"`
+	Notes     []string            `json:"notes,omitempty"`
+}
+
+// FunctionTestParam is one row of FDESC_COPY: the interface as saved.
+type FunctionTestParam struct {
+	Name   string `json:"name"`
+	DDIC   string `json:"ddic,omitempty"`
+	Type   string `json:"type,omitempty"`
+	Length string `json:"length,omitempty"`
+	Kind   string `json:"kind,omitempty"`
+}
+
+// FunctionTestData reads the saved test data of a function module.
+func (c *Client) FunctionTestData(ctx context.Context, function string) (*FunctionTestData, error) {
+	function = strings.ToUpper(strings.TrimSpace(function))
+	recs, err := c.ReadClusterRecords(ctx, "EUFUNC", fmt.Sprintf("relid = 'FL' AND name = '%s'", sqlQuote(function)), 5000)
+	if err != nil {
+		return nil, err
+	}
+	out := &FunctionTestData{Function: function, Sets: []FunctionTestSet{}}
+	if len(recs.Records) == 0 {
+		return out, fmt.Errorf("no test data saved for %s", function)
+	}
+	titles := map[string]FunctionTestSet{}
+	var sets []FunctionTestSet
+	for _, rec := range recs.Records {
+		number := ""
+		for _, kv := range rec.Key {
+			switch kv.Column {
+			case "NUMMER":
+				number = strings.TrimSpace(kv.Value)
+			case "GRUPPE":
+				out.Group = strings.TrimSpace(kv.Value)
+			}
+		}
+		cl, err := datacluster.Parse(rec.Blob)
+		if err != nil {
+			out.Notes = append(out.Notes, fmt.Sprintf("set %s: %v", number, err))
+			continue
+		}
+		if number == "999" {
+			if dir := cl.Object("TE_DATADIR"); dir != nil {
+				for _, row := range dir.Rows {
+					if len(row) >= 6 {
+						titles[strings.TrimSpace(str(row[0]))] = FunctionTestSet{Date: str(row[3]), Time: str(row[4]), Title: str(row[5])}
+					}
+				}
+			}
+			if iface := cl.Object("FDESC_COPY"); iface != nil {
+				for _, row := range iface.Rows {
+					if len(row) >= 3 {
+						p := FunctionTestParam{Name: str(row[0]), DDIC: str(row[1]), Type: str(row[2])}
+						if len(row) >= 4 {
+							p.Length = strings.TrimSpace(str(row[3]))
+						}
+						if len(row) >= 7 {
+							p.Kind = str(row[6])
+						}
+						if p.Name != "" && p.Name != "*" {
+							out.Interface = append(out.Interface, p)
+						}
+					}
+				}
+			}
+			continue
+		}
+		set := FunctionTestSet{Number: number, Inputs: map[string]any{}, Outputs: map[string]any{}, Others: map[string]any{}}
+		for _, obj := range cl.Objects {
+			var value any
+			switch {
+			case len(obj.Rows) == 0:
+				value = nil
+			case obj.Kind == datacluster.Table:
+				value = obj.Rows
+			case len(obj.Rows[0]) == 1:
+				value = obj.Rows[0][0]
+			default:
+				value = obj.Rows[0]
+			}
+			switch {
+			case strings.HasPrefix(obj.Name, "%_I"):
+				set.Inputs[obj.Name[3:]] = value
+			case strings.HasPrefix(obj.Name, "%_V"):
+				set.Outputs[obj.Name[3:]] = value
+			case obj.Name == "TIME1":
+				set.Runtime = fmt.Sprint(value) + " µs"
+			case obj.Name == "V_RC":
+				set.RC = fmt.Sprint(value)
+			case obj.Name == "VEXCEPTION":
+				set.Exception = strings.TrimSpace(fmt.Sprint(value))
+			default:
+				set.Others[obj.Name] = value
+			}
+		}
+		sets = append(sets, set)
+	}
+	for i := range sets {
+		if t, ok := titles[strings.TrimLeft(sets[i].Number, "0")]; ok || len(titles) > 0 {
+			if !ok {
+				t, ok = titles[sets[i].Number]
+			}
+			if ok {
+				sets[i].Title, sets[i].Date, sets[i].Time = t.Title, t.Date, t.Time
+			}
+		}
+	}
+	out.Sets = sets
+	return out, nil
+}
+
+// FunctionTestMarkdown renders the test data for a person.
+func FunctionTestMarkdown(d *FunctionTestData) string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "# Test data of %s", d.Function)
+	if d.Group != "" {
+		fmt.Fprintf(&b, " (%s)", d.Group)
+	}
+	b.WriteString("\n\n")
+	if len(d.Interface) > 0 {
+		b.WriteString("## Interface as saved\n\n| Parameter | Type | Length | DDIC |\n|---|---|---|---|\n")
+		for _, p := range d.Interface {
+			fmt.Fprintf(&b, "| %s | %s | %s | %s |\n", p.Name, p.Type, p.Length, p.DDIC)
+		}
+		b.WriteString("\n")
+	}
+	for _, s := range d.Sets {
+		fmt.Fprintf(&b, "## Set %s", s.Number)
+		if s.Title != "" {
+			fmt.Fprintf(&b, " — %s", s.Title)
+		}
+		if s.Date != "" {
+			fmt.Fprintf(&b, " (%s %s)", s.Date, s.Time)
+		}
+		b.WriteString("\n\n")
+		writeKV := func(title string, m map[string]any) {
+			if len(m) == 0 {
+				return
+			}
+			fmt.Fprintf(&b, "**%s**\n\n| Parameter | Value |\n|---|---|\n", title)
+			for _, k := range sortedKeys(m) {
+				fmt.Fprintf(&b, "| %s | %s |\n", k, strings.ReplaceAll(fmt.Sprint(m[k]), "|", "\\|"))
+			}
+			b.WriteString("\n")
+		}
+		writeKV("Inputs", s.Inputs)
+		writeKV("Outputs", s.Outputs)
+		writeKV("Other", s.Others)
+		var facts []string
+		if s.Runtime != "" {
+			facts = append(facts, "runtime "+s.Runtime)
+		}
+		if s.RC != "" {
+			facts = append(facts, "rc "+s.RC)
+		}
+		if s.Exception != "" {
+			facts = append(facts, "exception "+s.Exception)
+		}
+		if len(facts) > 0 {
+			b.WriteString(strings.Join(facts, ", ") + "\n\n")
+		}
+	}
+	for _, n := range d.Notes {
+		b.WriteString("_" + n + "_\n")
+	}
+	return b.String()
+}
+
+func sortedKeys(m map[string]any) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	for i := 1; i < len(keys); i++ {
+		for j := i; j > 0 && keys[j] < keys[j-1]; j-- {
+			keys[j], keys[j-1] = keys[j-1], keys[j]
+		}
+	}
+	return keys
+}

--- a/pkg/adt/inspect_test.go
+++ b/pkg/adt/inspect_test.go
@@ -1,0 +1,37 @@
+package adt
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestVariantMarkdown(t *testing.T) {
+	v := &Variant{Report: "ZDEMO_RUN", Name: "MONTH_END", Text: "Month end", CreatedBy: "TESTUSER", Created: time.Date(2026, 9, 1, 0, 0, 0, 0, time.UTC),
+		Fields: []VariantField{
+			{Name: "P_BUKRS", Label: "Company Code", Kind: "P", Type: "C", DDIC: "T001-BUKRS", Value: "1000"},
+			{Name: "S_DATE", Label: "Posting Date", Kind: "S", Type: "D", Ranges: []Range{{Sign: "I", Option: "BT", Low: "20260901", High: "20260930"}, {Sign: "E", Option: "EQ", Low: "20260915"}}},
+			{Name: "P_TEST", Kind: "P", Type: "C", Value: "X"},
+		}}
+	md := VariantMarkdown(v)
+	for _, want := range []string{"# ZDEMO_RUN / MONTH_END", "Month end", "Created by TESTUSER on 2026-09-01.",
+		"| P_BUKRS | Company Code | P | C T001-BUKRS | 1000 |", "| S_DATE | Posting Date | S | D | I BT 20260901 … 20260930<br>E EQ 20260915 |", "| P_TEST |  | P | C | X |"} {
+		if !strings.Contains(md, want) {
+			t.Errorf("missing %q in:\n%s", want, md)
+		}
+	}
+}
+
+func TestFunctionTestMarkdown(t *testing.T) {
+	d := &FunctionTestData{Function: "ZDEMO_CALC", Group: "ZDEMO",
+		Interface: []FunctionTestParam{{Name: "IV_AMOUNT", Type: "P", Length: "8"}, {Name: "EV_TAX", Type: "P", Length: "8"}},
+		Sets: []FunctionTestSet{{Number: "001", Title: "ten percent", Date: "20260901", Time: "120000",
+			Inputs: map[string]any{"IV_AMOUNT": "100.00", "IV_RATE": "10"}, Outputs: map[string]any{"EV_TAX": "10.00"}, Runtime: "42 µs", RC: "0"}}}
+	md := FunctionTestMarkdown(d)
+	for _, want := range []string{"# Test data of ZDEMO_CALC (ZDEMO)", "| IV_AMOUNT | P | 8 |  |", "## Set 001 — ten percent (20260901 120000)",
+		"| IV_AMOUNT | 100.00 |\n| IV_RATE | 10 |", "| EV_TAX | 10.00 |", "runtime 42 µs, rc 0"} {
+		if !strings.Contains(md, want) {
+			t.Errorf("missing %q in:\n%s", want, md)
+		}
+	}
+}

--- a/pkg/adt/variants.go
+++ b/pkg/adt/variants.go
@@ -1,0 +1,278 @@
+package adt
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/oisee/vibing-steampunk/pkg/datacluster"
+)
+
+// A report variant is three things: VARID says it exists and who made it,
+// VARIT says what it is called, and VARI — a cluster table — holds the
+// values under RELID VA, one object per parameter named after it, and the
+// selection screen's shape under RELID VB: %_VARI40C, a row per field with
+// its kind (P parameter, S select-option), type, length and DDIC reference.
+// The labels a person sees are the program's selection texts, the S entries
+// of its text pool.
+
+// Variant is one report variant.
+type Variant struct {
+	Report    string    `json:"report"`
+	Name      string    `json:"name"`
+	Text      string    `json:"text,omitempty"`
+	CreatedBy string    `json:"createdBy,omitempty"`
+	Created   time.Time `json:"created,omitempty"`
+	ChangedBy string    `json:"changedBy,omitempty"`
+	Changed   time.Time `json:"changed,omitempty"`
+	Protected bool      `json:"protected,omitempty"`
+	// Fields are the selection screen fields with their values, in screen
+	// order when the screen description is stored, else by name.
+	Fields []VariantField `json:"fields,omitempty"`
+}
+
+// VariantField is one parameter or select-option with its value.
+type VariantField struct {
+	Name string `json:"name"`
+	// Label is the selection text, when the program has one.
+	Label string `json:"label,omitempty"`
+	// Kind is P for a parameter, S for a select-option.
+	Kind     string  `json:"kind"`
+	Type     string  `json:"type,omitempty"`
+	Length   int     `json:"length,omitempty"`
+	DDIC     string  `json:"ddic,omitempty"`
+	Protect  string  `json:"protect,omitempty"`
+	Value    any     `json:"value,omitempty"`
+	Ranges   []Range `json:"ranges,omitempty"`
+	Screen   int     `json:"screen,omitempty"`
+	Position int     `json:"position,omitempty"`
+}
+
+// Range is one row of a select-option.
+type Range struct {
+	Sign   string `json:"sign"`
+	Option string `json:"option"`
+	Low    string `json:"low"`
+	High   string `json:"high,omitempty"`
+}
+
+// Variants lists the variants of a report.
+func (c *Client) Variants(ctx context.Context, report, lang string) ([]Variant, error) {
+	report = strings.ToUpper(strings.TrimSpace(report))
+	res, err := c.RunQuery(ctx, fmt.Sprintf("SELECT report, variant, ename, edat, etime, aename, aedat, aetime, protected FROM varid WHERE report = '%s' ORDER BY variant", sqlQuote(report)), 500)
+	if err != nil {
+		return nil, fmt.Errorf("reading the variants of %s: %w", report, err)
+	}
+	var out []Variant
+	if res == nil {
+		return out, nil
+	}
+	for _, row := range res.Rows {
+		v := Variant{Report: report, Name: cell(row, "VARIANT"), CreatedBy: cell(row, "ENAME"), ChangedBy: cell(row, "AENAME"), Protected: cell(row, "PROTECTED") == "X"}
+		v.Created = parseSAPStamp(cell(row, "EDAT"), cell(row, "ETIME"))
+		v.Changed = parseSAPStamp(cell(row, "AEDAT"), cell(row, "AETIME"))
+		out = append(out, v)
+	}
+	texts, err := c.RunQuery(ctx, fmt.Sprintf("SELECT variant, vtext FROM varit WHERE report = '%s' AND langu = '%s'", sqlQuote(report), sqlQuote(spras(lang))), 500)
+	if err == nil && texts != nil {
+		byName := map[string]string{}
+		for _, row := range texts.Rows {
+			byName[cell(row, "VARIANT")] = cell(row, "VTEXT")
+		}
+		for i := range out {
+			out[i].Text = byName[out[i].Name]
+		}
+	}
+	return out, nil
+}
+
+// Variant reads one variant with its values and the screen's labels.
+func (c *Client) Variant(ctx context.Context, report, name, lang string) (*Variant, error) {
+	report, name = strings.ToUpper(strings.TrimSpace(report)), strings.ToUpper(strings.TrimSpace(name))
+	all, err := c.Variants(ctx, report, lang)
+	if err != nil {
+		return nil, err
+	}
+	var v *Variant
+	for i := range all {
+		if all[i].Name == name {
+			v = &all[i]
+		}
+	}
+	if v == nil {
+		return nil, fmt.Errorf("report %s has no variant %s", report, name)
+	}
+	recs, err := c.ReadClusterRecords(ctx, "VARI", fmt.Sprintf("report = '%s' AND variant = '%s'", sqlQuote(report), sqlQuote(name)), 2000)
+	if err != nil {
+		return nil, err
+	}
+	fields := map[string]*VariantField{}
+	var order []string
+	for _, rec := range recs.Records {
+		relid := ""
+		for _, kv := range rec.Key {
+			if kv.Column == "RELID" {
+				relid = kv.Value
+			}
+		}
+		cl, err := datacluster.Parse(rec.Blob)
+		if err != nil {
+			return nil, fmt.Errorf("variant %s %s (%s): %w", report, name, relid, err)
+		}
+		switch relid {
+		case "VA":
+			for _, obj := range cl.Objects {
+				f := fields[obj.Name]
+				if f == nil {
+					f = &VariantField{Name: obj.Name, Kind: "P"}
+					fields[obj.Name] = f
+					order = append(order, obj.Name)
+				}
+				if obj.Kind == datacluster.Table {
+					f.Kind = "S"
+					for _, row := range obj.Rows {
+						if len(row) >= 3 {
+							r := Range{Sign: str(row[0]), Option: str(row[1]), Low: str(row[2])}
+							if len(row) >= 4 {
+								r.High = str(row[3])
+							}
+							f.Ranges = append(f.Ranges, r)
+						}
+					}
+				} else if len(obj.Rows) > 0 && len(obj.Rows[0]) > 0 {
+					if len(obj.Rows[0]) == 1 {
+						f.Value = obj.Rows[0][0]
+					} else {
+						f.Value = obj.Rows[0]
+					}
+				}
+			}
+		case "VB":
+			if meta := cl.Object("%_VARI40C"); meta != nil {
+				for i, row := range meta.Rows {
+					if len(row) < 12 {
+						continue
+					}
+					n := str(row[0])
+					f := fields[n]
+					if f == nil {
+						f = &VariantField{Name: n}
+						fields[n] = f
+						order = append(order, n)
+					}
+					f.Kind = str(row[2])
+					if v, ok := row[3].(int64); ok {
+						f.Length = int(v)
+					}
+					f.Type = str(row[4])
+					f.DDIC = str(row[5])
+					f.Protect = str(row[11])
+					f.Position = i + 1
+					if v, ok := row[1].(int64); ok {
+						f.Screen = int(v / 1000000)
+					}
+				}
+			}
+		}
+	}
+	// Selection texts: "?..." is what SAP stores for "none maintained", and
+	// a text beginning with D and a dot says "use the DDIC field label".
+	labels := map[string]string{}
+	if pool, perr := c.GetTextPoolInLanguage(ctx, report, lang); perr == nil {
+		for _, e := range pool {
+			if e.ID == "S" {
+				labels[strings.ToUpper(strings.TrimSpace(e.Key))] = strings.TrimSpace(e.Text)
+			}
+		}
+	}
+	for _, n := range order {
+		f := fields[n]
+		label := labels[n]
+		switch {
+		case label == "?...":
+			label = ""
+		case strings.HasPrefix(label, "D") && strings.Contains(label, "."):
+			label = strings.TrimSpace(label[strings.Index(label, ".")+1:])
+		}
+		if label == "" && f.DDIC != "" {
+			label = c.ddicLabel(ctx, f.DDIC, lang)
+		}
+		f.Label = label
+		v.Fields = append(v.Fields, *f)
+	}
+	sort.SliceStable(v.Fields, func(i, j int) bool {
+		if v.Fields[i].Position != v.Fields[j].Position && v.Fields[i].Position > 0 && v.Fields[j].Position > 0 {
+			return v.Fields[i].Position < v.Fields[j].Position
+		}
+		return v.Fields[i].Name < v.Fields[j].Name
+	})
+	return v, nil
+}
+
+// VariantMarkdown renders a variant for a person: one table of fields.
+func VariantMarkdown(v *Variant) string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "# %s / %s\n\n", v.Report, v.Name)
+	if v.Text != "" {
+		fmt.Fprintf(&b, "%s\n\n", v.Text)
+	}
+	if v.CreatedBy != "" {
+		fmt.Fprintf(&b, "Created by %s on %s", v.CreatedBy, v.Created.Format("2006-01-02"))
+		if v.ChangedBy != "" && !v.Changed.IsZero() {
+			fmt.Fprintf(&b, ", changed by %s on %s", v.ChangedBy, v.Changed.Format("2006-01-02"))
+		}
+		b.WriteString(".\n\n")
+	}
+	b.WriteString("| Field | Label | Kind | Type | Value |\n|---|---|---|---|---|\n")
+	for _, f := range v.Fields {
+		value := ""
+		switch {
+		case f.Kind == "S":
+			var parts []string
+			for _, r := range f.Ranges {
+				p := r.Sign + " " + r.Option + " " + r.Low
+				if r.High != "" {
+					p += " … " + r.High
+				}
+				parts = append(parts, strings.TrimSpace(p))
+			}
+			value = strings.Join(parts, "<br>")
+		case f.Value != nil:
+			value = fmt.Sprint(f.Value)
+		}
+		typ := f.Type
+		if f.DDIC != "" {
+			typ += " " + f.DDIC
+		}
+		fmt.Fprintf(&b, "| %s | %s | %s | %s | %s |\n", f.Name, f.Label, f.Kind, strings.TrimSpace(typ), strings.ReplaceAll(value, "|", "\\|"))
+	}
+	return b.String()
+}
+
+// ddicLabel finds the medium field label of a DDIC reference: a data element
+// by name, or TABLE-FIELD through DD03L. Empty when there is none.
+func (c *Client) ddicLabel(ctx context.Context, ref, lang string) string {
+	element := strings.ToUpper(strings.TrimSpace(ref))
+	if table, field, ok := strings.Cut(element, "-"); ok {
+		res, err := c.RunQuery(ctx, fmt.Sprintf("SELECT rollname FROM dd03l WHERE tabname = '%s' AND fieldname = '%s' AND as4local = 'A'", sqlQuote(table), sqlQuote(field)), 1)
+		if err != nil || res == nil || len(res.Rows) == 0 {
+			return ""
+		}
+		element = cell(res.Rows[0], "ROLLNAME")
+	}
+	if element == "" {
+		return ""
+	}
+	res, err := c.RunQuery(ctx, fmt.Sprintf("SELECT scrtext_m, scrtext_l, ddtext FROM dd04t WHERE rollname = '%s' AND ddlanguage = '%s' AND as4local = 'A'", sqlQuote(element), sqlQuote(spras(lang))), 1)
+	if err != nil || res == nil || len(res.Rows) == 0 {
+		return ""
+	}
+	for _, col := range []string{"SCRTEXT_M", "SCRTEXT_L", "DDTEXT"} {
+		if t := cell(res.Rows[0], col); t != "" {
+			return t
+		}
+	}
+	return ""
+}

--- a/pkg/itf/itf.go
+++ b/pkg/itf/itf.go
@@ -1,0 +1,258 @@
+// Package itf renders SAPscript ITF — the format of every documentation
+// text in DOKTL: data element docs, report and function docs, IMG activity
+// docs, the general texts they include — as Markdown.
+//
+// ITF is a line per record with a two-character paragraph format in front:
+// AS for a standard paragraph, U1..U4 for headings, B1/B2 for bullets, N1
+// for numbered items, "/" for a line break, "=" for a continuation, "/:"
+// for a command such as INCLUDE, "/*" for a comment, and an empty format
+// for "the paragraph above continues". Inside a line, <ex>, <zh>, <zk> and
+// <ds:...> are character formats, and &NAME& on a line of its own is a
+// chapter marker the viewer turns into a heading.
+package itf
+
+import (
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+// Line is one DOKTL record.
+type Line struct {
+	Format string `json:"format"`
+	Text   string `json:"text"`
+}
+
+// Includer resolves an INCLUDE command to the lines of the included text;
+// nil disables includes, which then appear as a note.
+type Includer func(object, id string) ([]Line, error)
+
+// ToMarkdown renders the lines. include may be nil.
+func ToMarkdown(lines []Line, include Includer) string {
+	r := &renderer{include: include, seen: map[string]bool{}}
+	r.render(lines, 0)
+	r.flush()
+	return strings.TrimRight(r.out.String(), "\n") + "\n"
+}
+
+type renderer struct {
+	out     strings.Builder
+	para    []string // words of the paragraph being built
+	prefix  string   // list marker or heading prefix for the open paragraph
+	include Includer
+	seen    map[string]bool
+	number  int
+}
+
+func (r *renderer) flush() {
+	if len(r.para) == 0 {
+		r.prefix = ""
+		return
+	}
+	var sb strings.Builder
+	for i, w := range r.para {
+		if i > 0 && !strings.HasSuffix(r.para[i-1], "\n") {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(w)
+	}
+	text := inline(sb.String())
+	if r.prefix != "" {
+		r.out.WriteString(r.prefix + text + "\n")
+		if strings.HasPrefix(r.prefix, "#") {
+			r.out.WriteString("\n")
+		}
+	} else {
+		r.out.WriteString(text + "\n\n")
+	}
+	r.para, r.prefix = nil, ""
+}
+
+func (r *renderer) open(prefix string, text string) {
+	r.flush()
+	r.prefix = prefix
+	if t := strings.TrimSpace(text); t != "" {
+		r.para = append(r.para, t)
+	}
+}
+
+func (r *renderer) render(lines []Line, depth int) {
+	for _, l := range lines {
+		format := strings.TrimSpace(l.Format)
+		text := l.Text
+		if m := chapter(text); m != "" && (format == "" || strings.HasPrefix(format, "U") || format == "AS" || format == "*") {
+			r.flush()
+			r.out.WriteString("## " + m + "\n\n")
+			continue
+		}
+		switch {
+		case format == "":
+			// Continuation of the paragraph above.
+			if t := strings.TrimSpace(text); t != "" {
+				if r.prefix == "" && len(r.para) == 0 {
+					r.prefix = ""
+				}
+				r.para = append(r.para, t)
+			}
+		case format == "=":
+			// Continuation with no blank between.
+			if len(r.para) > 0 {
+				r.para[len(r.para)-1] += strings.TrimSpace(text)
+			} else {
+				r.para = append(r.para, strings.TrimSpace(text))
+			}
+		case format == "/":
+			// Line break inside the paragraph.
+			if len(r.para) > 0 {
+				r.para[len(r.para)-1] += "  \n"
+			}
+			if t := strings.TrimSpace(text); t != "" {
+				r.para = append(r.para, t)
+			}
+		case format == "/:":
+			r.command(l.Text, depth)
+		case format == "/*", format == "/(", format == "/=", format == "PE":
+			// Comments, protection and page controls carry nothing to read.
+		case format == "LZ":
+			r.flush()
+		case strings.HasPrefix(format, "U") && len(format) == 2:
+			level := 3
+			if n, err := strconv.Atoi(format[1:]); err == nil && n >= 1 && n <= 4 {
+				level = n + 1
+			}
+			r.open(strings.Repeat("#", level)+" ", text)
+		case format == "HT", format == "HU", format == "TX":
+			r.open("### ", text)
+		case format == "B1", format == "BL", format == "B0", format == "L1", format == "LL":
+			r.open("- ", text)
+		case format == "B2", format == "B3":
+			r.open("  - ", text)
+		case format == "N1", format == "N2":
+			r.number++
+			r.open(strconv.Itoa(r.number)+". ", text)
+		case strings.HasPrefix(format, "K") && len(format) == 2:
+			r.open("", "<zh>"+strings.TrimSpace(text)+"</>")
+		case strings.HasPrefix(format, "M") && len(format) == 2, strings.HasPrefix(format, "T") && len(format) == 2, strings.HasPrefix(format, "E") && len(format) == 2:
+			r.open("    ", text)
+		case strings.HasPrefix(format, ">"):
+			r.open("| ", strings.ReplaceAll(text, "  ", " | "))
+		default:
+			// AS, *, AL and everything not named: a paragraph.
+			r.number = 0
+			r.open("", text)
+		}
+	}
+}
+
+var includeCmd = regexp.MustCompile(`(?i)^\s*INCLUDE\s+(\S+)\s+OBJECT\s+(\S+)\s+ID\s+(\S+)`)
+
+func (r *renderer) command(text string, depth int) {
+	m := includeCmd.FindStringSubmatch(text)
+	if m == nil {
+		return
+	}
+	object, id := strings.ToUpper(m[1]), strings.ToUpper(strings.TrimRight(m[3], "."))
+	key := id + " " + object
+	r.flush()
+	if r.include == nil || depth > 4 || r.seen[key] {
+		r.out.WriteString("_[included text " + key + "]_\n\n")
+		return
+	}
+	r.seen[key] = true
+	lines, err := r.include(object, id)
+	if err != nil {
+		r.out.WriteString("_[included text " + key + " not read: " + err.Error() + "]_\n\n")
+		return
+	}
+	r.render(lines, depth+1)
+	r.flush()
+}
+
+var chapterMarker = regexp.MustCompile(`^&([A-Z_0-9 ]+)&$`)
+
+// chapter turns a marker line like &DEFINITION& into its heading text.
+func chapter(text string) string {
+	m := chapterMarker.FindStringSubmatch(strings.TrimSpace(text))
+	if m == nil {
+		return ""
+	}
+	words := strings.Fields(strings.ReplaceAll(m[1], "_", " "))
+	for i, w := range words {
+		words[i] = strings.ToUpper(w[:1]) + strings.ToLower(w[1:])
+	}
+	return strings.Join(words, " ")
+}
+
+var (
+	tagOpen  = regexp.MustCompile(`<([A-Za-z]{2})(?::([^>]*))?>`)
+	tagClose = "</>"
+)
+
+// inline turns the character formats into Markdown: <ex> code, <zh> bold,
+// <zk> italic, <ds:ID.OBJECT> links kept as their text with the target after
+// it, <(> and <)> the literal brackets.
+func inline(s string) string {
+	s = strings.ReplaceAll(s, "<(>", "\x00lt\x00")
+	s = strings.ReplaceAll(s, "<)>", "\x00gt\x00")
+	var out strings.Builder
+	var stack []string
+	for len(s) > 0 {
+		if strings.HasPrefix(s, tagClose) {
+			if n := len(stack); n > 0 {
+				out.WriteString(closeFor(stack[n-1]))
+				stack = stack[:n-1]
+			}
+			s = s[len(tagClose):]
+			continue
+		}
+		if m := tagOpen.FindStringSubmatchIndex(s); m != nil && m[0] == 0 {
+			tag := strings.ToUpper(s[m[2]:m[3]])
+			target := ""
+			if m[4] >= 0 {
+				target = s[m[4]:m[5]]
+			}
+			stack = append(stack, tag+"\x00"+target)
+			out.WriteString(openFor(tag))
+			s = s[m[1]:]
+			continue
+		}
+		out.WriteByte(s[0])
+		s = s[1:]
+	}
+	for i := len(stack) - 1; i >= 0; i-- {
+		out.WriteString(closeFor(stack[i]))
+	}
+	res := out.String()
+	res = strings.ReplaceAll(res, "\x00lt\x00", "<")
+	res = strings.ReplaceAll(res, "\x00gt\x00", ">")
+	return res
+}
+
+func openFor(tag string) string {
+	switch tag {
+	case "EX", "LS":
+		return "`"
+	case "ZH", "KY":
+		return "**"
+	case "ZK", "EM":
+		return "*"
+	}
+	return ""
+}
+
+func closeFor(entry string) string {
+	tag, target, _ := strings.Cut(entry, "\x00")
+	switch tag {
+	case "EX", "LS":
+		return "`"
+	case "ZH", "KY":
+		return "**"
+	case "ZK", "EM":
+		return "*"
+	case "DS":
+		if target != "" {
+			return " (" + strings.ReplaceAll(target, ".", " ") + ")"
+		}
+	}
+	return ""
+}

--- a/pkg/itf/itf_test.go
+++ b/pkg/itf/itf_test.go
@@ -1,0 +1,88 @@
+package itf
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestToMarkdown(t *testing.T) {
+	// An IMG activity's text as DOKTL holds it: chapter markers, paragraphs
+	// continued on unformatted lines, <ex> code, a numbered list, and empty
+	// chapters.
+	lines := []Line{
+		{"UT", "&USE&"},
+		{"AS", "This activity deletes the cleanup jobs for"},
+		{"", "delta links."},
+		{"AS", "It deletes all jobs that use the report"},
+		{"", "<ex>/IWBEP/R_DELTA_LINK_CLEANUP</> as a job step."},
+		{"UT", "&PRECONDITIONS&"},
+		{"AS", "You need <zh>S_BTCH_JOB</> with these values:"},
+		{"N1", "Job group (JOBGROUP): <ex>*</>"},
+		{"N1", "Job action (JOBACTION): <ex>DELE</>"},
+		{"AS", ""},
+		{"UT", "&STANDARD_SETUP&"},
+		{"AS", ""},
+	}
+	got := ToMarkdown(lines, nil)
+	want := "## Use\n\nThis activity deletes the cleanup jobs for delta links.\n\nIt deletes all jobs that use the report `/IWBEP/R_DELTA_LINK_CLEANUP` as a job step.\n\n## Preconditions\n\nYou need **S_BTCH_JOB** with these values:\n\n1. Job group (JOBGROUP): `*`\n2. Job action (JOBACTION): `DELE`\n## Standard Setup\n"
+	if got != want {
+		t.Errorf("got:\n%s\nwant:\n%s", got, want)
+	}
+}
+
+func TestIncludesAndLinks(t *testing.T) {
+	lines := []Line{
+		{"U1", "&FUNCTIONALITY&"},
+		{"/:", "INCLUDE BAL_FU_LOG_CREATE OBJECT DOKU ID TX."},
+		{"U1", "Related function modules"},
+		{"AS", "<DS:TX.BAL_CH_SIMPLE>Simple log creation call</>"},
+		{"/", "<DS:TX.BAL_CH_COLLECT>Methods of collecting messages</>"},
+		{"/:", "INCLUDE BAL_FU_LOG_CREATE OBJECT DOKU ID TX"},
+	}
+	include := func(object, id string) ([]Line, error) {
+		if object == "BAL_FU_LOG_CREATE" && id == "TX" {
+			return []Line{{"AS", "Creates a log with the header <ex>I_S_LOG</>."}}, nil
+		}
+		return nil, nil
+	}
+	got := ToMarkdown(lines, include)
+	for _, want := range []string{
+		"## Functionality\n\nCreates a log with the header `I_S_LOG`.",
+		"## Related function modules\n",
+		"Simple log creation call (TX BAL_CH_SIMPLE)  \nMethods of collecting messages (TX BAL_CH_COLLECT)",
+		"_[included text TX BAL_FU_LOG_CREATE]_", // the second time: seen, not repeated
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("missing %q in:\n%s", want, got)
+		}
+	}
+	if strings.Count(got, "Creates a log") != 1 {
+		t.Errorf("include rendered %d times", strings.Count(got, "Creates a log"))
+	}
+	// A character format that spans two DOKTL lines closes on the second.
+	spanned := ToMarkdown([]Line{{"AS", "See <DS:TX.BAL_FUNCTION_GROUPS>the most important function"}, {"", "groups</> here."}}, nil)
+	if spanned != "See the most important function groups (TX BAL_FUNCTION_GROUPS) here.\n" {
+		t.Errorf("spanned tag: %q", spanned)
+	}
+	if ToMarkdown(lines[:2], nil) != "## Functionality\n\n_[included text TX BAL_FU_LOG_CREATE]_\n" {
+		t.Errorf("without an includer: %q", ToMarkdown(lines[:2], nil))
+	}
+}
+
+func TestInline(t *testing.T) {
+	for in, want := range map[string]string{
+		"a <ex>code</> b":           "a `code` b",
+		"<zh>bold</> and <zk>it</>": "**bold** and *it*",
+		"x <(>tag<)> y":             "x <tag> y",
+		"<DS:DE.BALLEVEL>level</>":  "level (DE BALLEVEL)",
+		"unclosed <zh>bold":         "unclosed **bold**",
+		"plain & text":              "plain & text",
+	} {
+		if got := inline(in); got != want {
+			t.Errorf("%q: got %q, want %q", in, got, want)
+		}
+	}
+	if chapter("&FURTHER_HINTS&") != "Further Hints" || chapter("not a marker") != "" {
+		t.Error("chapter markers")
+	}
+}


### PR DESCRIPTION
## What

`vsp variants`, `vsp fmtest`, `vsp docs read|index|img|activity`, and MCP `variants`, `fm_test_data`, `documentation`, `img_search`, `img_activity`. Variants from VARI (values under VA, screen shape under VB) with selection-text and DDIC labels; SE37 test data from EUFUNC; SE61 documentation as Markdown via a new `pkg/itf`; the IMG searched by activity and folder titles with the path to each.

## Verified

Unit: ITF rendering (chapters, continuation, lists, inline formats, includes), Markdown renderers. Live on A4H: a variant with DDIC labels, STRING_CONCATENATE and X500_COMMTYP_SELECT test data, BAL_LOG_CREATE and BALLEVEL docs with includes, IMG search "Cleanup Job" and the /IWBEP/CP_DELETE_JOB activity with path, transaction and text.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0162uKF31Qeg14pwMwj4dmts
