### PR TITLE
feat(texts): write a program's text pool, and take selection texts from "~t: comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -305,6 +305,31 @@ vsp -s a4h docs read DE BALLEVEL
 vsp -s a4h docs activity /IWBEP/CP_DELETE_JOB
 ```
 
+### Selection texts, beside the field they describe
+
+A selection text is maintained in a screen three clicks from the code and
+falls out of sync with it. `vsp texts sync` reads the source instead: a
+trailing comment of the form `"~t:` on a PARAMETERS, SELECT-OPTIONS or named
+SELECTION-SCREEN COMMENT line is that field's text, and the text pool is
+written from it, in the logon language or `--lang`.
+
+```abap
+PARAMETERS: p_devc TYPE tadir-devclass DEFAULT '$TMP', "~t: Package to scan
+            p_deep TYPE abap_bool AS CHECKBOX.      "~t: Follow includes
+SELECT-OPTIONS s_obj FOR tadir-obj_name.            "~t: Object names
+```
+
+```bash
+vsp -s a4h texts sync ZDEMO_RUN --dry-run     # what would be written
+vsp -s a4h texts sync ZDEMO_RUN               # 3 text(s) written to ZDEMO_RUN (selections, EN)
+vsp -s a4h texts set ZDEMO_RUN P_DEVC="Package to scan"    # or one at a time
+vsp -s a4h texts get ZDEMO_RUN                # S, I and H entries
+```
+
+The text elements are their own ADT resource with their own lock; the lock,
+the write and the unlock happen in the one call. MCP: `i18n` with
+`op: sync_text_pool` or `op: write_text_pool`.
+
 ### Cluster tables, decoded — BALDAT, INDX, STXL over plain ADT
 
 BALDAT is one of a family: INDX, STXL, and every table an `EXPORT ... TO
@@ -983,6 +1008,7 @@ vsp -s a4h variants ZDEMO_NIGHTLY_RUN MONTH_END      # every field, its label, i
 vsp -s a4h fmtest ZDEMO_CALCULATE_TAX                # SE37's saved test data
 vsp -s a4h docs read FU BAL_LOG_CREATE               # SE61 documentation as Markdown
 vsp -s a4h docs img "cleanup job"                    # where in the IMG, and which activity
+vsp -s a4h texts sync ZDEMO_RUN                      # selection texts from "~t: comments in the source
 
 # Cluster tables — what only IMPORT could read, decoded here
 vsp -s a4h cluster read INDX --where "relid = 'ZV'" --schema

--- a/agenda/AGENDA.md
+++ b/agenda/AGENDA.md
@@ -37,6 +37,18 @@ Left on A4H: two INDX rows under `RELID = ZV` from the cluster fixture
 program, which itself was deleted after the fixtures were captured. Its
 source is `pkg/datacluster/testdata/zvsp_cluster_fixture.prog.abap`.
 
+## Done — 2026-09-07 — selection texts from the source
+
+`vsp texts get|set|sync`, MCP `i18n` ops `write_text_pool` and
+`sync_text_pool`. The text pool is its own ADT resource
+(`/sap/bc/adt/textelements/programs/{name}`, lock object REPT — a lock on
+the program is not a lock on its texts), three plain-text documents under
+it (`KEY     =text`, key padded to eight). `sync` takes `"~t:` comments
+from PARAMETERS / SELECT-OPTIONS / named SELECTION-SCREEN COMMENT lines.
+Text symbols (I) and headings (H) write through the same call with
+`--kind`; no source convention for them yet — `"~i:001` would be the
+obvious one if anyone wants it.
+
 ## Done — 2026-09-06 — the cache that was a flag
 
 `cache: true` in `.vsp.json` and `VSP_CACHE` reached `systemParams` and

--- a/cmd/vsp/texts.go
+++ b/cmd/vsp/texts.go
@@ -1,0 +1,147 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"sort"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/oisee/vibing-steampunk/pkg/adt"
+)
+
+var textsCmd = &cobra.Command{
+	Use:   "texts",
+	Short: "A program's text pool: selection texts, text symbols, headings — read, set, or sync from the source",
+	Long: `The text pool of a program over ADT: selection texts (S), text symbols (I)
+and list headings (H).
+
+  vsp texts get ZDEMO_RUN                          # every entry, with its kind
+  vsp texts set ZDEMO_RUN P_DEVC="Package to scan" S_OBJ="Object names"
+  vsp texts set ZDEMO_RUN --kind I 001="Nothing found"
+  vsp texts sync ZDEMO_RUN                         # from "~t: comments in the source
+  vsp texts sync ZDEMO_RUN --dry-run
+
+sync reads the source and takes every trailing comment of the form "~t: on a
+PARAMETERS, SELECT-OPTIONS or named SELECTION-SCREEN COMMENT line as that
+field's selection text:
+
+  PARAMETERS p_devc TYPE tadir-devclass DEFAULT '$TMP'. "~t: Package to scan
+  SELECT-OPTIONS s_obj FOR tadir-obj_name.            "~t: Object names
+
+The text lives beside the field, versioned with the code; the text pool is
+written from it, in the logon language unless --lang says otherwise.`,
+}
+
+var textsGetCmd = &cobra.Command{
+	Use:   "get <PROGRAM>",
+	Short: "Read the text pool",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		client, lang, err := docsClient(cmd)
+		if err != nil {
+			return err
+		}
+		entries, err := client.GetTextPoolInLanguage(context.Background(), args[0], lang)
+		if err != nil {
+			return err
+		}
+		if asJSON, _ := cmd.Flags().GetBool("json"); asJSON {
+			return printJSON(entries)
+		}
+		if len(entries) == 0 {
+			fmt.Fprintln(os.Stderr, "no texts")
+			return nil
+		}
+		for _, e := range entries {
+			fmt.Printf("%s  %-16s %s\n", e.ID, e.Key, e.Text)
+		}
+		return nil
+	},
+}
+
+var textsSetCmd = &cobra.Command{
+	Use:   "set <PROGRAM> KEY=TEXT [KEY=TEXT ...]",
+	Short: "Write texts; keys not named keep theirs",
+	Args:  cobra.MinimumNArgs(2),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		entries := map[string]string{}
+		for _, kv := range args[1:] {
+			k, v, ok := strings.Cut(kv, "=")
+			if !ok || strings.TrimSpace(k) == "" {
+				return fmt.Errorf("%q: want KEY=TEXT", kv)
+			}
+			entries[strings.ToUpper(strings.TrimSpace(k))] = v
+		}
+		return writeTexts(cmd, args[0], entries)
+	},
+}
+
+var textsSyncCmd = &cobra.Command{
+	Use:   "sync <PROGRAM>",
+	Short: "Write the selection texts found as \"~t: comments in the source",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		params, err := resolveSystemParams(cmd)
+		if err != nil {
+			return err
+		}
+		client, err := getClient(params)
+		if err != nil {
+			return err
+		}
+		ctx := context.Background()
+		source, err := client.GetSource(ctx, "PROG", strings.ToUpper(args[0]), nil)
+		if err != nil {
+			return err
+		}
+		entries := adt.SelectionTextsFromSource(source)
+		if len(entries) == 0 {
+			fmt.Fprintln(os.Stderr, "no \"~t: comments in the source; nothing to write")
+			return nil
+		}
+		if dry, _ := cmd.Flags().GetBool("dry-run"); dry {
+			keys := make([]string, 0, len(entries))
+			for k := range entries {
+				keys = append(keys, k)
+			}
+			sort.Strings(keys)
+			for _, k := range keys {
+				fmt.Printf("%-16s %s\n", k, entries[k])
+			}
+			fmt.Fprintf(os.Stderr, "%d selection text(s) found; not written (--dry-run)\n", len(entries))
+			return nil
+		}
+		return writeTexts(cmd, args[0], entries)
+	},
+}
+
+func writeTexts(cmd *cobra.Command, program string, entries map[string]string) error {
+	client, lang, err := docsClient(cmd)
+	if err != nil {
+		return err
+	}
+	kind, _ := cmd.Flags().GetString("kind")
+	transport, _ := cmd.Flags().GetString("transport")
+	if err := client.WriteTextPool(context.Background(), program, lang, kind, entries, transport); err != nil {
+		return err
+	}
+	fmt.Fprintf(os.Stderr, "%d text(s) written to %s (%s, %s)\n", len(entries), strings.ToUpper(program), adt.TextPoolKinds[strings.ToUpper(kind)], strings.ToUpper(lang))
+	return nil
+}
+
+func init() {
+	for _, c := range []*cobra.Command{textsGetCmd, textsSetCmd, textsSyncCmd} {
+		c.Flags().String("lang", "", "Language (ISO code); the system's logon language by default")
+	}
+	textsGetCmd.Flags().Bool("json", false, "Emit JSON")
+	for _, c := range []*cobra.Command{textsSetCmd, textsSyncCmd} {
+		c.Flags().String("kind", "S", "Text kind: S selection texts, I text symbols, H headings")
+		c.Flags().String("transport", "", "Transport request for a transportable program")
+	}
+	textsSyncCmd.Flags().Bool("dry-run", false, "Show what would be written")
+	textsCmd.AddCommand(textsGetCmd, textsSetCmd, textsSyncCmd)
+	rootCmd.AddCommand(textsCmd)
+}

--- a/internal/mcp/handlers_help.go
+++ b/internal/mcp/handlers_help.go
@@ -185,6 +185,10 @@ What differs between two languages — named separately, not as a list:
 
 Writing needs a lock_handle from a lock taken first, and changes the system:
   SAP(action="i18n", params={"op": "write_message_texts", "name": "ZVSP_GIT", "language": "DE", "lock_handle": "...", "texts": []})
+  SAP(action="i18n", params={"op": "write_text_pool", "program_name": "ZDEMO_RUN", "texts": {"P_DEVC": "Package to scan"}})
+      selection texts (kind S; I symbols, H headings); the lock is taken and released in the call
+  SAP(action="i18n", params={"op": "sync_text_pool", "program_name": "ZDEMO_RUN", "dry_run": true})
+      selection texts from "~t: comments in the source: PARAMETERS p_devc TYPE devclass. "~t: Package to scan
 
 write_labels is not implemented and refuses. What it used to send was a
 four-field document to a resource that takes the data element's whole

--- a/internal/mcp/handlers_i18n.go
+++ b/internal/mcp/handlers_i18n.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strings"
 
 	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/oisee/vibing-steampunk/pkg/adt"
@@ -221,4 +222,80 @@ func (s *Server) handleCompareObjectLanguages(ctx context.Context, request mcp.C
 	}
 
 	return mcp.NewToolResultText(string(jsonBytes)), nil
+}
+
+// handleWriteTextPool writes a program's texts of one kind: params
+// program_name, language (logon language by default), kind (S selection
+// texts by default, I symbols, H headings), texts as {KEY: text} or as
+// "KEY=text" lines, transport for a transportable program. The lock is
+// taken and released here; nothing to carry across calls.
+func (s *Server) handleWriteTextPool(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	args := request.GetArguments()
+	program := getStringParam(args, "program_name")
+	if program == "" {
+		program = getStringParam(args, "program")
+	}
+	if program == "" {
+		return newToolResultError("program_name is required"), nil
+	}
+	lang := getStringParam(args, "language")
+	if lang == "" {
+		lang = s.adtClient.Language()
+	}
+	kind := getStringParam(args, "kind")
+	if kind == "" {
+		kind = "S"
+	}
+	entries := map[string]string{}
+	switch t := args["texts"].(type) {
+	case map[string]any:
+		for k, v := range t {
+			entries[strings.ToUpper(k)] = fmt.Sprint(v)
+		}
+	case string:
+		for _, line := range strings.Split(t, "\n") {
+			if k, v, ok := strings.Cut(line, "="); ok && strings.TrimSpace(k) != "" {
+				entries[strings.ToUpper(strings.TrimSpace(k))] = strings.TrimRight(v, "\r")
+			}
+		}
+	}
+	if len(entries) == 0 {
+		return newToolResultError("texts is required: {\"P_DEVC\": \"Package to scan\"} or \"P_DEVC=Package to scan\" lines"), nil
+	}
+	if err := s.adtClient.WriteTextPool(ctx, program, lang, kind, entries, getStringParam(args, "transport")); err != nil {
+		return newToolResultError(fmt.Sprintf("WriteTextPool failed: %v", err)), nil
+	}
+	return newToolResultJSON(map[string]any{"program": strings.ToUpper(program), "language": strings.ToUpper(lang), "kind": strings.ToUpper(kind), "written": len(entries)}), nil
+}
+
+// handleSyncTextPool takes the "~t: comments of a program's source as its
+// selection texts and writes them; dry_run lists them instead.
+func (s *Server) handleSyncTextPool(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	args := request.GetArguments()
+	program := getStringParam(args, "program_name")
+	if program == "" {
+		program = getStringParam(args, "program")
+	}
+	if program == "" {
+		return newToolResultError("program_name is required"), nil
+	}
+	source, err := s.adtClient.GetSource(ctx, "PROG", strings.ToUpper(program), nil)
+	if err != nil {
+		return newToolResultError(fmt.Sprintf("reading the source: %v", err)), nil
+	}
+	entries := adt.SelectionTextsFromSource(source)
+	if len(entries) == 0 {
+		return newToolResultJSON(map[string]any{"program": strings.ToUpper(program), "found": 0, "notes": []string{"No \"~t: comments in the source. Put one after a PARAMETERS, SELECT-OPTIONS or named SELECTION-SCREEN COMMENT line: PARAMETERS p_devc TYPE tadir-devclass. \"~t: Package to scan"}}), nil
+	}
+	if dry, _ := getBoolParam(args, "dry_run"); dry {
+		return newToolResultJSON(map[string]any{"program": strings.ToUpper(program), "found": len(entries), "texts": entries, "written": 0}), nil
+	}
+	lang := getStringParam(args, "language")
+	if lang == "" {
+		lang = s.adtClient.Language()
+	}
+	if err := s.adtClient.WriteTextPool(ctx, program, lang, "S", entries, getStringParam(args, "transport")); err != nil {
+		return newToolResultError(fmt.Sprintf("WriteTextPool failed: %v", err)), nil
+	}
+	return newToolResultJSON(map[string]any{"program": strings.ToUpper(program), "language": strings.ToUpper(lang), "texts": entries, "written": len(entries)}), nil
 }

--- a/internal/mcp/handlers_route_eleven.go
+++ b/internal/mcp/handlers_route_eleven.go
@@ -37,6 +37,8 @@ func (s *Server) i18nTypes() map[string]server.ToolHandlerFunc {
 		"compare_languages":   s.handleCompareObjectLanguages,
 		"write_labels":        s.handleWriteDataElementLabels,
 		"write_message_texts": s.handleWriteMessageClassTexts,
+		"write_text_pool":     s.handleWriteTextPool,
+		"sync_text_pool":      s.handleSyncTextPool,
 	}
 }
 
@@ -141,6 +143,6 @@ func (s *Server) lintTypes() map[string]server.ToolHandlerFunc {
 func i18nOps() []string {
 	return []string{
 		"texts", "data_element_labels", "message_class_texts", "text_pool",
-		"compare_languages", "write_labels", "write_message_texts",
+		"compare_languages", "write_labels", "write_message_texts", "write_text_pool", "sync_text_pool",
 	}
 }

--- a/pkg/adt/textpool_write.go
+++ b/pkg/adt/textpool_write.go
@@ -1,0 +1,147 @@
+package adt
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/url"
+	"regexp"
+	"sort"
+	"strings"
+)
+
+// Writing a program's text pool. The text elements are their own ADT
+// resource — /sap/bc/adt/textelements/programs/{name} — with its own lock
+// (REPT, not the program's), and three documents under it: symbols (text
+// symbols, I), selections (selection texts, S), headings (H). Each is plain
+// text, one `KEY     =text` per line with the key padded to eight
+// characters, the format the GET returns and the PUT expects. The lock, the
+// PUT and the unlock go through one stateful session, as every write does.
+
+// TextPoolKinds maps the classic READ TEXTPOOL id to the ADT document.
+var TextPoolKinds = map[string]string{"I": "symbols", "S": "selections", "H": "headings"}
+
+// WriteTextPool replaces the texts of one kind (I, S or H) in one language
+// with the entries given: every key in entries gets its text, keys not
+// named keep theirs. transport may be empty for local objects.
+func (c *Client) WriteTextPool(ctx context.Context, program, lang, kind string, entries map[string]string, transport string) error {
+	if err := c.checkSafety(OpUpdate, "WriteTextPool"); err != nil {
+		return err
+	}
+	program = strings.ToUpper(strings.TrimSpace(program))
+	kind = strings.ToUpper(strings.TrimSpace(kind))
+	doc, ok := TextPoolKinds[kind]
+	if !ok {
+		return fmt.Errorf("text pool kind %q: want I (symbols), S (selection texts) or H (headings)", kind)
+	}
+	if len(entries) == 0 {
+		return fmt.Errorf("no texts to write")
+	}
+
+	// What is there now, so that keys not named keep their text.
+	current, err := c.GetTextPoolInLanguage(ctx, program, lang)
+	if err != nil {
+		return err
+	}
+	merged := map[string]string{}
+	for _, e := range current {
+		if e.ID == kind {
+			merged[strings.ToUpper(strings.TrimSpace(e.Key))] = e.Text
+		}
+	}
+	for k, v := range entries {
+		merged[strings.ToUpper(strings.TrimSpace(k))] = v
+	}
+
+	resource := fmt.Sprintf("/sap/bc/adt/textelements/programs/%s", url.PathEscape(strings.ToLower(program)))
+	lock, err := c.LockObject(ctx, resource, "MODIFY")
+	if err != nil {
+		return fmt.Errorf("locking the text pool of %s: %w", program, err)
+	}
+	defer func() { _ = c.UnlockObject(ctx, resource, lock.LockHandle) }()
+
+	params := url.Values{}
+	params.Set("lockHandle", lock.LockHandle)
+	if transport = strings.TrimSpace(transport); transport != "" {
+		params.Set("corrNr", transport)
+	}
+	vocabulary := "application/vnd.sap.adt.textelements." + doc + ".v1"
+	_, err = c.transport.Request(ctx, resource+"/source/"+doc, &RequestOptions{
+		Method:           http.MethodPut,
+		Query:            params,
+		Body:             []byte(FormatTextPool(merged)),
+		ContentType:      vocabulary + "; charset=UTF-8",
+		Accept:           vocabulary,
+		OverrideLanguage: strings.ToUpper(lang),
+		Stateful:         true,
+	})
+	if err != nil {
+		return fmt.Errorf("writing the %s of %s: %w", doc, program, err)
+	}
+	return nil
+}
+
+// FormatTextPool renders entries the way the text element documents hold
+// them: keys padded to eight characters, one per line, sorted.
+func FormatTextPool(entries map[string]string) string {
+	keys := make([]string, 0, len(entries))
+	for k := range entries {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	var b strings.Builder
+	for _, k := range keys {
+		fmt.Fprintf(&b, "%-8s=%s\n", k, entries[k])
+	}
+	return b.String()
+}
+
+// The selection-text comment: a trailing comment on the line that declares
+// a parameter, a select-option or a named selection-screen comment, of the
+// form "~t: the text. The text lives beside the field it describes, in the
+// source, where it is versioned with it; SyncSelectionTexts carries it to
+// the text pool.
+//
+//	PARAMETERS p_devc TYPE tadir-devclass DEFAULT '$TMP'. "~t: Package to scan
+//	SELECT-OPTIONS s_obj FOR tadir-obj_name.            "~t: Object names
+//	SELECTION-SCREEN COMMENT 3(60) gv_hint FOR FIELD p_devc. "~t: Where to look
+var (
+	textComment  = regexp.MustCompile(`"\s*~+t\s*:\s*(.*?)\s*$`)
+	declKeyword  = regexp.MustCompile(`(?i)^\s*(?:PARAMETERS?|SELECT-OPTIONS?|SELECTION-SCREEN\s+COMMENT\s+(?:/?\d+\(\d+\)|\S+))\s*:?\s*`)
+	firstIdent   = regexp.MustCompile(`^([A-Za-z_][A-Za-z0-9_]*)`)
+	commentLabel = regexp.MustCompile(`(?i)SELECTION-SCREEN\s+COMMENT\s+\S+\s+([A-Za-z_][A-Za-z0-9_]*)`)
+)
+
+// SelectionTextsFromSource collects the "~t: comments of a program: the
+// first identifier of the line, after any declaring keyword, is the key —
+// which is right for PARAMETERS, SELECT-OPTIONS, the chained lines that
+// follow them, and a named SELECTION-SCREEN COMMENT. A "~t: on a line of
+// its own has no key and is skipped.
+func SelectionTextsFromSource(source string) map[string]string {
+	out := map[string]string{}
+	for _, line := range strings.Split(source, "\n") {
+		m := textComment.FindStringSubmatch(line)
+		if m == nil {
+			continue
+		}
+		text := strings.TrimSpace(m[1])
+		if text == "" {
+			continue
+		}
+		code := line[:strings.LastIndex(line, m[0])]
+		key := ""
+		if cm := commentLabel.FindStringSubmatch(code); cm != nil {
+			key = cm[1]
+		} else {
+			rest := declKeyword.ReplaceAllString(code, "")
+			if im := firstIdent.FindStringSubmatch(strings.TrimSpace(rest)); im != nil {
+				key = im[1]
+			}
+		}
+		if key == "" {
+			continue
+		}
+		out[strings.ToUpper(key)] = text
+	}
+	return out
+}

--- a/pkg/adt/textpool_write_test.go
+++ b/pkg/adt/textpool_write_test.go
@@ -1,0 +1,38 @@
+package adt
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestSelectionTextsFromSource(t *testing.T) {
+	src := `REPORT zdemo.
+TABLES tadir.
+PARAMETERS: p_devc TYPE tadir-devclass DEFAULT '$TMP', "~t: Package to scan
+            p_deep TYPE abap_bool AS CHECKBOX.      "~~t:Follow includes
+SELECT-OPTIONS s_obj FOR tadir-obj_name. "~t: Object names
+PARAMETER p_old TYPE c. " an ordinary comment, no text
+SELECTION-SCREEN COMMENT 3(60) gv_hint FOR FIELD p_devc. "~t: Where to look
+SELECTION-SCREEN COMMENT /1(30) gv_two. "~t: Second line
+  p_cont TYPE i. "~t: In a chained statement
+WRITE 'not a declaration'. "~t: ignored? no — a token is a token
+"~t: a comment on its own line is nothing
+`
+	got := SelectionTextsFromSource(src)
+	want := map[string]string{
+		"P_DEVC": "Package to scan", "P_DEEP": "Follow includes", "S_OBJ": "Object names",
+		"GV_HINT": "Where to look", "GV_TWO": "Second line", "P_CONT": "In a chained statement",
+		"WRITE": "ignored? no — a token is a token",
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("got %v\nwant %v", got, want)
+	}
+}
+
+func TestFormatTextPool(t *testing.T) {
+	got := FormatTextPool(map[string]string{"S_OBJ": "Object names", "P_DEVC": "Package to scan", "P_DEEP": ""})
+	want := "P_DEEP  =\nP_DEVC  =Package to scan\nS_OBJ   =Object names\n"
+	if got != want {
+		t.Errorf("got %q want %q", got, want)
+	}
+}


### PR DESCRIPTION
## What

`vsp texts get|set|sync`, MCP `i18n` ops `write_text_pool` / `sync_text_pool`. Text elements are their own ADT resource with their own lock (REPT); `sync` takes `"~t:` trailing comments on PARAMETERS / SELECT-OPTIONS / named SELECTION-SCREEN COMMENT lines as selection texts.

## Verified

Unit: comment parser, document format. Live on A4H: a probe program with two parameters and a select-option — `sync --dry-run`, `sync`, `get` reads the three texts back.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0162uKF31Qeg14pwMwj4dmts
