### PR TITLE
Transport: choose the request a write goes under, the way the editor does

### DIFF
--- a/README.md
+++ b/README.md
@@ -372,6 +372,20 @@ vsp -s a4h description CLAS ZCL_DEMO "Demo class"    # PROG, INCL, CLAS, INTF, F
 MCP: `edit` with `type: set_description`, and a `description` on
 `deploy_from_file` and `write_program` is written after the source.
 
+**A write with no transport named** used to leave the choice to SAP, which
+answered with a request of its own — *Generated Request for Change
+Recording* — one per write, so a day's work on one feature ended up spread
+over three requests beside the one already open. Now the write asks the
+transport check what Eclipse's dialog asks it: which of your open requests
+fit. The object's own request wins, then the one already holding objects of
+the package, then the only candidate, then the newest; with none and
+`--enable-transports`, one is created and the result says so. Every result
+carries `transport` and, when the choice was made here, `transportNote`.
+`--transport-choice off` (or `SAP_TRANSPORT_CHOICE=off`) restores the old
+behaviour. Merging requests is not in ADT's surface (the organizer offers
+add-object, change-owner, new-task, sort-and-compress — no merge, no
+remove), and `TR_MERGE_REQUESTS` is not remote-enabled; that stays SE09.
+
 `vsp update` fetches the latest release for this platform, compares it with
 the running version, verifies the download against the release's
 `checksums.txt`, and puts it in place of the running binary — the old one is

--- a/agenda/AGENDA.md
+++ b/agenda/AGENDA.md
@@ -114,6 +114,42 @@ the CLI takes the entry out (the plan lists it under `removed`), and
 parameter left behind is gone after the call, and a second call says
 unchanged.
 
+## Done — 2026-09-08 — the request a write goes under
+
+Asked for from the second session after a day on which the MCP, given no
+`transport`, let SAP generate two "Generated Request for Change Recording"
+beside the developer's open request. The write now runs the transport
+check first — `/sap/bc/adt/cts/transportchecks` lists the user's open
+requests that fit, the way Eclipse's dialog gets them — and picks: the
+object's own request from the lock, else the candidate already holding
+objects of the package (judged by TADIR over the request's object list),
+else the only candidate, else the newest; with none and transports
+enabled, it creates one named after the package and object. The check
+runs *before* the lock: it is stateless, and a stateless hop between LOCK
+and PUT retires the handle (#91) — the session-affinity tests caught the
+first version doing exactly that. A failed check leaves the choice to SAP
+as before; a failed creation fails the write. Every create/update result
+carries `transport` and `transportNote`. `--transport-choice off`,
+`SAP_TRANSPORT_CHOICE`, `transport_choice` in `.vsp.json`. Confirmed on
+A4H: a program created in a transportable package with no request named
+landed in the open request that already held one of that package.
+
+Not done from the same ask: merging requests and moving an object between
+them. ADT's organizer has no such resource (discovery: add-object,
+add-objects-from-package, modify, change-owner, new-task,
+sort-and-compress, release variants — nothing that removes an entry), and
+`TR_MERGE_REQUESTS`, `TR_APPEND_TO_COMM_OBJS_KEYS`, `TR_DELETE_COMM` are
+not remote-enabled (TFDIR.FMODE blank), so classic RFC cannot reach them.
+ZADT_VSP's `CALL FUNCTION` bridge could — its flat-string parameters would
+put a request number into the first field of the header structure — but
+the one test call of it was refused by the session's permission
+classifier, so nothing shipped untested. SE09 → Utilities → Reorganize →
+Merge Requests for now.
+
+Also new: `vsp adt request METHOD PATH` — one ADT request as given, over
+the client's session and CSRF token, for a resource vsp has no command for
+yet; it is what found the check's request list and the organizer's links.
+
 Still open from that session's notes, not done here: a function module
 whose TABLES parameter "declares no type" in the parser; a source line
 over 255 characters refused without a line number; `save_to_file` reading

--- a/agenda/AGENDA.md
+++ b/agenda/AGENDA.md
@@ -146,6 +146,12 @@ the one test call of it was refused by the session's permission
 classifier, so nothing shipped untested. SE09 → Utilities → Reorganize →
 Merge Requests for now.
 
+Left on A4H: two released local workbench requests from the probe, each
+holding the entry of a probe program deleted before it. Deleting them
+over ADT was refused — "contains locked objects", the entry's lock
+outliving the object, the same family as #166 — and releasing them was
+the way to close them out.
+
 Also new: `vsp adt request METHOD PATH` — one ADT request as given, over
 the client's session and CSRF token, for a resource vsp has no command for
 yet; it is what found the check's request list and the organizer's links.

--- a/cmd/vsp/adt_request.go
+++ b/cmd/vsp/adt_request.go
@@ -1,0 +1,102 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/url"
+	"os"
+	"strings"
+
+	"github.com/spf13/cobra"
+)
+
+var adtRequestCmd = &cobra.Command{
+	Use:   "request <METHOD> <PATH>",
+	Short: "Send one ADT request as given, over HTTP, with the session and CSRF token",
+	Long: `One ADT request, as given: for a resource vsp has no command for yet, or to
+see exactly what a resource answers. The session, the CSRF token and the
+response cache are the client's own; the status line and headers go to stderr,
+the body to stdout.
+
+  vsp adt request GET /sap/bc/adt/discovery
+  vsp adt request GET /sap/bc/adt/cts/transportrequests -q user=TESTUSER -H "Accept=application/vnd.sap.adt.transportorganizer.v1+xml"
+  vsp adt request POST /sap/bc/adt/cts/transportchecks --body check.xml -H "Content-Type=application/vnd.sap.as+xml; charset=UTF-8; dataname=com.sap.adt.transport.service.checkData"
+
+Anything but GET and HEAD is a write as far as the safety gates are concerned
+(--read-only refuses it), and --body - reads the body from stdin.`,
+	Args:         cobra.ExactArgs(2),
+	SilenceUsage: true,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		client, _, err := docsClient(cmd)
+		if err != nil {
+			return err
+		}
+		query := url.Values{}
+		for _, kv := range mustStringArray(cmd, "query") {
+			k, v, ok := strings.Cut(kv, "=")
+			if !ok {
+				return fmt.Errorf("query %q must be NAME=VALUE", kv)
+			}
+			query.Add(k, v)
+		}
+		accept, contentType := "", ""
+		for _, kv := range mustStringArray(cmd, "header") {
+			k, v, ok := strings.Cut(kv, "=")
+			if !ok {
+				return fmt.Errorf("header %q must be NAME=VALUE", kv)
+			}
+			switch strings.ToLower(strings.TrimSpace(k)) {
+			case "accept":
+				accept = v
+			case "content-type":
+				contentType = v
+			default:
+				return fmt.Errorf("header %q: only Accept and Content-Type can be set here", k)
+			}
+		}
+		var body []byte
+		if path, _ := cmd.Flags().GetString("body"); path == "-" {
+			if body, err = io.ReadAll(os.Stdin); err != nil {
+				return err
+			}
+		} else if path != "" {
+			if body, err = os.ReadFile(path); err != nil {
+				return err
+			}
+		}
+		stateful, _ := cmd.Flags().GetBool("stateful")
+		resp, err := client.RawRequest(context.Background(), strings.ToUpper(args[0]), args[1], query, accept, contentType, body, stateful)
+		if err != nil {
+			return err
+		}
+		fmt.Fprintf(os.Stderr, "HTTP %d\n", resp.StatusCode)
+		for k, vs := range resp.Headers {
+			for _, v := range vs {
+				fmt.Fprintf(os.Stderr, "%s: %s\n", k, v)
+			}
+		}
+		fmt.Fprintf(os.Stderr, "(%d bytes)\n", len(resp.Body))
+		if out, _ := cmd.Flags().GetString("output"); out != "" {
+			return os.WriteFile(out, resp.Body, 0o644)
+		}
+		_, err = os.Stdout.Write(resp.Body)
+		return err
+	},
+}
+
+func mustStringArray(cmd *cobra.Command, name string) []string {
+	v, _ := cmd.Flags().GetStringArray(name)
+	return v
+}
+
+func init() {
+	adtRequestCmd.Flags().StringArrayP("header", "H", nil, "Accept=... or Content-Type=... (repeatable)")
+	adtRequestCmd.Flags().StringArrayP("query", "q", nil, "NAME=VALUE query parameter (repeatable)")
+	adtRequestCmd.Flags().String("body", "", "File with the request body, or - for stdin")
+	adtRequestCmd.Flags().String("output", "", "Write the body to this file instead of stdout")
+	adtRequestCmd.Flags().Bool("stateful", false, "Send the request on the stateful session")
+	adtRequestCmd.Flags().String("lang", "", "")
+	_ = adtRequestCmd.Flags().MarkHidden("lang")
+	adtCmd.AddCommand(adtRequestCmd)
+}

--- a/cmd/vsp/cli.go
+++ b/cmd/vsp/cli.go
@@ -64,6 +64,7 @@ type systemParams struct {
 	TransportReadOnly       bool
 	AllowedTransports       []string
 	AllowTransportableEdits bool
+	TransportChoice         string
 	BlockFreeSQL            bool
 
 	Cache     bool
@@ -137,6 +138,7 @@ func resolveSystemParams(cmd *cobra.Command) (*systemParams, error) {
 			TransportReadOnly:       sys.TransportReadOnly || envFlag("SAP_TRANSPORT_READ_ONLY"),
 			AllowedTransports:       firstNonEmptyList(sys.AllowedTransports, splitList(os.Getenv("SAP_ALLOWED_TRANSPORTS"))),
 			AllowTransportableEdits: sys.AllowTransportableEdits || envFlag("SAP_ALLOW_TRANSPORTABLE_EDITS"),
+			TransportChoice:         firstNonEmpty(sys.TransportChoice, os.Getenv("SAP_TRANSPORT_CHOICE")),
 			BlockFreeSQL:            sys.BlockFreeSQL || envFlag("SAP_BLOCK_FREE_SQL"),
 			Cache:                   sys.Cache,
 			CachePath:               sys.CachePath,
@@ -194,6 +196,13 @@ func envFlag(name string) bool {
 }
 
 // firstNonEmptyList returns the configured list, falling back to the environment.
+func firstNonEmpty(configured, fromEnv string) string {
+	if strings.TrimSpace(configured) != "" {
+		return configured
+	}
+	return fromEnv
+}
+
 func firstNonEmptyList(configured, fromEnv []string) []string {
 	if len(configured) > 0 {
 		return configured
@@ -269,6 +278,9 @@ func buildClient(params *systemParams) (*adt.Client, error) {
 	}
 	if len(params.AllowedTransports) > 0 {
 		safety.AllowedTransports, restricted = params.AllowedTransports, true
+	}
+	if params.TransportChoice != "" {
+		safety.TransportChoice = params.TransportChoice
 	}
 	if params.AllowTransportableEdits {
 		safety.AllowTransportableEdits = true

--- a/cmd/vsp/devops.go
+++ b/cmd/vsp/devops.go
@@ -3239,6 +3239,12 @@ func runDeploy(cmd *cobra.Command, args []string) error {
 		if result.ObjectURL != "" {
 			fmt.Fprintf(os.Stderr, "URL: %s\n", result.ObjectURL)
 		}
+		if result.Transport != "" {
+			fmt.Fprintf(os.Stderr, "Transport: %s\n", result.Transport)
+		}
+		if result.TransportNote != "" {
+			fmt.Fprintf(os.Stderr, "  %s\n", result.TransportNote)
+		}
 		if result.Message != "" {
 			fmt.Fprintf(os.Stderr, "%s\n", result.Message)
 		}

--- a/cmd/vsp/main.go
+++ b/cmd/vsp/main.go
@@ -144,6 +144,7 @@ func init() {
 	rootCmd.Flags().BoolVar(&cfg.TransportReadOnly, "transport-read-only", false, "Only allow read operations on transports (list, get)")
 	rootCmd.Flags().StringSliceVar(&cfg.AllowedTransports, "allowed-transports", nil, "Restrict transport operations to specific transports (comma-separated, supports wildcards like A4HK*)")
 	rootCmd.Flags().BoolVar(&cfg.AllowTransportableEdits, "allow-transportable-edits", false, "Allow editing objects in transportable packages (requires transport parameter)")
+	rootCmd.Flags().StringVar(&cfg.TransportChoice, "transport-choice", "auto", "A write with no transport named: auto picks the object's own or an open request of yours that fits (and creates one with --enable-transports); off leaves it to SAP, which generates a request per write")
 
 	// Mode options
 	rootCmd.Flags().StringVar(&cfg.Mode, "mode", "hyperfocused", "Tool mode: hyperfocused (single universal SAP tool), focused (100 tools), or expert (147 tools)")
@@ -451,6 +452,11 @@ func resolveConfig(cmd *cobra.Command) {
 	}
 	if !cmd.Flags().Changed("allow-transportable-edits") {
 		cfg.AllowTransportableEdits = viper.GetBool("ALLOW_TRANSPORTABLE_EDITS")
+	}
+	if !cmd.Flags().Changed("transport-choice") {
+		if v := viper.GetString("TRANSPORT_CHOICE"); v != "" {
+			cfg.TransportChoice = v
+		}
 	}
 
 	// Feature configuration: flag > SAP_FEATURE_* env

--- a/internal/mcp/handlers_help.go
+++ b/internal/mcp/handlers_help.go
@@ -196,6 +196,12 @@ Writing needs a lock_handle from a lock taken first, and changes the system:
       selection text and TEXT-xxx the source uses but does not define. create PROGRAM also takes "texts".
       The written texts are activated in the same call; without that they stay an inactive version.
 
+A write to a transportable object with no "transport" named picks a request the way Eclipse's
+dialog would: the object's own, else your open request that already holds the package's objects,
+else the only one that fits, else the newest; with none and --enable-transports one is created.
+The result says which under "transport" and why under "transportNote". SAP no longer generates a
+"Generated Request for Change Recording" per write. --transport-choice off restores that.
+
 The description — SE38's title — of an existing object, without touching its source:
   SAP(action="edit", target="PROG ZDEMO_XFER", params={"type": "set_description", "description": "DPL snapshot transfer"})
       PROG, INCL, CLAS, INTF, FUGR, FUNC (with "parent"), TABL, DDLS; without "description" it reads the current one.

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -99,6 +99,7 @@ type Config struct {
 	TransportReadOnly       bool     // Only allow read operations on transports (list, get)
 	AllowedTransports       []string // Whitelist specific transports (supports wildcards like "A4HK*")
 	AllowTransportableEdits bool     // Allow editing objects that require transport requests
+	TransportChoice         string   // auto (default): pick a request for a write that names none; off: leave it to SAP
 
 	// Feature configuration (safety network)
 	// Values: "auto" (default, probe system), "on" (force enabled), "off" (force disabled)
@@ -191,6 +192,9 @@ func NewServer(cfg *Config) *Server {
 	}
 	if cfg.AllowTransportableEdits {
 		safety.AllowTransportableEdits = true
+	}
+	if cfg.TransportChoice != "" {
+		safety.TransportChoice = cfg.TransportChoice
 	}
 	opts = append(opts, adt.WithSafety(safety))
 

--- a/pkg/adt/config.go
+++ b/pkg/adt/config.go
@@ -191,6 +191,14 @@ func WithAllowedTransports(transports ...string) Option {
 	}
 }
 
+// WithTransportChoice sets how a write with no request named picks one:
+// "auto" (the default) or "off".
+func WithTransportChoice(mode string) Option {
+	return func(c *Config) {
+		c.Safety.TransportChoice = mode
+	}
+}
+
 // WithAllowTransportableEdits enables editing objects that require transport requests.
 // By default, only local objects ($TMP, $* packages) can be edited.
 // When enabled, users can provide transport parameters to EditSource/WriteSource.

--- a/pkg/adt/crud.go
+++ b/pkg/adt/crud.go
@@ -242,7 +242,10 @@ type CreateObjectOptions struct {
 	Description string              `json:"description"`
 	PackageName string              `json:"packageName"`
 	Transport   string              `json:"transport,omitempty"`
-	Responsible string              `json:"responsible,omitempty"`
+	// Chosen, when given, receives the request picked for a transportable
+	// object created with no Transport named — reused or created — and why.
+	Chosen      *TransportChoice `json:"-"`
+	Responsible string           `json:"responsible,omitempty"`
 	// For function modules - the function group name
 	ParentName string `json:"parentName,omitempty"`
 	// For packages - the software component (required for transportable packages)
@@ -642,6 +645,26 @@ func (c *Client) CreateObject(ctx context.Context, opts CreateObjectOptions) err
 		Transport: opts.Transport,
 	}); err != nil {
 		return err
+	}
+
+	// A transportable object with no request named: pick one the way the
+	// editor would, rather than let SAP generate a request per write.
+	if opts.Transport == "" && opts.ObjectType != ObjectTypePackage && opts.PackageName != "" && !strings.HasPrefix(opts.PackageName, "$") && c.config.Safety.TransportChoice != "off" {
+		if objectURL, uerr := c.buildObjectURLWithParent(opts.ObjectType, opts.Name, opts.ParentName); uerr == nil {
+			choice := c.planTransport(ctx, "", objectURL, opts.PackageName)
+			if choice.Err != nil {
+				return choice.Err
+			}
+			if choice.Transport != "" {
+				if err := c.checkTransportableEdit(choice.Transport, "CreateObject"); err != nil {
+					return err
+				}
+				opts.Transport = choice.Transport
+			}
+			if opts.Chosen != nil {
+				*opts.Chosen = *choice
+			}
+		}
 	}
 
 	// Package creation validation: local packages always allowed, transportable requires opt-in

--- a/pkg/adt/description.go
+++ b/pkg/adt/description.go
@@ -19,12 +19,13 @@ import (
 
 // DescriptionResult says what changed.
 type DescriptionResult struct {
-	ObjectURL string `json:"objectUrl"`
-	Old       string `json:"old"`
-	New       string `json:"new"`
-	Changed   bool   `json:"changed"`
-	Transport string `json:"transport,omitempty"`
-	Limit     int    `json:"limit,omitempty"`
+	ObjectURL     string `json:"objectUrl"`
+	Old           string `json:"old"`
+	New           string `json:"new"`
+	Changed       bool   `json:"changed"`
+	Transport     string `json:"transport,omitempty"`
+	TransportNote string `json:"transportNote,omitempty"`
+	Limit         int    `json:"limit,omitempty"`
 }
 
 var (
@@ -107,13 +108,14 @@ func (c *Client) SetDescription(ctx context.Context, objectType, name, parent, d
 		return res, nil
 	}
 
+	trPlan := c.planTransport(ctx, transport, objectURL, "")
 	lock, err := c.LockObject(ctx, objectURL, "MODIFY")
 	if err != nil {
 		return res, fmt.Errorf("locking %s: %w", objectURL, err)
 	}
 	unlockCtx := context.WithoutCancel(ctx)
 	defer func() { _ = c.UnlockObject(unlockCtx, objectURL, lock.LockHandle) }()
-	if res.Transport, err = c.resolveWriteTransport(transport, lock.CorrNr, "SetDescription"); err != nil {
+	if res.Transport, res.TransportNote, err = c.resolveWriteTransportFor(trPlan, transport, lock.CorrNr, "SetDescription"); err != nil {
 		return res, err
 	}
 	// Read again under the lock: the document is put back whole, so it has

--- a/pkg/adt/raw.go
+++ b/pkg/adt/raw.go
@@ -1,0 +1,27 @@
+package adt
+
+import (
+	"context"
+	"net/http"
+	"net/url"
+)
+
+// RawRequest sends one ADT request as given — method, path, query, headers,
+// body — through the client's transport, with its session, CSRF token and
+// cache, and returns the response as it came. It is the door for a resource
+// this package has no method for yet: exploration, and the odd one-off.
+func (c *Client) RawRequest(ctx context.Context, method, path string, query url.Values, accept, contentType string, body []byte, stateful bool) (*Response, error) {
+	if method != http.MethodGet && method != http.MethodHead {
+		if err := c.checkSafety(OpUpdate, "RawRequest "+method); err != nil {
+			return nil, err
+		}
+	}
+	return c.transport.Request(ctx, path, &RequestOptions{
+		Method:      method,
+		Query:       query,
+		Accept:      accept,
+		ContentType: contentType,
+		Body:        body,
+		Stateful:    stateful,
+	})
+}

--- a/pkg/adt/safety.go
+++ b/pkg/adt/safety.go
@@ -70,6 +70,13 @@ type SafetyConfig struct {
 	//   - User takes responsibility for transport management
 	// Use --allow-transportable-edits or SAP_ALLOW_TRANSPORTABLE_EDITS=true to enable
 	AllowTransportableEdits bool
+
+	// TransportChoice says what a write to a transportable object does when
+	// no request is named: "auto" (or empty) picks one the way the editor
+	// would — the object's own, else an open request of the user's that
+	// fits — and creates one when none does and transports are enabled;
+	// "off" leaves the choice to SAP, which generates a request per write.
+	TransportChoice string
 }
 
 // DefaultSafetyConfig returns a safe default configuration (read-only, no free SQL)

--- a/pkg/adt/textpool.go
+++ b/pkg/adt/textpool.go
@@ -384,6 +384,7 @@ func (c *Client) WriteTextPool(ctx context.Context, target TextPoolTarget, lang 
 		return plan, nil
 	}
 
+	trPlan := c.planTransport(ctx, transport, t.objectURL(), "")
 	lock, err := c.LockObject(ctx, t.resource(), "MODIFY")
 	if err != nil {
 		return plan, fmt.Errorf("locking the text pool of %s: %w", t, err)
@@ -397,8 +398,12 @@ func (c *Client) WriteTextPool(ctx context.Context, target TextPoolTarget, lang 
 		}
 	}
 	defer unlock()
-	if plan.Transport, err = c.resolveWriteTransport(transport, lock.CorrNr, "WriteTextPool"); err != nil {
+	var trNote string
+	if plan.Transport, trNote, err = c.resolveWriteTransportFor(trPlan, transport, lock.CorrNr, "WriteTextPool"); err != nil {
 		return plan, err
+	}
+	if trNote != "" {
+		plan.Notes = append(plan.Notes, trNote)
 	}
 
 	plan.Kinds = plan.Kinds[:0]

--- a/pkg/adt/transport_choice.go
+++ b/pkg/adt/transport_choice.go
@@ -1,0 +1,298 @@
+package adt
+
+import (
+	"context"
+	"encoding/xml"
+	"errors"
+	"fmt"
+	"net/http"
+	"strings"
+)
+
+// A write to a transportable object with no transport named used to leave
+// the choice to SAP, which answers with a request of its own — "Generated
+// Request for Change Recording" — one per write, so a day's work on one
+// feature ended up spread over three requests beside the one the developer
+// already had open. Eclipse does not do that: it asks the transport check
+// which of the user's open requests fit, and offers them. This does the
+// same, without the dialog: the open request that already holds this
+// package's objects wins, then the only candidate, then the newest; when
+// there is none, one is created and the result says so.
+
+// TransportCheck is what /sap/bc/adt/cts/transportchecks answers for one
+// object: whether a request is needed, and which of the user's open ones
+// fit.
+type TransportCheck struct {
+	Package    string
+	Recording  bool // a request is required
+	ObjectType string
+	ObjectName string
+	// Candidates are the user's modifiable requests the object could go
+	// into, as the check lists them.
+	Candidates []TransportCandidate
+	// LockedIn is the request the object is already locked in, when the
+	// check reports one.
+	LockedIn string
+	Messages []string
+}
+
+// TransportCandidate is one open request from the check.
+type TransportCandidate struct {
+	Number      string `json:"number"`
+	Owner       string `json:"owner"`
+	Description string `json:"description"`
+	Status      string `json:"status"`
+	Function    string `json:"function"`
+}
+
+// TransportChoice is the outcome: the request to write under and why.
+type TransportChoice struct {
+	Transport string `json:"transport,omitempty"`
+	// Reason says how the request was chosen — reused, created, or none
+	// needed — in words for the result.
+	Reason  string `json:"reason,omitempty"`
+	Created bool   `json:"created,omitempty"`
+	// Err is a creation that failed after the caller enabled it.
+	Err error `json:"-"`
+}
+
+var errTransportCreate = errors.New("creating a transport request failed")
+
+// CheckTransport runs the transport check for an object about to be
+// written. devClass may be empty for an existing object.
+func (c *Client) CheckTransport(ctx context.Context, objectURL, devClass, operation string) (*TransportCheck, error) {
+	if operation == "" {
+		operation = "I"
+	}
+	body := fmt.Sprintf(`<?xml version="1.0" encoding="utf-8"?>
+<asx:abap xmlns:asx="http://www.sap.com/abapxml" version="1.0">
+  <asx:values>
+    <DATA>
+      <DEVCLASS>%s</DEVCLASS>
+      <OPERATION>%s</OPERATION>
+      <URI>%s</URI>
+    </DATA>
+  </asx:values>
+</asx:abap>`, escapeXMLAttr(strings.ToUpper(devClass)), operation, escapeXMLAttr(objectURL))
+	resp, err := c.transport.Request(ctx, "/sap/bc/adt/cts/transportchecks", &RequestOptions{
+		Method:      http.MethodPost,
+		Body:        []byte(body),
+		ContentType: "application/vnd.sap.as+xml; charset=UTF-8; dataname=com.sap.adt.transport.service.checkData",
+		Accept:      "application/vnd.sap.as+xml;charset=UTF-8;dataname=com.sap.adt.transport.service.checkData",
+	})
+	if err != nil {
+		return nil, fmt.Errorf("transport check for %s: %w", objectURL, err)
+	}
+	return parseTransportCheck(resp.Body)
+}
+
+func parseTransportCheck(data []byte) (*TransportCheck, error) {
+	type header struct {
+		Trkorr     string `xml:"TRKORR"`
+		Function   string `xml:"TRFUNCTION"`
+		Status     string `xml:"TRSTATUS"`
+		User       string `xml:"AS4USER"`
+		Text       string `xml:"AS4TEXT"`
+		LockedTask string `xml:"LOCKED_TASK"`
+	}
+	type ctsRequest struct {
+		Header header `xml:"REQ_HEADER"`
+	}
+	type lock struct {
+		Header header `xml:"REQ_HEADER"`
+		Task   string `xml:"TASK"`
+		Trkorr string `xml:"TRKORR"`
+	}
+	type msg struct {
+		Text string `xml:"TEXT"`
+		Type string `xml:"SEVERITY"`
+	}
+	type dataType struct {
+		Object     string       `xml:"OBJECT"`
+		ObjectName string       `xml:"OBJECTNAME"`
+		DevClass   string       `xml:"DEVCLASS"`
+		TadirDevc  string       `xml:"TADIRDEVC"`
+		Recording  string       `xml:"RECORDING"`
+		Requests   []ctsRequest `xml:"REQUESTS>CTS_REQUEST"`
+		Locks      []lock       `xml:"LOCKS>CTS_OBJECT_LOCK"`
+		Messages   []msg        `xml:"MESSAGES>CTS_MESSAGE"`
+	}
+	type root struct {
+		Data dataType `xml:"values>DATA"`
+	}
+	var r root
+	if err := xml.Unmarshal([]byte(strings.ReplaceAll(string(data), "asx:", "")), &r); err != nil {
+		return nil, fmt.Errorf("parsing the transport check: %w", err)
+	}
+	d := r.Data
+	tc := &TransportCheck{Package: d.DevClass, Recording: d.Recording == "X", ObjectType: d.Object, ObjectName: d.ObjectName}
+	if tc.Package == "" {
+		tc.Package = d.TadirDevc
+	}
+	for _, q := range d.Requests {
+		h := q.Header
+		tc.Candidates = append(tc.Candidates, TransportCandidate{Number: h.Trkorr, Owner: h.User, Description: h.Text, Status: h.Status, Function: h.Function})
+	}
+	for _, l := range d.Locks {
+		switch {
+		case l.Header.Trkorr != "":
+			tc.LockedIn = l.Header.Trkorr
+		case l.Trkorr != "":
+			tc.LockedIn = l.Trkorr
+		}
+	}
+	for _, m := range d.Messages {
+		if strings.TrimSpace(m.Text) != "" {
+			tc.Messages = append(tc.Messages, strings.TrimSpace(m.Text))
+		}
+	}
+	return tc, nil
+}
+
+// chooseTransport picks the request a write with no transport named goes
+// under. The lock's own request comes first — an object already captured
+// stays where it is. Otherwise the check's candidates: the one that
+// already holds an object of this package, else the only one, else the
+// newest. With no candidate and recording on, a request is created,
+// named after the package and the object, and the choice says so.
+func (c *Client) chooseTransport(ctx context.Context, objectURL, devClass, lockCorrNr, description string) (*TransportChoice, error) {
+	if lockCorrNr != "" {
+		return &TransportChoice{Transport: lockCorrNr, Reason: "the request the object is already locked in"}, nil
+	}
+	op := "U"
+	if devClass != "" {
+		op = "I"
+	}
+	check, err := c.CheckTransport(ctx, objectURL, devClass, op)
+	if err != nil {
+		return nil, err
+	}
+	if !check.Recording {
+		return &TransportChoice{}, nil
+	}
+	if check.LockedIn != "" {
+		return &TransportChoice{Transport: check.LockedIn, Reason: "the request the object is already locked in"}, nil
+	}
+	open := check.Candidates[:0:0]
+	for _, cand := range check.Candidates {
+		if cand.Status == "" || cand.Status == "D" || cand.Status == "L" {
+			open = append(open, cand)
+		}
+	}
+	pkg := check.Package
+	if pkg == "" {
+		pkg = strings.ToUpper(devClass)
+	}
+	switch {
+	case len(open) == 1:
+		return &TransportChoice{Transport: open[0].Number, Reason: fmt.Sprintf("reused %s (%s): your only open request that fits", open[0].Number, open[0].Description)}, nil
+	case len(open) > 1:
+		// The one already holding this package's objects.
+		for _, cand := range open {
+			if pkg != "" && c.transportHoldsPackage(ctx, cand.Number, pkg) {
+				return &TransportChoice{Transport: cand.Number, Reason: fmt.Sprintf("reused %s (%s): it already holds objects of %s", cand.Number, cand.Description, pkg)}, nil
+			}
+		}
+		newest := open[0]
+		for _, cand := range open[1:] {
+			if cand.Number > newest.Number {
+				newest = cand
+			}
+		}
+		return &TransportChoice{Transport: newest.Number, Reason: fmt.Sprintf("reused %s (%s): the newest of %d open requests that fit; name transport to choose another", newest.Number, newest.Description, len(open))}, nil
+	}
+	if description == "" {
+		description = fmt.Sprintf("%s %s", pkg, check.ObjectName)
+	}
+	if !c.config.Safety.IsTransportWriteAllowed() {
+		return &TransportChoice{Reason: fmt.Sprintf("no open request of yours holds %s; SAP will generate one — name transport, or run with --enable-transports to have one created here", pkg)}, nil
+	}
+	number, err := c.CreateTransport(ctx, objectURL, description, pkg)
+	if err != nil {
+		return nil, fmt.Errorf("%w: no open request of yours fits %s: %v", errTransportCreate, pkg, err)
+	}
+	return &TransportChoice{Transport: number, Created: true, Reason: fmt.Sprintf("created request %s (%s): no open request of yours held %s", number, description, pkg)}, nil
+}
+
+// transportHoldsPackage reports whether a request carries an object of the
+// package, judged by TADIR — the request's object list names objects, not
+// packages.
+func (c *Client) transportHoldsPackage(ctx context.Context, number, pkg string) bool {
+	details, err := c.GetTransport(ctx, number)
+	if err != nil {
+		return false
+	}
+	var names []string
+	for _, o := range details.Objects {
+		if o.PgmID == "R3TR" || o.PgmID == "LIMU" {
+			names = append(names, "'"+sqlQuote(o.Name)+"'")
+		}
+	}
+	for _, t := range details.Tasks {
+		for _, o := range t.Objects {
+			if o.PgmID == "R3TR" || o.PgmID == "LIMU" {
+				names = append(names, "'"+sqlQuote(o.Name)+"'")
+			}
+		}
+	}
+	if len(names) == 0 {
+		return false
+	}
+	if len(names) > 200 {
+		names = names[:200]
+	}
+	res, err := c.RunQuery(ctx, fmt.Sprintf("SELECT COUNT(*) AS n FROM tadir WHERE devclass = '%s' AND obj_name IN (%s)", sqlQuote(pkg), strings.Join(names, ",")), 1)
+	if err != nil || res == nil || len(res.Rows) == 0 {
+		return false
+	}
+	return cell(res.Rows[0], "N") != "0" && cell(res.Rows[0], "N") != ""
+}
+
+// planTransport is the half of the choice that runs before the lock: the
+// check and, when transports are enabled and nothing fits, the creation.
+// It runs before the lock because it is a stateless request, and a
+// stateless hop between LOCK and PUT retires the lock handle (#91). A
+// check that fails is not a reason to refuse the write — the choice is
+// then left to SAP as it was — but a creation that fails is, since the
+// caller enabled it. nil when a request was named, or the choice is off.
+func (c *Client) planTransport(ctx context.Context, supplied, objectURL, devClass string) *TransportChoice {
+	if supplied != "" || c.config.Safety.TransportChoice == "off" {
+		return nil
+	}
+	choice, err := c.chooseTransport(ctx, objectURL, devClass, "", "")
+	if err != nil {
+		if errors.Is(err, errTransportCreate) {
+			return &TransportChoice{Err: err}
+		}
+		return &TransportChoice{Reason: "transport not chosen here (" + err.Error() + "); left to SAP"}
+	}
+	return choice
+}
+
+// resolveWriteTransportFor is resolveWriteTransport with the plan behind
+// it: the supplied request, else the lock's own, else the planned one.
+// The policy on transportable edits is applied to whatever was chosen, so
+// a request found or made cannot bypass the gate the caller would have
+// hit naming it. The reason comes back for the result.
+func (c *Client) resolveWriteTransportFor(plan *TransportChoice, supplied, lockCorrNr, opName string) (string, string, error) {
+	if supplied != "" || plan == nil {
+		tr, err := c.resolveWriteTransport(supplied, lockCorrNr, opName)
+		return tr, "", err
+	}
+	if plan.Err != nil {
+		return "", "", plan.Err
+	}
+	if lockCorrNr != "" {
+		if err := c.checkTransportableEdit(lockCorrNr, opName); err != nil {
+			return "", "", err
+		}
+		return lockCorrNr, "", nil
+	}
+	if plan.Transport == "" {
+		return "", plan.Reason, nil
+	}
+	if err := c.checkTransportableEdit(plan.Transport, opName); err != nil {
+		return "", "", err
+	}
+	return plan.Transport, plan.Reason, nil
+}

--- a/pkg/adt/transport_choice_test.go
+++ b/pkg/adt/transport_choice_test.go
@@ -1,0 +1,64 @@
+package adt
+
+import (
+	"context"
+	"testing"
+)
+
+func TestParseTransportCheck(t *testing.T) {
+	body := `<?xml version="1.0" encoding="utf-8"?><asx:abap version="1.0" xmlns:asx="http://www.sap.com/abapxml"><asx:values><DATA><PGMID>LIMU</PGMID><OBJECT>REPS</OBJECT><OBJECTNAME>ZDEMO_B</OBJECTNAME><OPERATION>I</OPERATION><DEVCLASS>ZDEMO</DEVCLASS><KORRFLAG>X</KORRFLAG><RESULT>S</RESULT><RECORDING>X</RECORDING><EXISTING_REQ_ONLY/><MESSAGES/><REQUESTS><CTS_REQUEST><REQ_HEADER><TRKORR>TR-EXAMPLE</TRKORR><TRFUNCTION>K</TRFUNCTION><TRSTATUS>D</TRSTATUS><AS4USER>TESTUSER</AS4USER><AS4TEXT>feature X</AS4TEXT><CLIENT>001</CLIENT></REQ_HEADER></CTS_REQUEST></REQUESTS><LOCKS/><TADIRDEVC>ZDEMO</TADIRDEVC></DATA></asx:values></asx:abap>`
+	tc, err := parseTransportCheck([]byte(body))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !tc.Recording || tc.Package != "ZDEMO" || tc.ObjectName != "ZDEMO_B" || len(tc.Candidates) != 1 {
+		t.Fatalf("check: %+v", tc)
+	}
+	if c := tc.Candidates[0]; c.Number != "TR-EXAMPLE" || c.Status != "D" || c.Description != "feature X" || c.Owner != "TESTUSER" {
+		t.Errorf("candidate: %+v", c)
+	}
+	local, err := parseTransportCheck([]byte(`<asx:abap xmlns:asx="x"><asx:values><DATA><DEVCLASS>$TMP</DEVCLASS><RECORDING/><REQUESTS/></DATA></asx:values></asx:abap>`))
+	if err != nil || local.Recording || len(local.Candidates) != 0 {
+		t.Errorf("local: %+v %v", local, err)
+	}
+}
+
+func TestResolveWriteTransportFor(t *testing.T) {
+	c := &Client{config: &Config{Safety: SafetyConfig{AllowTransportableEdits: true}}}
+	// Named: as given, no note.
+	if tr, note, err := c.resolveWriteTransportFor(&TransportChoice{Transport: "TR-EXAMPLE"}, "TR-NAMED", "", "op"); tr != "TR-NAMED" || note != "" || err != nil {
+		t.Errorf("named: %q %q %v", tr, note, err)
+	}
+	// The lock's own request beats the plan.
+	if tr, note, err := c.resolveWriteTransportFor(&TransportChoice{Transport: "TR-PLANNED", Reason: "reused"}, "", "TR-LOCKED", "op"); tr != "TR-LOCKED" || note != "" || err != nil {
+		t.Errorf("locked: %q %q %v", tr, note, err)
+	}
+	// The plan, with its reason.
+	if tr, note, err := c.resolveWriteTransportFor(&TransportChoice{Transport: "TR-PLANNED", Reason: "reused it"}, "", "", "op"); tr != "TR-PLANNED" || note != "reused it" || err != nil {
+		t.Errorf("planned: %q %q %v", tr, note, err)
+	}
+	// Nothing chosen: the reason still comes back, no request.
+	if tr, note, err := c.resolveWriteTransportFor(&TransportChoice{Reason: "left to SAP"}, "", "", "op"); tr != "" || note != "left to SAP" || err != nil {
+		t.Errorf("none: %q %q %v", tr, note, err)
+	}
+	// A failed creation is the write's error.
+	if _, _, err := c.resolveWriteTransportFor(&TransportChoice{Err: errTransportCreate}, "", "", "op"); err == nil {
+		t.Error("creation failure swallowed")
+	}
+	// The policy applies to a planned request as to a named one.
+	gated := &Client{config: &Config{Safety: SafetyConfig{}}}
+	if _, _, err := gated.resolveWriteTransportFor(&TransportChoice{Transport: "TR-PLANNED"}, "", "", "op"); err == nil {
+		t.Error("planned request bypassed the transportable-edit gate")
+	}
+	// nil plan: the old behaviour.
+	if tr, _, err := c.resolveWriteTransportFor(nil, "", "TR-LOCKED", "op"); tr != "TR-LOCKED" || err != nil {
+		t.Errorf("nil plan: %q %v", tr, err)
+	}
+	off := &Client{config: &Config{Safety: SafetyConfig{TransportChoice: "off"}}}
+	if off.planTransport(context.Background(), "", "/sap/bc/adt/programs/programs/zdemo", "") != nil {
+		t.Error("off still planned")
+	}
+	if c.planTransport(context.Background(), "TR-NAMED", "/sap/bc/adt/programs/programs/zdemo", "") != nil {
+		t.Error("a named request still planned")
+	}
+}

--- a/pkg/adt/workflows.go
+++ b/pkg/adt/workflows.go
@@ -12,12 +12,16 @@ import (
 
 // WriteProgramResult represents the result of writing a program.
 type WriteProgramResult struct {
-	Success      bool                       `json:"success"`
-	ProgramName  string                     `json:"programName"`
-	ObjectURL    string                     `json:"objectUrl"`
-	SyntaxErrors []SyntaxCheckResult        `json:"syntaxErrors,omitempty"`
-	Activation   *ActivationResult          `json:"activation,omitempty"`
-	Message      string                     `json:"message,omitempty"`
+	// Transport is the request the write went under, and TransportNote
+	// says how it was chosen when the caller named none.
+	Transport     string              `json:"transport,omitempty"`
+	TransportNote string              `json:"transportNote,omitempty"`
+	Success       bool                `json:"success"`
+	ProgramName   string              `json:"programName"`
+	ObjectURL     string              `json:"objectUrl"`
+	SyntaxErrors  []SyntaxCheckResult `json:"syntaxErrors,omitempty"`
+	Activation    *ActivationResult   `json:"activation,omitempty"`
+	Message       string              `json:"message,omitempty"`
 }
 
 // WriteProgram performs Lock -> SyntaxCheck -> UpdateSource -> Unlock -> Activate workflow.
@@ -63,6 +67,7 @@ func (c *Client) WriteProgram(ctx context.Context, programName string, source st
 	result.SyntaxErrors = syntaxErrors // Include warnings if any
 
 	// Step 2: Lock the object
+	trPlan := c.planTransport(ctx, transport, objectURL, "")
 	lock, err := c.LockObject(ctx, objectURL, "MODIFY")
 	if err != nil {
 		result.Message = fmt.Sprintf("Failed to lock object: %v", err)
@@ -79,11 +84,13 @@ func (c *Client) WriteProgram(ctx context.Context, programName string, source st
 	// Reuse the request the object is already bound to when the caller supplied no
 	// transport, so an already-captured object is not rejected with a spurious 409
 	// (issue #144). Re-checks transportable-edit policy on the resolved request.
-	transport, err = c.resolveWriteTransport(transport, lock.CorrNr, "WriteProgram")
+	var trNote string
+	transport, trNote, err = c.resolveWriteTransportFor(trPlan, transport, lock.CorrNr, "WriteProgram")
 	if err != nil {
 		result.Message = fmt.Sprintf("Transportable-edit check failed: %v", err)
 		return result, nil
 	}
+	result.Transport, result.TransportNote = transport, trNote
 
 	// Step 3: Update source
 	err = c.UpdateSource(ctx, sourceURL, source, lock.LockHandle, transport)
@@ -202,12 +209,16 @@ func (c *Client) WriteInclude(ctx context.Context, includeName string, source st
 
 // WriteClassResult represents the result of writing a class.
 type WriteClassResult struct {
-	Success      bool                       `json:"success"`
-	ClassName    string                     `json:"className"`
-	ObjectURL    string                     `json:"objectUrl"`
-	SyntaxErrors []SyntaxCheckResult        `json:"syntaxErrors,omitempty"`
-	Activation   *ActivationResult          `json:"activation,omitempty"`
-	Message      string                     `json:"message,omitempty"`
+	// Transport is the request the write went under, and TransportNote
+	// says how it was chosen when the caller named none.
+	Transport     string              `json:"transport,omitempty"`
+	TransportNote string              `json:"transportNote,omitempty"`
+	Success       bool                `json:"success"`
+	ClassName     string              `json:"className"`
+	ObjectURL     string              `json:"objectUrl"`
+	SyntaxErrors  []SyntaxCheckResult `json:"syntaxErrors,omitempty"`
+	Activation    *ActivationResult   `json:"activation,omitempty"`
+	Message       string              `json:"message,omitempty"`
 }
 
 // WriteClass performs Lock -> SyntaxCheck -> UpdateSource -> Unlock -> Activate workflow for classes.
@@ -252,6 +263,7 @@ func (c *Client) WriteClass(ctx context.Context, className string, source string
 	result.SyntaxErrors = syntaxErrors
 
 	// Step 2: Lock
+	trPlan := c.planTransport(ctx, transport, objectURL, "")
 	lock, err := c.LockObject(ctx, objectURL, "MODIFY")
 	if err != nil {
 		result.Message = fmt.Sprintf("Failed to lock object: %v", err)
@@ -267,11 +279,13 @@ func (c *Client) WriteClass(ctx context.Context, className string, source string
 	// Reuse the request the object is already bound to when the caller supplied no
 	// transport, so an already-captured object is not rejected with a spurious 409
 	// (issue #144). Re-checks transportable-edit policy on the resolved request.
-	transport, err = c.resolveWriteTransport(transport, lock.CorrNr, "WriteClass")
+	var trNote string
+	transport, trNote, err = c.resolveWriteTransportFor(trPlan, transport, lock.CorrNr, "WriteClass")
 	if err != nil {
 		result.Message = fmt.Sprintf("Transportable-edit check failed: %v", err)
 		return result, nil
 	}
+	result.Transport, result.TransportNote = transport, trNote
 
 	// Step 3: Update source
 	err = c.UpdateSource(ctx, sourceURL, source, lock.LockHandle, transport)
@@ -308,12 +322,16 @@ func (c *Client) WriteClass(ctx context.Context, className string, source string
 
 // CreateProgramResult represents the result of creating a program.
 type CreateProgramResult struct {
-	Success      bool                `json:"success"`
-	ProgramName  string              `json:"programName"`
-	ObjectURL    string              `json:"objectUrl"`
-	SyntaxErrors []SyntaxCheckResult `json:"syntaxErrors,omitempty"`
-	Activation   *ActivationResult   `json:"activation,omitempty"`
-	Message      string              `json:"message,omitempty"`
+	// Transport is the request the write went under, and TransportNote
+	// says how it was chosen when the caller named none.
+	Transport     string              `json:"transport,omitempty"`
+	TransportNote string              `json:"transportNote,omitempty"`
+	Success       bool                `json:"success"`
+	ProgramName   string              `json:"programName"`
+	ObjectURL     string              `json:"objectUrl"`
+	SyntaxErrors  []SyntaxCheckResult `json:"syntaxErrors,omitempty"`
+	Activation    *ActivationResult   `json:"activation,omitempty"`
+	Message       string              `json:"message,omitempty"`
 }
 
 // CreateAndActivateProgram creates a new program with source code and activates it.
@@ -341,17 +359,23 @@ func (c *Client) CreateAndActivateProgram(ctx context.Context, programName strin
 	}
 
 	// Step 1: Create the program
+	var chosen TransportChoice
 	err := c.CreateObject(ctx, CreateObjectOptions{
 		ObjectType:  ObjectTypeProgram,
 		Name:        programName,
 		Description: description,
 		PackageName: packageName,
 		Transport:   transport,
+		Chosen:      &chosen,
 	})
 	if err != nil {
 		result.Message = fmt.Sprintf("Failed to create program: %v", err)
 		return result, nil
 	}
+	if chosen.Transport != "" {
+		transport = chosen.Transport
+	}
+	result.Transport, result.TransportNote = transport, chosen.Reason
 
 	// The gate above accepted packageName, and CreateObject gated it a second
 	// time before asking SAP to put the program there — so the program's

--- a/pkg/adt/workflows_deploy.go
+++ b/pkg/adt/workflows_deploy.go
@@ -12,15 +12,19 @@ import (
 
 // DeployResult contains the result of a file deployment operation.
 type DeployResult struct {
-	ObjectURL    string   `json:"objectUrl"`
-	ObjectName   string   `json:"objectName"`
-	ObjectType   string   `json:"objectType"`
-	FilePath     string   `json:"filePath"`
-	Success      bool     `json:"success"`
-	Created      bool     `json:"created"` // true if created, false if updated
-	SyntaxErrors []string `json:"syntaxErrors,omitempty"`
-	Errors       []string `json:"errors,omitempty"`
-	Message      string   `json:"message,omitempty"`
+	// Transport is the request the write went under, and TransportNote
+	// says how it was chosen when the caller named none.
+	Transport     string   `json:"transport,omitempty"`
+	TransportNote string   `json:"transportNote,omitempty"`
+	ObjectURL     string   `json:"objectUrl"`
+	ObjectName    string   `json:"objectName"`
+	ObjectType    string   `json:"objectType"`
+	FilePath      string   `json:"filePath"`
+	Success       bool     `json:"success"`
+	Created       bool     `json:"created"` // true if created, false if updated
+	SyntaxErrors  []string `json:"syntaxErrors,omitempty"`
+	Errors        []string `json:"errors,omitempty"`
+	Message       string   `json:"message,omitempty"`
 }
 
 // CreateFromFile creates a new ABAP object from a file and activates it.
@@ -53,6 +57,7 @@ func (c *Client) CreateFromFile(ctx context.Context, filePath, packageName, tran
 	source := string(sourceBytes)
 
 	// 3. Create object
+	var chosen TransportChoice
 	err = c.CreateObject(ctx, CreateObjectOptions{
 		ObjectType:  info.ObjectType,
 		Name:        info.ObjectName,
@@ -60,7 +65,12 @@ func (c *Client) CreateFromFile(ctx context.Context, filePath, packageName, tran
 		Description: info.Description,
 		PackageName: packageName,
 		Transport:   transport,
+		Chosen:      &chosen,
 	})
+	if chosen.Transport != "" {
+		transport = chosen.Transport
+	}
+	trNote := chosen.Reason
 	if err != nil {
 		return &DeployResult{
 			FilePath:   filePath,
@@ -210,8 +220,9 @@ func (c *Client) CreateFromFile(ctx context.Context, filePath, packageName, tran
 		ObjectName: info.ObjectName,
 		ObjectType: string(info.ObjectType),
 		Success:    true,
-		Created:    true,
-		Message:    fmt.Sprintf("Successfully created and activated %s %s from %s", info.ObjectType, info.ObjectName, filePath),
+		Transport:  transport, TransportNote: trNote,
+		Created: true,
+		Message: fmt.Sprintf("Successfully created and activated %s %s from %s", info.ObjectType, info.ObjectName, filePath),
 	}, nil
 }
 
@@ -304,6 +315,7 @@ func (c *Client) UpdateFromFile(ctx context.Context, filePath, transport string)
 	}
 
 	// 5. Lock object
+	trPlan := c.planTransport(ctx, transport, objectURL, "")
 	lockResult, err := c.LockObject(ctx, objectURL, "MODIFY")
 	if err != nil {
 		return &DeployResult{
@@ -328,7 +340,8 @@ func (c *Client) UpdateFromFile(ctx context.Context, filePath, transport string)
 	// Reuse the request the object is already bound to when the caller supplied no
 	// transport, so an already-captured object is not rejected with a spurious 409
 	// (issue #144). Re-checks transportable-edit policy on the resolved request.
-	transport, err = c.resolveWriteTransport(transport, lockResult.CorrNr, "UpdateFromFile")
+	var trNote string
+	transport, trNote, err = c.resolveWriteTransportFor(trPlan, transport, lockResult.CorrNr, "UpdateFromFile")
 	if err != nil {
 		return &DeployResult{
 			FilePath:   filePath,
@@ -443,8 +456,9 @@ func (c *Client) UpdateFromFile(ctx context.Context, filePath, transport string)
 		ObjectName: info.ObjectName,
 		ObjectType: objTypeStr,
 		Success:    true,
-		Created:    false,
-		Message:    fmt.Sprintf("Successfully updated and activated %s %s from %s", objTypeStr, info.ObjectName, filePath),
+		Transport:  transport, TransportNote: trNote,
+		Created: false,
+		Message: fmt.Sprintf("Successfully updated and activated %s %s from %s", objTypeStr, info.ObjectName, filePath),
 	}, nil
 }
 

--- a/pkg/adt/workflows_edit.go
+++ b/pkg/adt/workflows_edit.go
@@ -10,6 +10,10 @@ import (
 
 // EditSourceResult represents the result of editing source code.
 type EditSourceResult struct {
+	// Transport is the request the write went under, and TransportNote
+	// says how it was chosen when the caller named none.
+	Transport      string            `json:"transport,omitempty"`
+	TransportNote  string            `json:"transportNote,omitempty"`
 	Success        bool              `json:"success"`
 	ObjectURL      string            `json:"objectUrl"`
 	ObjectName     string            `json:"objectName"`
@@ -380,6 +384,7 @@ func (c *Client) EditSourceWithOptions(ctx context.Context, objectURL, oldString
 	if isClassInclude && parentClassURL != "" {
 		lockURL = parentClassURL
 	}
+	trPlan := c.planTransport(ctx, opts.Transport, lockURL, "")
 	lockResult, err := c.LockObject(ctx, lockURL, "MODIFY")
 	if err != nil {
 		result.Message = fmt.Sprintf("Failed to lock object: %v", err)
@@ -397,11 +402,12 @@ func (c *Client) EditSourceWithOptions(ctx context.Context, objectURL, oldString
 	// Reuse the request the object is already bound to when the caller supplied no
 	// transport, so an already-captured object is not rejected with a spurious 409
 	// (issue #144). Re-checks transportable-edit policy on the resolved request.
-	tr, err := c.resolveWriteTransport(opts.Transport, lockResult.CorrNr, "EditSource")
+	tr, trNote, err := c.resolveWriteTransportFor(trPlan, opts.Transport, lockResult.CorrNr, "EditSource")
 	if err != nil {
 		result.Message = fmt.Sprintf("Transportable-edit check failed: %v", err)
 		return result, nil
 	}
+	result.Transport, result.TransportNote = tr, trNote
 
 	// 6. Update source
 	if isClassInclude && className != "" {

--- a/pkg/adt/workflows_source.go
+++ b/pkg/adt/workflows_source.go
@@ -161,16 +161,20 @@ type WriteSourceOptions struct {
 
 // WriteSourceResult represents the result of WriteSource operation
 type WriteSourceResult struct {
-	Success      bool                `json:"success"`
-	ObjectType   string              `json:"objectType"`
-	ObjectName   string              `json:"objectName"`
-	ObjectURL    string              `json:"objectUrl"`
-	Mode         string              `json:"mode"`             // "created" or "updated"
-	Method       string              `json:"method,omitempty"` // Method name if method-level update
-	SyntaxErrors []SyntaxCheckResult `json:"syntaxErrors,omitempty"`
-	Activation   *ActivationResult   `json:"activation,omitempty"`
-	TestResults  *UnitTestResult     `json:"testResults,omitempty"` // For CLAS with TestSource
-	Message      string              `json:"message,omitempty"`
+	// Transport is the request the write went under, and TransportNote
+	// says how it was chosen when the caller named none.
+	Transport     string              `json:"transport,omitempty"`
+	TransportNote string              `json:"transportNote,omitempty"`
+	Success       bool                `json:"success"`
+	ObjectType    string              `json:"objectType"`
+	ObjectName    string              `json:"objectName"`
+	ObjectURL     string              `json:"objectUrl"`
+	Mode          string              `json:"mode"`             // "created" or "updated"
+	Method        string              `json:"method,omitempty"` // Method name if method-level update
+	SyntaxErrors  []SyntaxCheckResult `json:"syntaxErrors,omitempty"`
+	Activation    *ActivationResult   `json:"activation,omitempty"`
+	TestResults   *UnitTestResult     `json:"testResults,omitempty"` // For CLAS with TestSource
+	Message       string              `json:"message,omitempty"`
 }
 
 // WriteSourceResultError converts a logical WriteSource failure into an error
@@ -566,11 +570,17 @@ func (c *Client) writeSourceCreate(ctx context.Context, objectType, name, source
 		if objectType == "BDEF" {
 			createOpts.Source = source // BDEF requires source embedded in creation request
 		}
+		var chosen TransportChoice
+		createOpts.Chosen = &chosen
 		err := c.CreateObject(ctx, createOpts)
 		if err != nil {
 			result.Message = fmt.Sprintf("Failed to create %s: %v", objectType, err)
 			return result, nil
 		}
+		if chosen.Transport != "" {
+			opts.Transport = chosen.Transport
+		}
+		result.Transport, result.TransportNote = opts.Transport, chosen.Reason
 
 		// Created in opts.Package, which CreateObject checked against the
 		// whitelist. Both branches below (BDEF shell fill, DDLS/SRVD source
@@ -852,6 +862,7 @@ func (c *Client) writeSourceUpdate(ctx context.Context, objectType, name, source
 			}
 
 			// Lock for test update
+			trPlan := c.planTransport(ctx, opts.Transport, objectURL, "")
 			lock, err := c.LockObject(ctx, objectURL, "MODIFY")
 			if err != nil {
 				result.Message += fmt.Sprintf(" (Warning: Failed to lock for test update: %v)", err)
@@ -861,7 +872,7 @@ func (c *Client) writeSourceUpdate(ctx context.Context, objectType, name, source
 			// Reuse the request the object is already bound to when the caller supplied no
 			// transport, so an already-captured object is not rejected with a spurious 409
 			// (issue #144). Re-checks transportable-edit policy on the resolved request.
-			testTransport, resolveErr := c.resolveWriteTransport(opts.Transport, lock.CorrNr, "WriteSource(testclasses)")
+			testTransport, _, resolveErr := c.resolveWriteTransportFor(trPlan, opts.Transport, lock.CorrNr, "WriteSource(testclasses)")
 			if resolveErr != nil {
 				// The compensating unlock is the only place a leak can be
 				// observed, so its failure is reported rather than dropped.
@@ -943,6 +954,7 @@ func (c *Client) writeSourceUpdate(ctx context.Context, objectType, name, source
 		result.SyntaxErrors = syntaxErrors
 
 		// Lock
+		trPlan := c.planTransport(ctx, opts.Transport, objectURL, "")
 		lock, err := c.LockObject(ctx, objectURL, "MODIFY")
 		if err != nil {
 			result.Message = fmt.Sprintf("Failed to lock object: %v", err)
@@ -958,11 +970,12 @@ func (c *Client) writeSourceUpdate(ctx context.Context, objectType, name, source
 		// Reuse the request the object is already bound to when the caller supplied no
 		// transport, so an already-captured object is not rejected with a spurious 409
 		// (issue #144). Re-checks transportable-edit policy on the resolved request.
-		transport, err := c.resolveWriteTransport(opts.Transport, lock.CorrNr, "WriteSource(INTF)")
+		transport, trNote, err := c.resolveWriteTransportFor(trPlan, opts.Transport, lock.CorrNr, "WriteSource(INTF)")
 		if err != nil {
 			result.Message = fmt.Sprintf("Transportable-edit check failed: %v", err)
 			return result, nil
 		}
+		result.Transport, result.TransportNote = transport, trNote
 
 		// Update
 		err = c.UpdateSource(ctx, sourceURL, source, lock.LockHandle, transport)
@@ -1047,6 +1060,7 @@ func (c *Client) writeSourceUpdate(ctx context.Context, objectType, name, source
 		result.SyntaxErrors = syntaxErrors
 
 		// Lock
+		trPlan := c.planTransport(ctx, opts.Transport, objectURL, "")
 		lock, err := c.LockObject(ctx, objectURL, "MODIFY")
 		if err != nil {
 			result.Message = fmt.Sprintf("Failed to lock object: %v", err)
@@ -1062,11 +1076,12 @@ func (c *Client) writeSourceUpdate(ctx context.Context, objectType, name, source
 		// Reuse the request the object is already bound to when the caller supplied no
 		// transport, so an already-captured object is not rejected with a spurious 409
 		// (issue #144). Re-checks transportable-edit policy on the resolved request.
-		transport, err := c.resolveWriteTransport(opts.Transport, lock.CorrNr, fmt.Sprintf("WriteSource(%s)", objectType))
+		transport, trNote, err := c.resolveWriteTransportFor(trPlan, opts.Transport, lock.CorrNr, fmt.Sprintf("WriteSource(%s)", objectType))
 		if err != nil {
 			result.Message = fmt.Sprintf("Transportable-edit check failed: %v", err)
 			return result, nil
 		}
+		result.Transport, result.TransportNote = transport, trNote
 
 		// Update
 		err = c.UpdateSource(ctx, sourceURL, source, lock.LockHandle, transport)
@@ -1197,6 +1212,7 @@ func (c *Client) writeClassMethodUpdate(ctx context.Context, className, methodNa
 	result.SyntaxErrors = syntaxErrors
 
 	// Lock
+	trPlan := c.planTransport(ctx, transport, objectURL, "")
 	lock, err := c.LockObject(ctx, objectURL, "MODIFY")
 	if err != nil {
 		result.Message = fmt.Sprintf("Failed to lock class: %v", err)
@@ -1212,11 +1228,13 @@ func (c *Client) writeClassMethodUpdate(ctx context.Context, className, methodNa
 	// Reuse the request the object is already bound to when the caller supplied no
 	// transport, so an already-captured object is not rejected with a spurious 409
 	// (issue #144). Re-checks transportable-edit policy on the resolved request.
-	transport, err = c.resolveWriteTransport(transport, lock.CorrNr, "WriteSource(method)")
+	var trNote string
+	transport, trNote, err = c.resolveWriteTransportFor(trPlan, transport, lock.CorrNr, "WriteSource(method)")
 	if err != nil {
 		result.Message = fmt.Sprintf("Transportable-edit check failed: %v", err)
 		return result, nil
 	}
+	result.Transport, result.TransportNote = transport, trNote
 
 	// Update
 	sourceURL := objectURL + "/source/main"

--- a/pkg/config/systems.go
+++ b/pkg/config/systems.go
@@ -62,6 +62,7 @@ type SystemConfig struct {
 	TransportReadOnly       bool     `json:"transport_read_only,omitempty"`
 	AllowedTransports       []string `json:"allowed_transports,omitempty"`
 	AllowTransportableEdits bool     `json:"allow_transportable_edits,omitempty"`
+	TransportChoice         string   `json:"transport_choice,omitempty"` // auto (default) or off
 	BlockFreeSQL            bool     `json:"block_free_sql,omitempty"`
 }
 


### PR DESCRIPTION
Asked for by a second session after a day on which the MCP, given no `transport`, let SAP generate two "Generated Request for Change Recording" beside the developer's open request.

## What
- Before locking, a write to a transportable object with no transport named runs `/sap/bc/adt/cts/transportchecks` — the resource Eclipse's transport dialog is fed from — and picks: the object's own request (lock `corrNr`), else the open request already holding objects of the package (TADIR over the request's object list), else the only candidate, else the newest. With none and `--enable-transports`, a request is created, named after the package and object.
- The check runs before the lock on purpose: it is stateless, and a stateless hop between LOCK and PUT retires the handle (#91). The session-affinity tests caught the first version doing exactly that.
- A failed check leaves the choice to SAP as before; a failed creation fails the write. The transportable-edit gate and the transport whitelist apply to whatever was chosen, so a found or created request cannot bypass them.
- Every create/update result carries `transport` and, when chosen here, `transportNote`. `--transport-choice off` / `SAP_TRANSPORT_CHOICE=off` / `transport_choice` in `.vsp.json` restore the old behaviour.
- `vsp adt request METHOD PATH`: one ADT request as given over the client's session and CSRF token.

## Not here
Merging requests and moving an object between them: ADT's organizer has no such resource (discovery lists add-object, modify, change-owner, new-task, sort-and-compress, release variants — nothing that removes an entry), and `TR_MERGE_REQUESTS` / `TR_APPEND_TO_COMM_OBJS_KEYS` / `TR_DELETE_COMM` are not remote-enabled. SE09 for now; noted in the agenda.

## Verified
- `go test ./...` green; new tests for the check parser and the choice logic (named > locked > planned, policy applied to a planned request, `off`).
- Live on A4H: two open requests holding objects of package `Z`; a program created there with no request named landed in one of them, not in a generated request. Probe objects removed afterwards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0162uKF31Qeg14pwMwj4dmts
