### PR TITLE
fix(adt): keep ADT headers across redirects and drop stale cookies on ICMENOSESSION

### DIFF
--- a/pkg/adt/config.go
+++ b/pkg/adt/config.go
@@ -290,17 +290,37 @@ func (c *Config) NewHTTPClient() *http.Client {
 		Timeout:   c.Timeout,
 	}
 
-	// Preserve Authorization header across redirects.
-	// Go's default strips it per RFC 7235 §4.2, but SAP BTP/Cloud
-	// authentication flows require it to survive redirects.
-	// Without this, BTP users get 401 even though curl works (issue #90).
+	// Preserve ADT-critical headers across redirects.
+	//
+	// Go's default strips Authorization / WWW-Authenticate / Cookie / Cookie2
+	// on cross-origin redirects per RFC 7235 §4.2 — SAP BTP/Cloud SAML flows
+	// need Authorization back, otherwise the IdP dance drops it and the user
+	// gets 401 even though curl works (issue #90).
+	//
+	// Custom headers like X-CSRF-Token and X-sap-adt-sessiontype are *not*
+	// in Go's sensitive-headers list, so Go technically forwards them by
+	// default. We re-set them explicitly anyway for two reasons:
+	//   - defensive: guards against any Go version or middleware tweak that
+	//     decides to strip custom headers on its own;
+	//   - intent: makes it obvious in the code that these two headers are
+	//     load-bearing for the lock→write→unlock ADT sequence. If either
+	//     goes missing across a redirect, the second hop hits SAP with a
+	//     fresh (stateless) session-type or a missing CSRF token, and the
+	//     lock handle / mutation is rejected.
 	client.CheckRedirect = func(req *http.Request, via []*http.Request) error {
 		if len(via) >= 10 {
 			return fmt.Errorf("too many redirects")
 		}
 		if len(via) > 0 {
-			if auth := via[0].Header.Get("Authorization"); auth != "" {
+			first := via[0]
+			if auth := first.Header.Get("Authorization"); auth != "" {
 				req.Header.Set("Authorization", auth)
+			}
+			if csrf := first.Header.Get("X-CSRF-Token"); csrf != "" {
+				req.Header.Set("X-CSRF-Token", csrf)
+			}
+			if st := first.Header.Get("X-sap-adt-sessiontype"); st != "" {
+				req.Header.Set("X-sap-adt-sessiontype", st)
 			}
 		}
 		return nil

--- a/pkg/adt/config_test.go
+++ b/pkg/adt/config_test.go
@@ -1,6 +1,7 @@
 package adt
 
 import (
+	"context"
 	"net/http"
 	"testing"
 	"time"
@@ -200,5 +201,83 @@ func TestSessionTypes(t *testing.T) {
 	}
 	if SessionKeep != "keep" {
 		t.Errorf("SessionKeep = %v, want keep", SessionKeep)
+	}
+}
+
+// TestNewHTTPClient_CheckRedirectPreservesADTHeaders verifies that the
+// HTTP client's CheckRedirect callback re-sets headers that are
+// load-bearing for the ADT lock→write→unlock sequence across redirects:
+//   - Authorization: Go strips this by default on cross-origin redirects
+//     (sensitive header per RFC 7235). Without restoration, SAML flows get
+//     401 even when curl works (issue #90).
+//   - X-CSRF-Token: mutation requests are rejected as CSRF-violating if
+//     this disappears mid-sequence.
+//   - X-sap-adt-sessiontype: the lock handle is bound to a stateful
+//     session; if a redirect hop lands stateless, the subsequent PUT
+//     can't find the lock and gets HTTP 423.
+//
+// Go's default forwards custom headers on same-origin redirects, but this
+// test pins the behaviour explicitly so future refactors can't silently
+// drop them.
+func TestNewHTTPClient_CheckRedirectPreservesADTHeaders(t *testing.T) {
+	cfg := NewConfig("https://sap.example.com:44300", "user", "pass")
+	client := cfg.NewHTTPClient()
+
+	if client.CheckRedirect == nil {
+		t.Fatal("CheckRedirect must be set")
+	}
+
+	// Build the "via" chain: the original request that carries the ADT
+	// headers we expect to be re-set on the redirect target.
+	orig, err := http.NewRequestWithContext(context.Background(), http.MethodPost,
+		"https://sap.example.com:44300/sap/bc/adt/oo/classes/ZFOO?_action=LOCK", nil)
+	if err != nil {
+		t.Fatalf("NewRequest(orig): %v", err)
+	}
+	orig.Header.Set("Authorization", "Basic dXNlcjpwYXNz")
+	orig.Header.Set("X-CSRF-Token", "ABC123==")
+	orig.Header.Set("X-sap-adt-sessiontype", "stateful")
+
+	// The redirect target that Go would follow — initially without any
+	// of the ADT headers (simulating Go having stripped them cross-origin).
+	next, err := http.NewRequestWithContext(context.Background(), http.MethodPost,
+		"https://sap.example.com:44300/sap/bc/adt/follow", nil)
+	if err != nil {
+		t.Fatalf("NewRequest(next): %v", err)
+	}
+
+	if err := client.CheckRedirect(next, []*http.Request{orig}); err != nil {
+		t.Fatalf("CheckRedirect returned error: %v", err)
+	}
+
+	if got := next.Header.Get("Authorization"); got != "Basic dXNlcjpwYXNz" {
+		t.Errorf("Authorization = %q, want preserved from initial request (issue #90)", got)
+	}
+	if got := next.Header.Get("X-CSRF-Token"); got != "ABC123==" {
+		t.Errorf("X-CSRF-Token = %q, want preserved — mutation requests need it to survive redirect hops", got)
+	}
+	if got := next.Header.Get("X-sap-adt-sessiontype"); got != "stateful" {
+		t.Errorf("X-sap-adt-sessiontype = %q, want preserved — lock handles are bound to a stateful session (issue #88)", got)
+	}
+}
+
+// TestNewHTTPClient_CheckRedirectHonoursLimit guards the 10-redirect cap
+// that CheckRedirect enforces to prevent infinite loops.
+func TestNewHTTPClient_CheckRedirectHonoursLimit(t *testing.T) {
+	cfg := NewConfig("https://sap.example.com:44300", "user", "pass")
+	client := cfg.NewHTTPClient()
+
+	if client.CheckRedirect == nil {
+		t.Fatal("CheckRedirect must be set")
+	}
+
+	next, _ := http.NewRequestWithContext(context.Background(), http.MethodGet, "https://sap.example.com:44300/", nil)
+	via := make([]*http.Request, 10)
+	for i := range via {
+		via[i], _ = http.NewRequestWithContext(context.Background(), http.MethodGet, "https://sap.example.com:44300/", nil)
+	}
+
+	if err := client.CheckRedirect(next, via); err == nil {
+		t.Error("CheckRedirect must return an error on the 10th redirect")
 	}
 }

--- a/pkg/adt/http.go
+++ b/pkg/adt/http.go
@@ -15,6 +15,97 @@ import (
 	"time"
 )
 
+// httpTraceEnabled reports whether the VSP_HTTP_TRACE env var requests raw
+// HTTP request/response dumps to stderr. Diagnostic-only — never leaves the
+// binary switched on by default, and Authorization / Cookie values are
+// redacted so the dump is safe to paste.
+func httpTraceEnabled() bool {
+	v := os.Getenv("VSP_HTTP_TRACE")
+	return v == "1" || strings.EqualFold(v, "true")
+}
+
+const httpTraceBodyLimit = 4096
+
+var (
+	traceOutMu sync.Mutex
+	traceOut   io.Writer
+)
+
+// traceWriter returns where HTTP trace lines go: the file named by
+// VSP_TRACE_LOG (appended, created on first use), otherwise stderr. An MCP
+// server's stderr is rarely visible, so the file is what makes the trace
+// readable there.
+func traceWriter() io.Writer {
+	traceOutMu.Lock()
+	defer traceOutMu.Unlock()
+	if traceOut != nil {
+		return traceOut
+	}
+	if path := strings.TrimSpace(os.Getenv("VSP_TRACE_LOG")); path != "" {
+		if f, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o600); err == nil {
+			traceOut = f
+			return traceOut
+		}
+	}
+	traceOut = os.Stderr
+	return traceOut
+}
+
+func traceHTTPRequest(req *http.Request, body []byte) {
+	if !httpTraceEnabled() {
+		return
+	}
+	w := traceWriter()
+	fmt.Fprintf(w, "\n>>> HTTP %s %s %s\n", time.Now().UTC().Format(time.RFC3339Nano), req.Method, req.URL.String())
+	for k, vs := range req.Header {
+		for _, v := range vs {
+			if strings.EqualFold(k, "Authorization") || strings.EqualFold(k, "Cookie") {
+				v = "[REDACTED]"
+			}
+			fmt.Fprintf(w, ">>> %s: %s\n", k, v)
+		}
+	}
+	if len(body) > 0 {
+		trunc := body
+		if len(trunc) > httpTraceBodyLimit {
+			trunc = trunc[:httpTraceBodyLimit]
+		}
+		fmt.Fprintf(w, ">>> body (%d bytes):\n%s\n", len(body), string(trunc))
+		if len(body) > httpTraceBodyLimit {
+			fmt.Fprintf(w, ">>> ... (truncated)\n")
+		}
+	}
+}
+
+func traceHTTPResponse(resp *http.Response, body []byte) {
+	if !httpTraceEnabled() || resp == nil {
+		return
+	}
+	w := traceWriter()
+	fmt.Fprintf(w, "<<< HTTP %d %s\n", resp.StatusCode, resp.Status)
+	for k, vs := range resp.Header {
+		for _, v := range vs {
+			if strings.EqualFold(k, "Set-Cookie") {
+				if i := strings.Index(v, "="); i > 0 {
+					v = v[:i] + "=[REDACTED]"
+				}
+			}
+			fmt.Fprintf(w, "<<< %s: %s\n", k, v)
+		}
+	}
+	if len(body) > 0 {
+		trunc := body
+		if len(trunc) > httpTraceBodyLimit {
+			trunc = trunc[:httpTraceBodyLimit]
+		}
+		fmt.Fprintf(w, "<<< body (%d bytes):\n%s\n", len(body), string(trunc))
+		if len(body) > httpTraceBodyLimit {
+			fmt.Fprintf(w, "<<< ... (truncated)\n")
+		}
+	}
+	fmt.Fprintln(w)
+}
+
 // HTTPDoer is an interface for executing HTTP requests.
 // This abstraction allows for easy testing with mock implementations.
 type HTTPDoer interface {
@@ -183,6 +274,7 @@ func (t *Transport) request(ctx context.Context, path string, opts *RequestOptio
 	t.addCookies(req)
 
 	// Execute request
+	traceHTTPRequest(req, opts.Body)
 	resp, err := t.httpClient.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("executing request: %w", err)
@@ -194,6 +286,7 @@ func (t *Transport) request(ctx context.Context, path string, opts *RequestOptio
 	if err != nil {
 		return nil, fmt.Errorf("reading response body: %w", err)
 	}
+	traceHTTPResponse(resp, body)
 	t.adoptServerCookies(resp)
 
 	// The same expiry reaches a plain read as a successful-looking response that
@@ -245,6 +338,12 @@ func (t *Transport) request(ctx context.Context, path string, opts *RequestOptio
 			// Clear cached CSRF token and session ID
 			t.setCSRFToken("")
 			t.setSessionID("")
+			// Drop the stale sap-contextid / SAP_SESSIONID cookies too: the
+			// stateless activation that ended the context on the SAP side left
+			// them in the jar, and every retry that re-sends them is answered
+			// with ICMENOSESSION again — including the /core/discovery probe
+			// that is supposed to open the fresh session.
+			t.resetCookieJar()
 			// Fetch new CSRF token (this establishes a new session)
 			if err := t.fetchCSRFTokenFor(ctx, opts.Stateful); err != nil {
 				return nil, fmt.Errorf("refreshing session after timeout: %w", err)
@@ -314,6 +413,7 @@ func (t *Transport) retryRequest(ctx context.Context, path string, opts *Request
 		req.Header.Set("X-sap-adt-sessiontype", "stateful")
 	}
 
+	traceHTTPRequest(req, opts.Body)
 	resp, err := t.httpClient.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("executing retry request: %w", err)
@@ -324,6 +424,7 @@ func (t *Transport) retryRequest(ctx context.Context, path string, opts *Request
 	if err != nil {
 		return nil, fmt.Errorf("reading response body: %w", err)
 	}
+	traceHTTPResponse(resp, body)
 
 	if resp.StatusCode >= 400 {
 		return nil, &APIError{
@@ -456,6 +557,7 @@ func (t *Transport) probeCSRFToken(ctx context.Context, method string, stateful 
 		req.Header.Set("X-sap-adt-sessiontype", "stateful")
 	}
 
+	traceHTTPRequest(req, nil)
 	resp, err := t.httpClient.Do(req)
 	if err != nil {
 		return "", 0, false, fmt.Errorf("executing request: %w", err)
@@ -463,6 +565,7 @@ func (t *Transport) probeCSRFToken(ctx context.Context, method string, stateful 
 	defer resp.Body.Close()
 	// Drain the body so the connection can be reused.
 	_, _ = io.Copy(io.Discard, resp.Body)
+	traceHTTPResponse(resp, nil)
 	t.adoptServerCookies(resp)
 
 	return resp.Header.Get("X-CSRF-Token"), resp.StatusCode, t.redirectedAwayFromSAP(resp), nil


### PR DESCRIPTION
## What

Parts 3 and 4 of #108, rebased onto current `main` as requested, plus the HTTP trace that found them.

1. **CheckRedirect re-sets `X-CSRF-Token` and `X-sap-adt-sessiontype`** from the first request, next to the existing `Authorization` restoration. Go forwards custom headers on redirects by default, but nothing pins that, and both headers are load-bearing for lock → write → unlock: without the session type the second hop lands stateless and SAP answers 423 for the lock handle; without the token the mutation is refused as a CSRF violation. Two regression tests in `config_test.go` pin the behaviour.
2. **`resetCookieJar()` in the session-expiry recovery** of `Transport.Request`, before the token is fetched again. A long-running MCP server hit `400 ICMENOSESSION` on every request after the first lock/write/unlock/activate cycle: the stateless activation ended the stateful context, the jar kept the `sap-contextid` set during it, and every retry — including the `/core/discovery` probe meant to open a fresh session — re-sent the dead identifier. `resetCookieJar` already exists on `main` for the re-authentication path; this uses it for the ICMENOSESSION path too.
3. **`VSP_HTTP_TRACE=1`** dumps requests and responses (Authorization and Cookie values redacted, bodies truncated at 4 KiB). **`VSP_TRACE_LOG=<file>`** writes the dump to a file — an MCP server's stderr is rarely visible, so the file is what makes the trace usable there. Both are off by default.

## Why the trace is part of this PR

It is the tool that produced both findings. The recorded sequence behind (2):

```
POST …?_action=LOCK                        → 200   stateful
PUT  …/source/main                         → 200   stateful
POST …?_action=UNLOCK                      → 200   stateful
POST /sap/bc/adt/activation                → 200   stateless (ends the context)
POST /sap/bc/adt/repository/nodestructure  → 400   ICMENOSESSION, six Set-Cookie: sap-contextid=…
HEAD /sap/bc/adt/core/discovery            → 400   ICMENOSESSION      (stuck)
```

## Tests

`go build ./...`, `go vet` and `go test ./pkg/adt ./internal/mcp ./cmd/vsp` are green. Verified live against an ABAP 7.57 system reached through the SAP Business Application Studio destination proxy.

## Related

#209 (`fix/session-holding-proxy-contextid-guard`) is stacked on this branch: it relies on the recovery from (2) and traces its own probe with (3). Please review that PR by its second commit only.
