### PR TITLE
Text pool: remove a key, count only ?... as a gap

### DIFF
--- a/README.md
+++ b/README.md
@@ -342,6 +342,7 @@ vsp -s a4h texts set ZDEMO_RUN P_DEVC="Package to scan" S_OBJ="Object names"
 vsp -s a4h texts set ZDEMO_RUN --kind I 001="Nothing found"
 vsp -s a4h texts set ZDEMO_RUN --dry-run P_DEVC="Package to scan"
 vsp -s a4h texts set CLAS ZCL_DEMO --kind I 001="Loaded"
+vsp -s a4h texts set ZDEMO_RUN --delete P_MODE            # the entry a removed field left behind
 ```
 
 The text elements are their own ADT resource with their own lock; the lock,

--- a/agenda/AGENDA.md
+++ b/agenda/AGENDA.md
@@ -105,6 +105,15 @@ FRAPVSCREENCNTR, `.6` FRAPVSCREENADDR, `.7` FRAPVSCREENNAME, `.8`
 FRA_S_ADDR_SCR_LIST_ENTITY, `SNAP.1` ZSCR_117_CPD_H; `HDR` and `HDR.10`
 are a program's local type and come from the names file only.
 
+After the merge, from the same second session on its own system: a
+field removed from the screen leaves its entry in the pool with an empty
+text, and the hint after a deploy asked for a text for it. Now `?...` is
+the only gap the hint counts, a null text over MCP or `--delete KEY` on
+the CLI takes the entry out (the plan lists it under `removed`), and
+`uncommented` is `untouched`. Confirmed on A4H: the entry a removed
+parameter left behind is gone after the call, and a second call says
+unchanged.
+
 Still open from that session's notes, not done here: a function module
 whose TABLES parameter "declares no type" in the parser; a source line
 over 255 characters refused without a line number; `save_to_file` reading

--- a/cmd/vsp/texts.go
+++ b/cmd/vsp/texts.go
@@ -23,6 +23,7 @@ of a program or a class, list headings (H).
   vsp texts set ZDEMO_RUN --kind I 001="Nothing found" B01="Options"
   vsp texts set ZDEMO_RUN --dry-run P_DEVC="Package to scan"
   vsp texts set ZDEMO_RUN --lang DE P_DEVC="Zu prüfendes Paket"
+  vsp texts set ZDEMO_RUN --delete P_MODE                     # the entry a removed field left behind
 
 A write is a plan first: what is added, what changes from what, what is
 already so, and what is refused — a selection text for a field the screen
@@ -61,7 +62,7 @@ var textsGetCmd = &cobra.Command{
 var textsSetCmd = &cobra.Command{
 	Use:   "set [PROG|CLAS] <NAME> KEY=TEXT [KEY=TEXT ...]",
 	Short: "Write texts of one kind; keys not named keep theirs",
-	Args:  cobra.MinimumNArgs(2),
+	Args:  cobra.MinimumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		// The target is the leading argument(s) up to the first KEY=TEXT.
 		split := 1
@@ -76,6 +77,13 @@ var textsSetCmd = &cobra.Command{
 				return fmt.Errorf("%q: want KEY=TEXT", kv)
 			}
 			entries[strings.ToUpper(strings.TrimSpace(k))] = v
+		}
+		del, _ := cmd.Flags().GetStringSlice("delete")
+		for _, k := range del {
+			entries[strings.ToUpper(strings.TrimSpace(k))] = adt.TextDelete
+		}
+		if len(entries) == 0 {
+			return fmt.Errorf("nothing to write: give KEY=TEXT or --delete KEY")
 		}
 		client, lang, err := docsClient(cmd)
 		if err != nil {
@@ -116,6 +124,9 @@ func printTextPlan(p *adt.TextPoolPlan) {
 		for _, c := range k.Changed {
 			fmt.Printf("~ %-3s %-16s %s  (was: %s)\n", k.Kind, c.Key, c.New, c.Old)
 		}
+		for _, r := range k.Removed {
+			fmt.Printf("- %-3s %-16s removed\n", k.Kind, r)
+		}
 		for _, u := range k.Unchanged {
 			fmt.Printf("= %-3s %-16s unchanged\n", k.Kind, u)
 		}
@@ -148,6 +159,7 @@ func init() {
 	}
 	textsSetCmd.Flags().String("kind", "S", "Text kind: S selection texts, I text symbols, H headings")
 	textsSetCmd.Flags().String("transport", "", "Transport request; the one the object is locked in is reused when empty")
+	textsSetCmd.Flags().StringSlice("delete", nil, "Keys to remove — entries a field left behind when it went from the screen")
 	textsSetCmd.Flags().Bool("dry-run", false, "Show the plan and write nothing")
 	textsSetCmd.Flags().Bool("allow-unknown", false, "Write selection texts for keys the screen does not declare")
 	textsCmd.AddCommand(textsGetCmd, textsSetCmd)

--- a/internal/mcp/handlers_help.go
+++ b/internal/mcp/handlers_help.go
@@ -191,6 +191,7 @@ Writing needs a lock_handle from a lock taken first, and changes the system:
       texts_set needs no lock_handle: the text pool is its own resource, locked and released in the call.
       The answer is a plan — added, changed (from what), unchanged, unknown (not on the screen), refused —
       and dry_run stops at the plan. "language" names a translation; without it the logon language is written.
+      A null text ({"P_MODE": null}) removes the key — a field gone from the screen leaves its entry behind.
       After create PROGRAM / write_program the result carries a "hints" line naming screen fields with no
       selection text and TEXT-xxx the source uses but does not define. create PROGRAM also takes "texts".
       The written texts are activated in the same call; without that they stay an inactive version.

--- a/internal/mcp/handlers_i18n.go
+++ b/internal/mcp/handlers_i18n.go
@@ -270,7 +270,8 @@ func (s *Server) handleTextsGet(ctx context.Context, request mcp.CallToolRequest
 
 // handleTextsSet writes texts: op=texts_set (write_text_pool is an alias).
 // texts is {KEY: text} for one kind (kind: S by default, I, H), or
-// {"selections": {...}, "symbols": {...}, "headings": {...}}. dry_run
+// {"selections": {...}, "symbols": {...}, "headings": {...}}; a null text
+// removes the key. dry_run
 // returns the plan; language names a translation and allows it;
 // allow_unknown writes selection texts for keys the screen does not have.
 func (s *Server) handleTextsSet(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
@@ -315,6 +316,11 @@ func textKindsFrom(args map[string]any) (map[string]map[string]string, error) {
 		}
 		flat := map[string]string{}
 		for k, x := range m {
+			if x == nil {
+				// null removes the key.
+				flat[strings.ToUpper(k)] = adt.TextDelete
+				continue
+			}
 			flat[strings.ToUpper(k)] = fmt.Sprint(x)
 		}
 		return flat, true

--- a/internal/mcp/handlers_i18n_test.go
+++ b/internal/mcp/handlers_i18n_test.go
@@ -6,11 +6,13 @@ import (
 	"testing"
 
 	"github.com/mark3labs/mcp-go/mcp"
+
+	"github.com/oisee/vibing-steampunk/pkg/adt"
 )
 
 func TestTextKindsFrom(t *testing.T) {
-	flat, err := textKindsFrom(map[string]any{"texts": map[string]any{"p_devc": "Package"}})
-	if err != nil || flat["S"]["P_DEVC"] != "Package" || len(flat) != 1 {
+	flat, err := textKindsFrom(map[string]any{"texts": map[string]any{"p_devc": "Package", "p_gone": nil}})
+	if err != nil || flat["S"]["P_DEVC"] != "Package" || flat["S"]["P_GONE"] != adt.TextDelete || len(flat) != 1 {
 		t.Errorf("flat: %v %v", flat, err)
 	}
 	kind, err := textKindsFrom(map[string]any{"kind": "i", "texts": map[string]any{"001": "Nothing"}})

--- a/pkg/adt/textpool.go
+++ b/pkg/adt/textpool.go
@@ -113,6 +113,16 @@ func parseTextDocument(body string) *textDocument {
 	return d
 }
 
+func (d *textDocument) remove(key string) {
+	kept := d.entries[:0]
+	for _, e := range d.entries {
+		if !strings.EqualFold(e.key, key) {
+			kept = append(kept, e)
+		}
+	}
+	d.entries = kept
+}
+
 func (d *textDocument) get(key string) (textEntry, bool) {
 	for _, e := range d.entries {
 		if strings.EqualFold(e.key, key) {
@@ -213,9 +223,17 @@ type KindPlan struct {
 	Unknown []string `json:"unknown,omitempty"`
 	// Refused are keys or texts SAP would reject, with the reason.
 	Refused []KeyReason `json:"refused,omitempty"`
-	// Uncommented are the document's keys the caller said nothing about.
-	Uncommented []string `json:"uncommented,omitempty"`
+	// Removed are keys taken out of the document: the caller gave
+	// TextDelete for them.
+	Removed []string `json:"removed,omitempty"`
+	// Untouched are the document's keys the caller said nothing about;
+	// they keep their texts.
+	Untouched []string `json:"untouched,omitempty"`
 }
+
+// TextDelete as a key's text removes the key from the document. A field
+// gone from the screen leaves its entry behind; this is how it goes.
+const TextDelete = "\x00delete"
 
 // KeyText is one text by key.
 type KeyText struct {
@@ -252,7 +270,7 @@ type TextPoolOptions struct {
 func (p *TextPoolPlan) changes() int {
 	n := 0
 	for _, k := range p.Kinds {
-		n += len(k.Added) + len(k.Changed)
+		n += len(k.Added) + len(k.Changed) + len(k.Removed)
 	}
 	return n
 }
@@ -391,7 +409,7 @@ func (c *Client) WriteTextPool(ctx context.Context, target TextPoolTarget, lang 
 		}
 		kp := planKind(k, d, texts[k], opts)
 		plan.Kinds = append(plan.Kinds, kp)
-		if len(kp.Added)+len(kp.Changed) == 0 {
+		if len(kp.Added)+len(kp.Changed)+len(kp.Removed) == 0 {
 			continue
 		}
 		for _, a := range kp.Added {
@@ -399,6 +417,9 @@ func (c *Client) WriteTextPool(ctx context.Context, target TextPoolTarget, lang 
 		}
 		for _, ch := range kp.Changed {
 			d.set(k, ch.Key, ch.New)
+		}
+		for _, r := range kp.Removed {
+			d.remove(r)
 		}
 		params := url.Values{}
 		params.Set("lockHandle", lock.LockHandle)
@@ -417,7 +438,7 @@ func (c *Client) WriteTextPool(ctx context.Context, target TextPoolTarget, lang 
 		}); err != nil {
 			return plan, fmt.Errorf("writing the %s of %s: %w", TextPoolKinds[k], t, err)
 		}
-		plan.Written += len(kp.Added) + len(kp.Changed)
+		plan.Written += len(kp.Added) + len(kp.Changed) + len(kp.Removed)
 	}
 	plan.Applied = true
 	if plan.Written == 0 {
@@ -492,6 +513,10 @@ func planKind(kind string, doc *textDocument, wanted map[string]string, opts Tex
 		}
 		cur, exists := doc.get(k)
 		switch {
+		case text == TextDelete && exists:
+			kp.Removed = append(kp.Removed, k)
+		case text == TextDelete:
+			kp.Unchanged = append(kp.Unchanged, k)
 		case !exists && kind != "I" && !opts.AllowUnknown:
 			kp.Unknown = append(kp.Unknown, k)
 		case !exists:
@@ -504,7 +529,7 @@ func planKind(kind string, doc *textDocument, wanted map[string]string, opts Tex
 	}
 	for _, e := range doc.entries {
 		if !seen[e.key] {
-			kp.Uncommented = append(kp.Uncommented, e.key)
+			kp.Untouched = append(kp.Untouched, e.key)
 		}
 	}
 	return kp
@@ -544,7 +569,9 @@ func (c *Client) TextPoolGaps(ctx context.Context, target TextPoolTarget, lang, 
 			return nil, err
 		}
 		for _, e := range sel.entries {
-			if strings.TrimSpace(e.text) == "" || strings.TrimSpace(e.text) == "?..." {
+			// "?..." is a screen field with no text. An empty text is an
+			// entry a field left behind when it went; not a gap.
+			if strings.TrimSpace(e.text) == "?..." {
 				gaps.Selections = append(gaps.Selections, e.key)
 			}
 		}

--- a/pkg/adt/textpool_test.go
+++ b/pkg/adt/textpool_test.go
@@ -53,8 +53,15 @@ func TestPlanKind(t *testing.T) {
 	if kp := planKind("I", parseTextDocument(""), map[string]string{"001": "New", "b01": "Block", "TOOLONG1": "x"}, TextPoolOptions{}); len(kp.Added) != 2 || len(kp.Refused) != 1 {
 		t.Errorf("symbols: %+v", kp)
 	}
-	if kp := planKind("S", doc, map[string]string{"P_DEEP": "Follow includes"}, TextPoolOptions{}); len(kp.Uncommented) != 2 {
-		t.Errorf("uncommented: %v", kp.Uncommented)
+	if kp := planKind("S", doc, map[string]string{"P_DEEP": "Follow includes"}, TextPoolOptions{}); len(kp.Untouched) != 2 {
+		t.Errorf("untouched: %v", kp.Untouched)
+	}
+	if kp := planKind("S", doc, map[string]string{"P_DEEP": TextDelete, "P_GONE": TextDelete}, TextPoolOptions{}); len(kp.Removed) != 1 || kp.Removed[0] != "P_DEEP" || len(kp.Unchanged) != 1 {
+		t.Errorf("delete: %+v", kp)
+	}
+	doc.remove("p_deep")
+	if _, ok := doc.get("P_DEEP"); ok || len(doc.entries) != 2 {
+		t.Errorf("remove: %+v", doc.entries)
 	}
 	head := parseTextDocument("listHeader=\ncolumnHeader_1=\n")
 	if kp := planKind("H", head, map[string]string{"listheader": "Found", "columnHeader_1": "", "COLUMNHEADER_9": "x"}, TextPoolOptions{}); len(kp.Changed) != 1 || kp.Changed[0].Key != "listHeader" || len(kp.Unchanged) != 1 || len(kp.Refused) != 1 {


### PR DESCRIPTION
A field removed from the screen leaves its entry in the pool with an empty text, and the hint after a deploy asked for a text for a parameter the source no longer had (found by a second session on its own system after #201).

- The hint counts `?...` only — what a screen field without a text shows; an empty text is an entry a field left behind.
- A null text over MCP (`{"P_MODE": null}`) or `--delete KEY` on the CLI removes the entry; the plan lists it under `removed`, and it counts as a change — it did not at first, so the plan showed the removal and wrote nothing.
- `uncommented` in the plan is `untouched`.

Verified on A4H with a probe program: the entry a removed parameter left behind is gone after the call, and a second call reports it unchanged. Probe deleted afterwards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0162uKF31Qeg14pwMwj4dmts
