### PR TITLE
feat(transport): ask the organizer tree for status and type explicitly

### DIFF
--- a/MCP_USAGE.md
+++ b/MCP_USAGE.md
@@ -122,6 +122,23 @@ flowchart TD
 
 ---
 
+### Transports
+
+`GetUserTransports` / `ListTransports` (hyperfocused: `SAP(action="system", params={"type": "get_user_transports" | "list_transports", ...})`) read the transport organizer tree, `GET /sap/bc/adt/cts/transportrequests`. Defaults: `request_type` `KWT` (workbench, customizing, transport of copies), `request_status` `DR` (modifiable and released), `targets` true, `source` `auto`.
+
+Why the defaults matter: without `requestStatus` the organizer answers with released requests of the last two weeks only, so a listing that sends the user alone looks empty of modifiable transports. Always let vsp send both parameters, or set them yourself.
+
+`source` selects where the listing comes from:
+
+| source | behaviour |
+|---|---|
+| `auto` (default) | organizer tree with explicit parameters, then the saved search configuration, then E070/E07T — the first source with requests wins; the answer names it and lists every fallback in `notes` |
+| `params` | organizer tree with explicit parameters only |
+| `config` | organizer tree through the saved Transport Organizer search configuration, as Eclipse does; the configuration decides the filters and the user (`config_uri` picks one explicitly) |
+| `sql` | E070/E07T directly; the only source for user `*` |
+
+`released_from`/`released_to` (YYYYMMDD) widen the released window. Each request carries `bucket` (`modifiable`/`released`) and, when the tree groups by target, `project`.
+
 ## Tool Selection Decision Tree
 
 ```mermaid

--- a/README_TOOLS.md
+++ b/README_TOOLS.md
@@ -225,7 +225,7 @@ Solves token limit problem for large files:
 | `CreateTransport` | Create transport request | Expert |
 | `GetTransportInfo` | Get transport details | Expert |
 | `ReleaseTransport` | Release transport | Expert |
-| `GetUserTransports` | List user's transports | Expert |
+| `GetUserTransports` | List a user's transports: workbench/customizing, modifiable/released, grouped by target and CTS project. Parameters `request_type` (KWT), `request_status` (DR), `released_from`/`released_to`, `targets`, `source` (auto/params/config/sql), `config_uri` | Expert |
 | `GetInactiveObjects` | List inactive objects | Expert |
 
 ---

--- a/cmd/vsp/devops.go
+++ b/cmd/vsp/devops.go
@@ -426,11 +426,21 @@ Examples:
 var transportListCmd = &cobra.Command{
 	Use:   "list",
 	Short: "List transport requests",
-	Long: `List transport requests for the current user.
+	Long: `List transport requests of a user: workbench and customizing, modifiable
+and released by default.
+
+The listing is read from GET /sap/bc/adt/cts/transportrequests with explicit
+requestType and requestStatus (without them the organizer answers with
+released requests only), falling back to the saved Transport Organizer
+search configuration and then to the E070/E07T tables. The source that
+answered is reported on stderr.
 
 Examples:
   vsp transport list
-  vsp transport list --user DEVELOPER`,
+  vsp transport list --user DEVELOPER
+  vsp transport list --status D                      # modifiable only
+  vsp transport list --source config                 # as Eclipse: saved search configuration
+  vsp transport list --status R --released-from 20260101 --released-to 20261231`,
 	RunE: runTransportList,
 }
 
@@ -557,7 +567,14 @@ func init() {
 	deployCmd.Flags().String("transport", "", "Transport request number")
 
 	// Transport list flags
-	transportListCmd.Flags().String("user", "", "Filter by user (default: current user, '*' for every user)")
+	transportListCmd.Flags().String("user", "", "Filter by user (default: current user, '*' for every user — source sql only)")
+	transportListCmd.Flags().String("type", "", "Request types: letters of K (workbench), W (customizing), T (transport of copies); default KWT")
+	transportListCmd.Flags().String("status", "", "Request statuses: letters of D (modifiable), R (released); default DR")
+	transportListCmd.Flags().String("released-from", "", "YYYYMMDD; with --released-to bounds the released requests (default: last 14 days)")
+	transportListCmd.Flags().String("released-to", "", "YYYYMMDD; see --released-from")
+	transportListCmd.Flags().String("source", "", "auto (default), params, config or sql; see 'vsp transport list --help'")
+	transportListCmd.Flags().String("config-uri", "", "Search configuration for --source config (default: the one saved for the user)")
+	transportListCmd.Flags().Bool("no-targets", false, "Do not group by transport target and CTS project")
 
 	// Install flags
 	installZadtVspCmd.Flags().String("package", "$ZADT_VSP", "Target package for ZADT_VSP objects")
@@ -3280,26 +3297,50 @@ func runTransportList(cmd *cobra.Command, args []string) error {
 	}
 
 	user, _ := cmd.Flags().GetString("user")
+	requestType, _ := cmd.Flags().GetString("type")
+	requestStatus, _ := cmd.Flags().GetString("status")
+	releasedFrom, _ := cmd.Flags().GetString("released-from")
+	releasedTo, _ := cmd.Flags().GetString("released-to")
+	source, _ := cmd.Flags().GetString("source")
+	configURI, _ := cmd.Flags().GetString("config-uri")
+	noTargets, _ := cmd.Flags().GetBool("no-targets")
 
 	ctx := context.Background()
-	transports, err := client.ListTransports(ctx, user)
+	res, err := client.QueryTransports(ctx, adt.TransportQuery{
+		User:            user,
+		RequestTypes:    requestType,
+		RequestStatuses: requestStatus,
+		ReleasedFrom:    releasedFrom,
+		ReleasedTo:      releasedTo,
+		Source:          source,
+		ConfigURI:       configURI,
+		Targets:         !noTargets,
+	})
 	if err != nil {
 		return fmt.Errorf("listing transports failed: %w", err)
 	}
+	fmt.Fprintf(os.Stderr, "source: %s; %s\n", res.Source, res.Query.Describe())
+	if res.ConfigURI != "" {
+		fmt.Fprintf(os.Stderr, "search configuration: %s\n", res.ConfigURI)
+	}
+	for _, n := range res.Notes {
+		fmt.Fprintf(os.Stderr, "note: %s\n", n)
+	}
 
+	transports := adt.FlattenTransports(res.Transports)
 	if len(transports) == 0 {
 		fmt.Println("No transport requests found.")
 		return nil
 	}
 
-	fmt.Printf("%-12s %-12s %-8s %-10s %s\n", "NUMBER", "OWNER", "STATUS", "TYPE", "DESCRIPTION")
-	fmt.Println(strings.Repeat("-", 80))
+	fmt.Printf("%-12s %-12s %-8s %-10s %-11s %s\n", "NUMBER", "OWNER", "STATUS", "TYPE", "BUCKET", "DESCRIPTION")
+	fmt.Println(strings.Repeat("-", 92))
 	for _, t := range transports {
 		status := t.Status
 		if t.StatusText != "" {
 			status = t.StatusText
 		}
-		fmt.Printf("%-12s %-12s %-8s %-10s %s\n", t.Number, t.Owner, status, t.Type, t.Description)
+		fmt.Printf("%-12s %-12s %-8s %-10s %-11s %s\n", t.Number, t.Owner, status, t.Type, t.Bucket, t.Description)
 	}
 	fmt.Printf("\n%d transport(s)\n", len(transports))
 	return nil

--- a/docs/adr/006-transport-organizer-explicit-filters.md
+++ b/docs/adr/006-transport-organizer-explicit-filters.md
@@ -1,0 +1,68 @@
+# ADR-006: Transport Organizer Tree — Ask for Status and Type Explicitly
+
+**Date:** 2026-09-08
+**Status:** ACCEPTED
+**Context:** `GetUserTransports` / `ListTransports` / `vsp transport list` on systems where the organizer tree answered with released requests only
+
+---
+
+## Summary
+
+vsp reads transport listings from `GET /sap/bc/adt/cts/transportrequests` and now always sends
+`requestType` and `requestStatus`, defaulting to `KWT` and `DR`. A `source` parameter selects the
+organizer tree with explicit parameters, the organizer tree through the saved Transport Organizer
+search configuration (what Eclipse ADT does), or the E070/E07T tables; `auto` tries them in that
+order and reports which one answered.
+
+## Problem
+
+On an ABAP 7.57 system the listing showed one released request and none of the user's modifiable
+ones, while Eclipse showed all of them. The old E070/E07T fallback had masked this: the previous
+parser found no request in a tree without a `modifiable` bucket, fell back to SQL, and the SQL
+listed the modifiable ones. The generic tree parser (#111, #140) finds the released request, skips
+the fallback, and exposes the gap.
+
+## Findings (backend, verified on 7.57)
+
+`CL_CTS_ADT_RES_APP` registers the collection, `CL_CTS_ADT_TM_RES_COLL_CONT` answers `GET`.
+ADT discovery advertises only `{?targets}`, but the handler reads:
+
+- `requestType` — letters of K (workbench), W (customizing), T (transport of copies)
+- `requestStatus` — letters of D (modifiable), R (released)
+- `user` (default sy-uname), `targetuser`, `targets`, `releasedFromDate`, `releasedToDate` (YYYYMMDD)
+- deprecated `req_cat`, `status`
+
+or, when `configUri` is present, everything from the saved search configuration
+(`/searchconfiguration/configurations/<id>`, properties WorkbenchRequests, CustomizingRequests,
+TransportOfCopies, Modifiable, Released, User, DateFilter, FromDate, ToDate); `user` is then ignored.
+
+Without `requestStatus` the handler assembles the selection criteria for modifiable requests but
+processes the hits only inside a block that requires a `D` in the status list. The block is skipped,
+and only released requests of the last 14 days come back. Sending `requestType=KWT&requestStatus=DR`
+returns the full tree for any user.
+
+## Decision
+
+1. `TransportQuery` in `pkg/adt` carries user, request types, statuses, released window, targets,
+   source and config URI. `withDefaults` fills `KWT` / `DR`; both tools and the CLI use it.
+2. `source`: `auto` (default) → `params` → `config` → `sql`, first source with requests wins.
+   Fallbacks and deviations are returned as `notes`; the source used is part of every answer.
+3. `config` picks the configuration whose `User` property matches the requested user. When none
+   matches, the first configuration is used and the answer says whose it is — the listing then
+   follows that configuration, not the user asked for.
+4. `ListTransports` lists modifiable and released rows by default (`request_status=D` restores the
+   old modifiable-only behaviour). Rows carry `bucket` and `project`.
+5. The SQL fallback filters by the requested types and statuses and reads E07T in the session
+   language instead of English only.
+6. The endpoint contract — parameters, the pitfall, the sibling resources — is documented in
+   `pkg/adt/transport_query.go`, the tool descriptions, `MCP_USAGE.md`, `README_TOOLS.md` and the
+   CLI help.
+
+## Consequences
+
+- One request answers the common case; the configuration round trip happens only on demand or as
+  a fallback.
+- Consumers of `ListTransports` see released rows too; anything that picks a transport to write
+  into must filter on `bucket == modifiable` (or ask with `request_status=D`).
+- The user-defaulting behaviour of the backend (sy-uname) is kept: a connection without a
+  configured user name still gets its own transports from the tree.

--- a/docs/cli-guide.md
+++ b/docs/cli-guide.md
@@ -335,8 +335,11 @@ vsp deploy zcl_test.clas.abap '$TMP'
 vsp deploy zreport.prog.abap '$TMP' --transport A4HK900001
 
 # Transport management
-vsp transport list
+vsp transport list                                  # modifiable + released (KWT/DR), source auto
 vsp transport list --user DEVELOPER
+vsp transport list --status D                       # modifiable only
+vsp transport list --source config                  # through the saved search configuration, as Eclipse
+vsp transport list --status R --released-from 20260101 --released-to 20261231
 vsp transport get A4HK900001
 
 # Install components to SAP

--- a/internal/mcp/handlers_help.go
+++ b/internal/mcp/handlers_help.go
@@ -460,11 +460,16 @@ Info:
 
 Transports:
   SAP(action="system", params={"type": "list_transports"})
+      defaults: request_type KWT, request_status DR, source auto (organizer tree → search configuration → E070/E07T)
+  SAP(action="system", params={"type": "list_transports", "request_status": "D"})        - modifiable only
+  SAP(action="system", params={"type": "list_transports", "source": "config"})           - as Eclipse: saved search configuration
+  SAP(action="system", params={"type": "list_transports", "request_status": "R", "released_from": "20260101", "released_to": "20261231"})
   SAP(action="system", params={"type": "get_transport", "transport": "A4HK900001"})
   SAP(action="system", params={"type": "create_transport", "description": "...", "package": "$TMP"})
   SAP(action="system", params={"type": "release_transport", "transport": "A4HK900001"})
   SAP(action="system", params={"type": "delete_transport", "transport": "A4HK900001"})
   SAP(action="system", params={"type": "get_user_transports", "user_name": "DEVELOPER"})
+      same parameters as list_transports (request_type, request_status, released_from/to, targets, source, config_uri)
   SAP(action="system", params={"type": "get_transport_info", "object_url": "...", "dev_class": "$TMP"})
 
 Git/abapGit:

--- a/internal/mcp/handlers_transport.go
+++ b/internal/mcp/handlers_transport.go
@@ -41,26 +41,58 @@ func (s *Server) routeTransportAction(ctx context.Context, action, objectType, o
 
 // --- Transport Management Handlers ---
 
-func (s *Server) handleGetUserTransports(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-	userName, ok := request.GetArguments()["user_name"].(string)
-	if !ok || userName == "" {
-		return newToolResultError("user_name is required"), nil
+// transportQueryFromArgs reads the shared listing parameters of
+// get_user_transports and list_transports. userKey names the parameter that
+// carries the user, which the two tools spell differently.
+func transportQueryFromArgs(args map[string]any, userKey string) adt.TransportQuery {
+	q := adt.TransportQuery{
+		User:            getStringParam(args, userKey),
+		RequestTypes:    getStringParam(args, "request_type"),
+		RequestStatuses: getStringParam(args, "request_status"),
+		ReleasedFrom:    getStringParam(args, "released_from"),
+		ReleasedTo:      getStringParam(args, "released_to"),
+		Source:          getStringParam(args, "source"),
+		ConfigURI:       getStringParam(args, "config_uri"),
+		Targets:         true,
 	}
+	if targets, ok := getBoolParam(args, "targets"); ok {
+		q.Targets = targets
+	}
+	return q
+}
 
-	transports, err := s.adtClient.GetUserTransports(ctx, userName)
+// transportListingHeader is the first line of a listing: whom it is for,
+// where it came from and which filters applied.
+func transportListingHeader(res *adt.TransportQueryResult) string {
+	user := res.Query.User
+	if user == "" {
+		user = "the connection user"
+	}
+	header := fmt.Sprintf("Transports for user %s (source: %s; %s)", user, res.Source, res.Query.Describe())
+	if res.ConfigURI != "" {
+		header += fmt.Sprintf("\nSearch configuration: %s", res.ConfigURI)
+	}
+	for _, n := range res.Notes {
+		header += "\nNote: " + n
+	}
+	return header
+}
+
+func (s *Server) handleGetUserTransports(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	args := request.GetArguments()
+	res, err := s.adtClient.QueryUserTransports(ctx, transportQueryFromArgs(args, "user_name"))
 	if err != nil {
 		return newToolResultError(fmt.Sprintf("GetUserTransports failed: %v", err)), nil
 	}
 
-	// Format output
 	var sb strings.Builder
-	fmt.Fprintf(&sb, "Transports for user %s:\n\n", strings.ToUpper(userName))
+	sb.WriteString(transportListingHeader(res))
+	sb.WriteString("\n\n")
 
+	transports := res.Transports
 	if len(transports.Workbench) > 0 {
 		sb.WriteString("=== Workbench Requests ===\n")
-		for _, tr := range transports.Workbench {
-			formatTransportRequest(&sb, &tr)
-		}
+		formatTransportBuckets(&sb, transports.Workbench)
 	} else {
 		sb.WriteString("No workbench requests found.\n")
 	}
@@ -69,9 +101,7 @@ func (s *Server) handleGetUserTransports(ctx context.Context, request mcp.CallTo
 
 	if len(transports.Customizing) > 0 {
 		sb.WriteString("=== Customizing Requests ===\n")
-		for _, tr := range transports.Customizing {
-			formatTransportRequest(&sb, &tr)
-		}
+		formatTransportBuckets(&sb, transports.Customizing)
 	} else {
 		sb.WriteString("No customizing requests found.\n")
 	}
@@ -79,11 +109,38 @@ func (s *Server) handleGetUserTransports(ctx context.Context, request mcp.CallTo
 	return mcp.NewToolResultText(sb.String()), nil
 }
 
+// formatTransportBuckets prints modifiable requests before released ones,
+// each group under its own heading, so a D and an R are never mistaken.
+func formatTransportBuckets(sb *strings.Builder, requests []adt.TransportRequest) {
+	for _, bucket := range []struct{ key, title string }{
+		{"modifiable", "--- Modifiable ---"},
+		{"released", "--- Released ---"},
+		{"", "--- Other ---"},
+	} {
+		var group []adt.TransportRequest
+		for _, tr := range requests {
+			if tr.Bucket == bucket.key {
+				group = append(group, tr)
+			}
+		}
+		if len(group) == 0 {
+			continue
+		}
+		fmt.Fprintf(sb, "%s\n", bucket.title)
+		for i := range group {
+			formatTransportRequest(sb, &group[i])
+		}
+	}
+}
+
 func formatTransportRequest(sb *strings.Builder, tr *adt.TransportRequest) {
 	fmt.Fprintf(sb, "\n%s - %s\n", tr.Number, tr.Description)
 	fmt.Fprintf(sb, "  Owner: %s, Status: %s", tr.Owner, tr.Status)
 	if tr.Target != "" {
 		fmt.Fprintf(sb, ", Target: %s", tr.Target)
+	}
+	if tr.Project != "" {
+		fmt.Fprintf(sb, ", Project: %s", tr.Project)
 	}
 	sb.WriteString("\n")
 
@@ -214,23 +271,26 @@ func (s *Server) handleExecuteABAP(ctx context.Context, request mcp.CallToolRequ
 }
 
 func (s *Server) handleListTransports(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-	// Check safety config for transport operations
-	if err := s.adtClient.Safety().CheckTransport("", "ListTransports", false); err != nil {
-		return newToolResultError(err.Error()), nil
-	}
-
-	user, _ := request.GetArguments()["user"].(string)
-
-	transports, err := s.adtClient.ListTransports(ctx, user)
+	args := request.GetArguments()
+	res, err := s.adtClient.QueryTransports(ctx, transportQueryFromArgs(args, "user"))
 	if err != nil {
 		return newToolResultError(fmt.Sprintf("ListTransports failed: %v", err)), nil
 	}
 
-	if len(transports) == 0 {
-		return mcp.NewToolResultText("No modifiable transports found."), nil
+	rows := adt.FlattenTransports(res.Transports)
+	if len(rows) == 0 {
+		return mcp.NewToolResultText(transportListingHeader(res) + "\n\nNo transport requests found."), nil
 	}
 
-	jsonBytes, err := json.MarshalIndent(transports, "", "  ")
+	out := struct {
+		Source     string                 `json:"source"`
+		ConfigURI  string                 `json:"configUri,omitempty"`
+		Query      adt.TransportQuery     `json:"query"`
+		Notes      []string               `json:"notes,omitempty"`
+		Transports []adt.TransportSummary `json:"transports"`
+	}{res.Source, res.ConfigURI, res.Query, res.Notes, rows}
+
+	jsonBytes, err := json.MarshalIndent(out, "", "  ")
 	if err != nil {
 		return newToolResultError(fmt.Sprintf("Failed to format result: %v", err)), nil
 	}

--- a/internal/mcp/tools_register.go
+++ b/internal/mcp/tools_register.go
@@ -1197,12 +1197,12 @@ func (s *Server) registerCRUDTools(shouldRegister func(string) bool) {
 
 	// Transport-related tools
 	if shouldRegister("GetUserTransports") {
-		s.mcpServer.AddTool(mcp.NewTool("GetUserTransports",
-			mcp.WithDescription("Get all transport requests for a user (requires --enable-transports flag). Returns both workbench and customizing requests grouped by target system."),
+		s.mcpServer.AddTool(mcp.NewTool("GetUserTransports", append([]mcp.ToolOption{
+			mcp.WithDescription("Get the transport requests of a user from the transport organizer (requires --enable-transports): workbench and customizing, modifiable and released, with tasks and objects, grouped by target and CTS project. Reads GET /sap/bc/adt/cts/transportrequests with explicit requestType/requestStatus (the organizer returns only released requests without them), falls back to the saved search configuration and then to E070/E07T."),
 			mcp.WithString("user_name",
-				mcp.Required(),
-				mcp.Description("SAP user name (will be converted to uppercase), or '*' for every user"),
+				mcp.Description("SAP user name (uppercased); default: the connection user. '*' for every user (source sql only)"),
 			),
+		}, transportListingParams...)...,
 		), s.handleGetUserTransports)
 	}
 
@@ -1853,11 +1853,12 @@ func (s *Server) registerAMDPTools(shouldRegister func(string) bool) {
 // registerTransportTools registers CTS/Transport management tools.
 func (s *Server) registerTransportTools(shouldRegister func(string) bool) {
 	if shouldRegister("ListTransports") {
-		s.mcpServer.AddTool(mcp.NewTool("ListTransports",
-			mcp.WithDescription("List transport requests. Returns modifiable transports for a user. Requires --enable-transports OR --allow-transportable-edits flag."),
+		s.mcpServer.AddTool(mcp.NewTool("ListTransports", append([]mcp.ToolOption{
+			mcp.WithDescription("List transport requests of a user as flat rows: workbench and customizing, modifiable and released by default (request_status D limits it to modifiable). Requires --enable-transports OR --allow-transportable-edits. Reads GET /sap/bc/adt/cts/transportrequests with explicit requestType/requestStatus, falls back to the saved search configuration and then to E070/E07T; the answer names the source used."),
 			mcp.WithString("user",
-				mcp.Description("Username to list transports for (default: current user, '*' for all users)"),
+				mcp.Description("Username to list transports for (default: the connection user, '*' for all users — source sql only)"),
 			),
+		}, transportListingParams...)...,
 		), s.handleListTransports)
 	}
 
@@ -2484,4 +2485,32 @@ func (s *Server) registerI18NTools(shouldRegister func(string) bool) {
 			),
 		), s.handleCompareObjectLanguages)
 	}
+}
+
+// transportListingParams are the parameters GetUserTransports and
+// ListTransports share. They mirror the query parameters of
+// GET /sap/bc/adt/cts/transportrequests; see pkg/adt/transport_query.go
+// for the contract.
+var transportListingParams = []mcp.ToolOption{
+	mcp.WithString("request_type",
+		mcp.Description("Letters of K (workbench), W (customizing), T (transport of copies); default KWT"),
+	),
+	mcp.WithString("request_status",
+		mcp.Description("Letters of D (modifiable), R (released); default DR. Without it the organizer would return released requests only"),
+	),
+	mcp.WithString("released_from",
+		mcp.Description("YYYYMMDD; with released_to bounds the released requests (default: last 14 days)"),
+	),
+	mcp.WithString("released_to",
+		mcp.Description("YYYYMMDD; see released_from"),
+	),
+	mcp.WithBoolean("targets",
+		mcp.Description("Group by transport target and CTS project (default true)"),
+	),
+	mcp.WithString("source",
+		mcp.Description("Where to read from: auto (default: params, then config, then sql — first source with requests wins), params (organizer tree with explicit parameters), config (organizer tree through the saved search configuration, as Eclipse does; the configuration decides the filters and the user), sql (E070/E07T)"),
+	),
+	mcp.WithString("config_uri",
+		mcp.Description("Search configuration to use with source config, e.g. /sap/bc/adt/cts/transportrequests/searchconfiguration/configurations/<id>; default: the one saved for the user, else the first one (noted in the answer)"),
+	),
 }

--- a/pkg/adt/transport.go
+++ b/pkg/adt/transport.go
@@ -12,13 +12,20 @@ import (
 
 // TransportRequest represents a transport request (workbench or customizing)
 type TransportRequest struct {
-	Number      string          `json:"number"`
-	Owner       string          `json:"owner"`
-	Description string          `json:"description"`
-	Status      string          `json:"status"`
-	Target      string          `json:"target,omitempty"`
-	Type        string          `json:"type"` // workbench or customizing
-	Tasks       []TransportTask `json:"tasks,omitempty"`
+	Number      string `json:"number"`
+	Owner       string `json:"owner"`
+	Description string `json:"description"`
+	Status      string `json:"status"`
+	Target      string `json:"target,omitempty"`
+	Type        string `json:"type"` // workbench or customizing
+	// Bucket is "modifiable" or "released": the organizer's own grouping,
+	// which is what tells a D from an R at a glance.
+	Bucket string `json:"bucket,omitempty"`
+	// Project and ProjectID name the CTS project the organizer filed the
+	// request under, when the tree carries that level.
+	Project   string          `json:"project,omitempty"`
+	ProjectID string          `json:"projectId,omitempty"`
+	Tasks     []TransportTask `json:"tasks,omitempty"`
 }
 
 // TransportTask represents a task within a transport request
@@ -46,15 +53,15 @@ type UserTransports struct {
 
 // TransportInfo represents information about an object's transport status
 type TransportInfo struct {
-	PGMID          string             `json:"pgmid"`
-	Object         string             `json:"object"`
-	ObjectName     string             `json:"objectName"`
-	Operation      string             `json:"operation"`
-	DevClass       string             `json:"devClass"`
-	Recording      string             `json:"recording"`
-	Transports     []TransportRequest `json:"transports,omitempty"`
-	LockedByUser   string             `json:"lockedByUser,omitempty"`
-	LockedInTask   string             `json:"lockedInTask,omitempty"`
+	PGMID        string             `json:"pgmid"`
+	Object       string             `json:"object"`
+	ObjectName   string             `json:"objectName"`
+	Operation    string             `json:"operation"`
+	DevClass     string             `json:"devClass"`
+	Recording    string             `json:"recording"`
+	Transports   []TransportRequest `json:"transports,omitempty"`
+	LockedByUser string             `json:"lockedByUser,omitempty"`
+	LockedInTask string             `json:"lockedInTask,omitempty"`
 }
 
 const (
@@ -64,40 +71,18 @@ const (
 
 // --- Transport Operations ---
 
-// GetUserTransports retrieves all transport requests for a user.
-// Returns both workbench and customizing requests grouped by target system.
+// GetUserTransports retrieves all transport requests for a user: workbench
+// and customizing, modifiable and released, grouped by target system.
+//
+// It is QueryTransports with the defaults (see TransportQuery); callers that
+// need a different filter, a date window or a specific source use
+// QueryUserTransports directly.
 func (c *Client) GetUserTransports(ctx context.Context, userName string) (*UserTransports, error) {
-	// Safety check
-	if err := c.checkSafety(OpTransport, "GetUserTransports"); err != nil {
-		return nil, err
-	}
-
-	userName = strings.ToUpper(userName)
-
-	resp, err := c.transport.Request(ctx, "/sap/bc/adt/cts/transportrequests", &RequestOptions{
-		Method: http.MethodGet,
-		Query:  map[string][]string{"user": {userName}, "targets": {"true"}},
-		Accept: acceptTransportOrganizerTreeV1 + ", " + acceptTransportOrganizerV1 + ";q=0.9",
-	})
-	if err != nil {
-		return nil, fmt.Errorf("get user transports failed: %w", err)
-	}
-
-	transports, err := parseUserTransports(resp.Body)
+	res, err := c.QueryUserTransports(ctx, TransportQuery{User: userName, Targets: true})
 	if err != nil {
 		return nil, err
 	}
-
-	if len(transports.Workbench) > 0 || len(transports.Customizing) > 0 {
-		return transports, nil
-	}
-
-	// Fallback: the same E070/E07T query ListTransports drops to. Without it,
-	// the two tools disagreed on the same system and the same user — one
-	// answered with transports and this one with a well-formed, plausible
-	// "none", which reads as "nothing to release" rather than as a failure
-	// (#111).
-	return c.userTransportsViaSQL(ctx, userName)
+	return res.Transports, nil
 }
 
 // userTransportsViaSQL groups the E070/E07T fallback rows the way the ADT tree
@@ -148,6 +133,12 @@ func parseUserTransports(data []byte) (*UserTransports, error) {
 			Description: r.Desc,
 			Status:      r.Status,
 			Target:      r.Target,
+			Bucket:      r.Bucket,
+			Project:     r.Project,
+			ProjectID:   r.ProjectID,
+		}
+		if tr.Bucket == "" {
+			tr.Bucket = bucketForStatus(tr.Status)
 		}
 		for _, t := range r.Tasks {
 			task := TransportTask{
@@ -321,9 +312,9 @@ func parseReleaseResult(data []byte) ([]string, error) {
 		Text string `xml:"shortText,attr"`
 	}
 	type report struct {
-		Reporter  string    `xml:"reporter,attr"`
-		Status    string    `xml:"status,attr"`
-		Messages  []message `xml:"checkMessageList>checkMessage"`
+		Reporter string    `xml:"reporter,attr"`
+		Status   string    `xml:"status,attr"`
+		Messages []message `xml:"checkMessageList>checkMessage"`
 	}
 	type root struct {
 		Reports []report `xml:"releasereports>checkReport"`
@@ -353,13 +344,15 @@ type TransportSummary struct {
 	Number      string `json:"number"`
 	Owner       string `json:"owner"`
 	Description string `json:"description"`
-	Type        string `json:"type"`       // K=Workbench, W=Customizing, S=Task
-	Status      string `json:"status"`     // D=Modifiable, R=Released
+	Type        string `json:"type"`   // K=Workbench, W=Customizing, S=Task
+	Status      string `json:"status"` // D=Modifiable, R=Released
 	StatusText  string `json:"statusText"`
 	Target      string `json:"target"`
 	TargetDesc  string `json:"targetDesc"`
 	ChangedAt   string `json:"changedAt"`
 	Client      string `json:"client"`
+	Bucket      string `json:"bucket,omitempty"`  // modifiable or released
+	Project     string `json:"project,omitempty"` // CTS project, when grouped
 }
 
 // TransportDetails represents detailed transport information
@@ -383,8 +376,8 @@ type TransportTaskV2 struct {
 
 // TransportObjectV2 represents an object in a transport (extended version)
 type TransportObjectV2 struct {
-	PgmID    string `json:"pgmid"`  // R3TR, LIMU, CORR
-	Type     string `json:"type"`   // PROG, CLAS, DEVC, etc.
+	PgmID    string `json:"pgmid"` // R3TR, LIMU, CORR
+	Type     string `json:"type"`  // PROG, CLAS, DEVC, etc.
 	Name     string `json:"name"`
 	WBType   string `json:"wbtype"` // PROG/P, CLAS/OC, etc.
 	Info     string `json:"info"`   // "Program", "Class", etc.
@@ -405,41 +398,17 @@ type ReleaseTransportOptions struct {
 	SkipATC     bool
 }
 
-// ListTransports returns transport requests for a user.
-// First tries ADT API, falls back to E070/E07T table query if ADT returns empty.
+// ListTransports lists transport requests for a user as flat rows: workbench
+// and customizing, modifiable and released (the defaults of TransportQuery).
+//
+// It is QueryTransports with the defaults; callers that need a different
+// filter, a date window or a specific source use QueryTransports directly.
 func (c *Client) ListTransports(ctx context.Context, user string) ([]TransportSummary, error) {
-	// Safety check
-	if err := c.config.Safety.CheckTransport("", "ListTransports", false); err != nil {
-		return nil, err
-	}
-
-	if user == "" {
-		user = c.config.Username
-	}
-
-	// Try ADT API first
-	resp, err := c.transport.Request(ctx, "/sap/bc/adt/cts/transportrequests", &RequestOptions{
-		Method: http.MethodGet,
-		Query:  map[string][]string{"user": {strings.ToUpper(user)}},
-		Accept: acceptTransportOrganizerTreeV1,
-	})
-	if err != nil {
-		return nil, fmt.Errorf("listing transports: %w", err)
-	}
-
-	transports, err := parseTransportList(resp.Body)
+	res, err := c.QueryTransports(ctx, TransportQuery{User: user, Targets: true})
 	if err != nil {
 		return nil, err
 	}
-
-	// If ADT API returned results, use them
-	if len(transports) > 0 {
-		return transports, nil
-	}
-
-	// Fallback: query E070/E07T tables directly
-	// This works on systems without configured transport routes (sandboxes)
-	return c.listTransportsViaSQL(ctx, user)
+	return FlattenTransports(res.Transports), nil
 }
 
 // as4userPredicate builds the E070~AS4USER condition for the fallback query,
@@ -485,9 +454,18 @@ func as4userPredicate(user string) (string, error) {
 	return "e070~AS4USER = '" + name + "'", nil
 }
 
-// listTransportsViaSQL queries E070/E07T tables to get modifiable transports.
-// Used as fallback when ADT API returns empty (common on sandbox systems).
+// listTransportsViaSQL queries E070/E07T for the user's modifiable workbench
+// and customizing requests. Used as the last fallback when the organizer tree
+// answers nothing (common on sandbox systems without transport routes).
 func (c *Client) listTransportsViaSQL(ctx context.Context, user string) ([]TransportSummary, error) {
+	return c.listTransportsViaSQLQuery(ctx, user, "KW", "D")
+}
+
+// listTransportsViaSQLQuery is listTransportsViaSQL with the request types
+// (letters of K, W, T) and statuses (letters of D, R) spelled out. Request
+// texts come in the session language, the way the organizer tree delivers
+// them, instead of English only.
+func (c *Client) listTransportsViaSQLQuery(ctx context.Context, user, types, statuses string) ([]TransportSummary, error) {
 	// '*' is the wildcard Eclipse ADT uses for "every user". It was being
 	// compared literally (AS4USER = '*'), which no row matches, so the wildcard
 	// answered "no transports found" instead of everyone's (#140).
@@ -496,10 +474,12 @@ func (c *Client) listTransportsViaSQL(ctx context.Context, user string) ([]Trans
 		return nil, err
 	}
 
-	// Query modifiable workbench requests (K) for the user
-	// TRFUNCTION: K=Workbench request, W=Customizing request, S=Task
-	// TRSTATUS: D=Modifiable, R=Released, N=Released (import started)
-	conditions := []string{"e070~TRSTATUS = 'D'", "e070~TRFUNCTION IN ('K', 'W')"}
+	// TRFUNCTION: K=Workbench request, W=Customizing request, T=Transport of copies, S=Task
+	// TRSTATUS: D=Modifiable, L=Modifiable (protected), R=Released, N=Released (import started)
+	conditions := []string{
+		"e070~TRSTATUS IN (" + sqlLetterList(statuses, map[string]string{"D": "'D', 'L'", "R": "'R', 'N'"}) + ")",
+		"e070~TRFUNCTION IN (" + sqlLetterList(types, nil) + ")",
+	}
 	if predicate != "" {
 		conditions = append([]string{predicate}, conditions...)
 	}
@@ -507,7 +487,7 @@ func (c *Client) listTransportsViaSQL(ctx context.Context, user string) ([]Trans
 	query := `SELECT e070~TRKORR, e070~TRFUNCTION, e070~TRSTATUS, e070~TARSYSTEM,
 		e070~AS4USER, e070~AS4DATE, e070~AS4TIME, e07t~AS4TEXT
 		FROM E070 AS e070
-		LEFT OUTER JOIN E07T AS e07t ON e070~TRKORR = e07t~TRKORR AND e07t~LANGU = 'E'
+		LEFT OUTER JOIN E07T AS e07t ON e070~TRKORR = e07t~TRKORR AND e07t~LANGU = '` + sapLanguageKey(c.config.Language) + `'
 		WHERE ` + strings.Join(conditions, "\n\t\tAND ") + `
 		ORDER BY e070~TRKORR DESCENDING`
 
@@ -520,23 +500,16 @@ func (c *Client) listTransportsViaSQL(ctx context.Context, user string) ([]Trans
 	var transports []TransportSummary
 	for _, row := range result.Rows {
 		tr := TransportSummary{
-			Number:     getString(row, "TRKORR"),
-			Owner:      getString(row, "AS4USER"),
+			Number:      getString(row, "TRKORR"),
+			Owner:       getString(row, "AS4USER"),
 			Description: getString(row, "AS4TEXT"),
-			Type:       getString(row, "TRFUNCTION"),
-			Status:     getString(row, "TRSTATUS"),
-			Target:     getString(row, "TARSYSTEM"),
+			Type:        getString(row, "TRFUNCTION"),
+			Status:      getString(row, "TRSTATUS"),
+			Target:      getString(row, "TARSYSTEM"),
 		}
 
-		// Map status code to text
-		switch tr.Status {
-		case "D":
-			tr.StatusText = "Modifiable"
-		case "R":
-			tr.StatusText = "Released"
-		case "N":
-			tr.StatusText = "Released (import started)"
-		}
+		tr.StatusText = transportStatusText(tr.Status)
+		tr.Bucket = bucketForStatus(tr.Status)
 
 		// Map type code to text
 		switch tr.Type {
@@ -546,6 +519,9 @@ func (c *Client) listTransportsViaSQL(ctx context.Context, user string) ([]Trans
 		case "W":
 			tr.Type = "W"
 			tr.TargetDesc = "Customizing Request"
+		case "T":
+			tr.Type = "T"
+			tr.TargetDesc = "Transport of Copies"
 		}
 
 		// Format date/time if available
@@ -569,6 +545,24 @@ func getString(row map[string]interface{}, key string) string {
 		}
 	}
 	return ""
+}
+
+// sqlLetterList turns letters such as "KW" into a quoted SQL list, expanding a
+// letter through expand when one status letter stands for several codes.
+func sqlLetterList(letters string, expand map[string]string) string {
+	var parts []string
+	for _, r := range letters {
+		l := string(r)
+		if e, ok := expand[l]; ok {
+			parts = append(parts, e)
+			continue
+		}
+		parts = append(parts, "'"+l+"'")
+	}
+	if len(parts) == 0 {
+		return "''"
+	}
+	return strings.Join(parts, ", ")
 }
 
 // parseTransportList extracts the transport summaries from a CTS listing.

--- a/pkg/adt/transport_query.go
+++ b/pkg/adt/transport_query.go
@@ -1,0 +1,622 @@
+package adt
+
+import (
+	"context"
+	"encoding/xml"
+	"fmt"
+	"net/http"
+	"net/url"
+	"regexp"
+	"strings"
+)
+
+// The transport organizer tree: GET /sap/bc/adt/cts/transportrequests
+//
+// ADT discovery advertises this collection with a single template parameter,
+// {?targets}. The handler reads far more, and what it does without the rest is
+// surprising enough that the whole contract is written down here. Verified on
+// ABAP 7.57 against the backend classes: CL_CTS_ADT_RES_APP registers the
+// collection, CL_CTS_ADT_TM_RES_COLL_CONT answers GET.
+//
+// Two ways to steer the listing:
+//
+//  1. Explicit query parameters (the pre-1908 contract, still served):
+//
+//     requestType      letters of K (workbench), W (customizing), T (transport of copies)
+//     requestStatus    letters of D (modifiable), R (released)
+//     user             SAP user name; the backend defaults to sy-uname
+//     targetuser       second user filter the organizer view offers
+//     targets          "true" groups requests by transport target and CTS project
+//     releasedFromDate YYYYMMDD; with releasedToDate bounds the released bucket
+//     releasedToDate   YYYYMMDD; both unset means the last 14 days
+//     req_cat, status  deprecated aliases of requestType and requestStatus
+//
+//  2. A saved search configuration (what Eclipse ADT sends since 1908):
+//
+//     configUri=/sap/bc/adt/cts/transportrequests/searchconfiguration/configurations/<id>
+//
+//     Every criterion — request types, statuses, the user, the date window —
+//     is read from that configuration (properties WorkbenchRequests,
+//     CustomizingRequests, TransportOfCopies, Modifiable, Released, User,
+//     DateFilter, FromDate, ToDate). A user parameter on the same request is
+//     ignored. Configurations are maintained in Eclipse (Transport Organizer
+//     view, "Configure Tree") and listed under
+//     /sap/bc/adt/cts/transportrequests/searchconfiguration/configurations.
+//
+// The pitfall that motivates all of this: without requestStatus the handler
+// assembles the selection criteria for modifiable requests but only processes
+// the hits inside a block that requires a D in the status list, so the answer
+// holds nothing but released requests of the last two weeks. A client that
+// sends user and targets alone therefore sees "no modifiable transports" on a
+// system full of them. Always send requestType and requestStatus.
+//
+// The same collection serves, per request number:
+//
+//	/{trnumber}                                 request or task
+//	/{trnumber}/{traction}                      releasejobs, newreleasejobs, relwithignlock,
+//	                                            relObjigchkatc, tasks, merge, sortandcompress,
+//	                                            consistencychecks, moveobjects, reassign
+//	/{trnumber}/checkruns                       transport editor checks
+//	/{trnumber}/transportlogs[/independentlogs] logs
+//	/{trnumber}/objectkeys[/checkruns]          object key editor
+//	/{trnumber}/transportchecks                 transport checks
+//	/valuehelp/{attribute|target|ctsproject|object/{field}}
+//	/reference                                  VIT to native URI mapping
+//	/searchconfiguration/{configurations|metadata}
+//
+// Neighbours: /sap/bc/adt/cts/transports (create and query, CL_CTS_ADT_RES_OBJ_RECORD)
+// and /sap/bc/adt/cts/transportchecks (CL_CTS_ADT_RES_CHECK).
+
+// Sources a transport listing can come from.
+const (
+	// TransportSourceAuto tries the organizer tree with explicit parameters,
+	// then the saved search configuration, then the E070/E07T tables, and
+	// stops at the first source that returns requests.
+	TransportSourceAuto = "auto"
+	// TransportSourceParams asks the organizer tree with explicit parameters.
+	TransportSourceParams = "params"
+	// TransportSourceConfig asks the organizer tree through a saved search
+	// configuration, the way Eclipse ADT does.
+	TransportSourceConfig = "config"
+	// TransportSourceSQL reads E070/E07T directly. The only source that
+	// understands User "*".
+	TransportSourceSQL = "sql"
+)
+
+// Defaults applied when a caller leaves the filters empty.
+const (
+	DefaultTransportRequestTypes    = "KWT"
+	DefaultTransportRequestStatuses = "DR"
+)
+
+const (
+	transportRequestsPath      = "/sap/bc/adt/cts/transportrequests"
+	transportSearchConfigsPath = transportRequestsPath + "/searchconfiguration/configurations"
+
+	acceptConfigurationsV1 = "application/vnd.sap.adt.configurations.v1+xml"
+	acceptConfigurationV1  = "application/vnd.sap.adt.configuration.v1+xml"
+)
+
+// TransportQuery describes one listing of the transport organizer.
+type TransportQuery struct {
+	// User is the SAP user whose requests are wanted. Empty means the
+	// connection's user (the backend falls back to sy-uname). "*" means every
+	// user and is served by the SQL source only.
+	User string `json:"user,omitempty"`
+	// RequestTypes holds letters of K (workbench), W (customizing) and
+	// T (transport of copies). Empty means DefaultTransportRequestTypes.
+	RequestTypes string `json:"requestTypes,omitempty"`
+	// RequestStatuses holds letters of D (modifiable) and R (released). Empty
+	// means DefaultTransportRequestStatuses.
+	RequestStatuses string `json:"requestStatuses,omitempty"`
+	// ReleasedFrom and ReleasedTo (YYYYMMDD) bound the released bucket. Both
+	// empty leaves the backend default, the last 14 days.
+	ReleasedFrom string `json:"releasedFrom,omitempty"`
+	ReleasedTo   string `json:"releasedTo,omitempty"`
+	// Targets groups the requests by transport target and CTS project.
+	Targets bool `json:"targets"`
+	// Source is one of the TransportSource* constants; empty means auto.
+	Source string `json:"source,omitempty"`
+	// ConfigURI names a saved search configuration explicitly. Setting it
+	// selects the config source.
+	ConfigURI string `json:"configUri,omitempty"`
+}
+
+// TransportQueryResult is a listing together with where it came from.
+type TransportQueryResult struct {
+	Transports *UserTransports `json:"transports"`
+	// Source names the source that produced Transports.
+	Source string `json:"source"`
+	// ConfigURI is the search configuration used, when Source is config.
+	ConfigURI string `json:"configUri,omitempty"`
+	// Query is the query after defaults were applied.
+	Query TransportQuery `json:"query"`
+	// Notes explain fallbacks and deviations, for the caller to pass on.
+	Notes []string `json:"notes,omitempty"`
+}
+
+// Empty reports whether the listing holds no request at all.
+func (r *TransportQueryResult) Empty() bool {
+	return r == nil || r.Transports == nil ||
+		(len(r.Transports.Workbench) == 0 && len(r.Transports.Customizing) == 0)
+}
+
+var yyyymmdd = regexp.MustCompile(`^\d{8}$`)
+
+// normalized applies defaults and validates the query.
+func (q TransportQuery) normalized(connectionUser string) (TransportQuery, error) {
+	q.User = strings.ToUpper(strings.TrimSpace(q.User))
+	if q.User == "" {
+		q.User = strings.ToUpper(strings.TrimSpace(connectionUser))
+	}
+
+	q.RequestTypes = strings.ToUpper(strings.TrimSpace(q.RequestTypes))
+	if q.RequestTypes == "" {
+		q.RequestTypes = DefaultTransportRequestTypes
+	}
+	if err := onlyLetters(q.RequestTypes, "KWT", "request type"); err != nil {
+		return q, err
+	}
+
+	q.RequestStatuses = strings.ToUpper(strings.TrimSpace(q.RequestStatuses))
+	if q.RequestStatuses == "" {
+		q.RequestStatuses = DefaultTransportRequestStatuses
+	}
+	if err := onlyLetters(q.RequestStatuses, "DR", "request status"); err != nil {
+		return q, err
+	}
+
+	for name, v := range map[string]string{"released_from": q.ReleasedFrom, "released_to": q.ReleasedTo} {
+		if v != "" && !yyyymmdd.MatchString(v) {
+			return q, fmt.Errorf("%s must be a date as YYYYMMDD, got %q", name, v)
+		}
+	}
+	if (q.ReleasedFrom == "") != (q.ReleasedTo == "") {
+		return q, fmt.Errorf("released_from and released_to go together; give both or neither")
+	}
+
+	q.ConfigURI = strings.TrimSpace(q.ConfigURI)
+	q.Source = strings.ToLower(strings.TrimSpace(q.Source))
+	switch q.Source {
+	case "":
+		if q.ConfigURI != "" {
+			q.Source = TransportSourceConfig
+		} else {
+			q.Source = TransportSourceAuto
+		}
+	case TransportSourceAuto, TransportSourceParams, TransportSourceConfig, TransportSourceSQL:
+	default:
+		return q, fmt.Errorf("source must be one of auto, params, config, sql; got %q", q.Source)
+	}
+	if q.ConfigURI != "" && q.Source != TransportSourceConfig && q.Source != TransportSourceAuto {
+		return q, fmt.Errorf("config_uri only applies to source config or auto, not %q", q.Source)
+	}
+	return q, nil
+}
+
+func onlyLetters(value, allowed, what string) error {
+	for _, r := range value {
+		if !strings.ContainsRune(allowed, r) {
+			return fmt.Errorf("%s %q: only letters of %s are allowed", what, value, allowed)
+		}
+	}
+	return nil
+}
+
+// Describe renders the effective filters in one line, for tool output.
+func (q TransportQuery) Describe() string {
+	parts := []string{"type " + q.RequestTypes, "status " + q.RequestStatuses}
+	if q.ReleasedFrom != "" {
+		parts = append(parts, fmt.Sprintf("released %s..%s", q.ReleasedFrom, q.ReleasedTo))
+	} else if strings.Contains(q.RequestStatuses, "R") {
+		parts = append(parts, "released within the last 14 days (backend default)")
+	}
+	if !q.Targets {
+		parts = append(parts, "no target grouping")
+	}
+	return strings.Join(parts, ", ")
+}
+
+// QueryUserTransports lists transport requests the way GetUserTransports
+// does, with the query spelled out. It needs transport management enabled.
+func (c *Client) QueryUserTransports(ctx context.Context, q TransportQuery) (*TransportQueryResult, error) {
+	if err := c.checkSafety(OpTransport, "GetUserTransports"); err != nil {
+		return nil, err
+	}
+	return c.queryTransports(ctx, q)
+}
+
+// QueryTransports lists transport requests the way ListTransports does, with
+// the query spelled out. Reading is allowed whenever transportable edits are.
+func (c *Client) QueryTransports(ctx context.Context, q TransportQuery) (*TransportQueryResult, error) {
+	if err := c.config.Safety.CheckTransport("", "ListTransports", false); err != nil {
+		return nil, err
+	}
+	return c.queryTransports(ctx, q)
+}
+
+func (c *Client) queryTransports(ctx context.Context, q TransportQuery) (*TransportQueryResult, error) {
+	q, err := q.normalized(c.config.Username)
+	if err != nil {
+		return nil, err
+	}
+	res := &TransportQueryResult{Query: q}
+
+	switch q.Source {
+	case TransportSourceParams:
+		return c.transportsViaParams(ctx, res)
+	case TransportSourceConfig:
+		return c.transportsViaConfig(ctx, res)
+	case TransportSourceSQL:
+		return c.transportsViaSQL(ctx, res)
+	}
+
+	// auto: first source with requests wins; a source that fails is noted
+	// and the next one is tried, so one broken path never hides the others.
+	if r, err := c.transportsViaParams(ctx, res); err != nil {
+		res.note("organizer tree with explicit parameters failed: %v", err)
+	} else if !r.Empty() {
+		return r, nil
+	} else {
+		res.note("organizer tree with explicit parameters returned no requests")
+	}
+
+	if r, err := c.transportsViaConfig(ctx, res); err != nil {
+		res.note("saved search configuration not usable: %v", err)
+	} else if !r.Empty() {
+		return r, nil
+	} else {
+		res.note("organizer tree via search configuration %s returned no requests", r.ConfigURI)
+	}
+
+	return c.transportsViaSQL(ctx, res)
+}
+
+func (r *TransportQueryResult) note(format string, args ...any) {
+	r.Notes = append(r.Notes, fmt.Sprintf(format, args...))
+}
+
+// transportsViaParams asks the organizer tree with explicit parameters.
+func (c *Client) transportsViaParams(ctx context.Context, res *TransportQueryResult) (*TransportQueryResult, error) {
+	q := res.Query
+	values := url.Values{}
+	if q.User != "" {
+		values.Set("user", q.User)
+	}
+	values.Set("targets", boolString(q.Targets))
+	values.Set("requestType", q.RequestTypes)
+	values.Set("requestStatus", q.RequestStatuses)
+	if q.ReleasedFrom != "" {
+		values.Set("releasedFromDate", q.ReleasedFrom)
+		values.Set("releasedToDate", q.ReleasedTo)
+	}
+
+	transports, err := c.fetchTransportTree(ctx, values)
+	if err != nil {
+		return nil, err
+	}
+	res.Transports = transports
+	res.Source = TransportSourceParams
+	res.ConfigURI = ""
+	return res, nil
+}
+
+// transportsViaConfig asks the organizer tree through a saved search
+// configuration. The configuration decides the filters, including the user.
+func (c *Client) transportsViaConfig(ctx context.Context, res *TransportQueryResult) (*TransportQueryResult, error) {
+	q := res.Query
+	if q.User == "*" {
+		return nil, fmt.Errorf("a search configuration always names one user; use source sql for every user")
+	}
+
+	configURI := q.ConfigURI
+	if configURI == "" {
+		configs, err := c.TransportSearchConfigurations(ctx)
+		if err != nil {
+			return nil, err
+		}
+		if len(configs) == 0 {
+			return nil, fmt.Errorf("no transport search configuration is saved on the server; " +
+				"create one in Eclipse (Transport Organizer view, Configure Tree) or use source params")
+		}
+		chosen := configs[0]
+		matched := false
+		for _, cfg := range configs {
+			if strings.EqualFold(cfg.User, q.User) {
+				chosen, matched = cfg, true
+				break
+			}
+		}
+		if !matched && q.User != "" {
+			res.note("no search configuration names user %s; using %s, which belongs to %s — "+
+				"the listing follows that configuration, not the user asked for",
+				q.User, chosen.URI, chosen.User)
+		}
+		if !chosen.Modifiable && strings.Contains(q.RequestStatuses, "D") {
+			res.note("search configuration %s excludes modifiable requests", chosen.URI)
+		}
+		if !chosen.Released && strings.Contains(q.RequestStatuses, "R") {
+			res.note("search configuration %s excludes released requests", chosen.URI)
+		}
+		configURI = chosen.URI
+	}
+
+	res.note("the search configuration decides request types, statuses, user and date window; "+
+		"request_type %s, request_status %s and any released window were not applied", q.RequestTypes, q.RequestStatuses)
+
+	values := url.Values{}
+	values.Set("targets", boolString(q.Targets))
+	values.Set("configUri", configURI)
+
+	transports, err := c.fetchTransportTree(ctx, values)
+	if err != nil {
+		return nil, err
+	}
+	res.Transports = transports
+	res.Source = TransportSourceConfig
+	res.ConfigURI = configURI
+	return res, nil
+}
+
+// transportsViaSQL reads E070/E07T directly.
+func (c *Client) transportsViaSQL(ctx context.Context, res *TransportQueryResult) (*TransportQueryResult, error) {
+	q := res.Query
+	rows, err := c.listTransportsViaSQLQuery(ctx, q.User, q.RequestTypes, q.RequestStatuses)
+	if err != nil {
+		return nil, err
+	}
+	res.Transports = summariesToUserTransports(rows)
+	res.Source = TransportSourceSQL
+	res.ConfigURI = ""
+	return res, nil
+}
+
+// fetchTransportTree runs one GET against the organizer tree and parses it.
+func (c *Client) fetchTransportTree(ctx context.Context, values url.Values) (*UserTransports, error) {
+	resp, err := c.transport.Request(ctx, transportRequestsPath, &RequestOptions{
+		Method: http.MethodGet,
+		Query:  values,
+		Accept: acceptTransportOrganizerTreeV1 + ", " + acceptTransportOrganizerV1 + ";q=0.9",
+	})
+	if err != nil {
+		return nil, fmt.Errorf("reading the transport organizer tree: %w", err)
+	}
+	return parseUserTransports(resp.Body)
+}
+
+func boolString(b bool) string {
+	if b {
+		return "true"
+	}
+	return "false"
+}
+
+// TransportSearchConfiguration is one saved Transport Organizer search
+// configuration, as Eclipse ADT keeps it on the server.
+type TransportSearchConfiguration struct {
+	URI         string            `json:"uri"`
+	User        string            `json:"user"`
+	Workbench   bool              `json:"workbench"`
+	Customizing bool              `json:"customizing"`
+	Copies      bool              `json:"transportOfCopies"`
+	Modifiable  bool              `json:"modifiable"`
+	Released    bool              `json:"released"`
+	DateFilter  string            `json:"dateFilter"`
+	FromDate    string            `json:"fromDate,omitempty"`
+	ToDate      string            `json:"toDate,omitempty"`
+	CreatedBy   string            `json:"createdBy,omitempty"`
+	ChangedAt   string            `json:"changedAt,omitempty"`
+	Properties  map[string]string `json:"properties"`
+}
+
+// TransportSearchConfigurations lists the saved search configurations with
+// their properties.
+func (c *Client) TransportSearchConfigurations(ctx context.Context) ([]TransportSearchConfiguration, error) {
+	resp, err := c.transport.Request(ctx, transportSearchConfigsPath, &RequestOptions{
+		Method: http.MethodGet,
+		Accept: acceptConfigurationsV1,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("listing transport search configurations: %w", err)
+	}
+	uris, err := parseConfigurationURIs(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	var out []TransportSearchConfiguration
+	for _, uri := range uris {
+		detail, err := c.transport.Request(ctx, uri, &RequestOptions{
+			Method: http.MethodGet,
+			Accept: acceptConfigurationV1,
+		})
+		if err != nil {
+			return nil, fmt.Errorf("reading transport search configuration %s: %w", uri, err)
+		}
+		cfg, err := parseSearchConfiguration(detail.Body)
+		if err != nil {
+			return nil, fmt.Errorf("parsing transport search configuration %s: %w", uri, err)
+		}
+		cfg.URI = uri
+		out = append(out, cfg)
+	}
+	return out, nil
+}
+
+// parseConfigurationURIs extracts the configuration URIs from the collection.
+//
+// The server builds the atom:link hrefs from the request URL it was called
+// with, so a call that carried sap-client and sap-language gets them back in
+// the middle of the href. Only the trailing id is trusted; the URI is rebuilt
+// from it.
+func parseConfigurationURIs(data []byte) ([]string, error) {
+	type link struct {
+		Href string `xml:"href,attr"`
+	}
+	type configuration struct {
+		Links []link `xml:"link"`
+	}
+	var doc struct {
+		Configurations []configuration `xml:"configuration"`
+	}
+	if err := xml.Unmarshal(data, &doc); err != nil {
+		return nil, fmt.Errorf("parsing transport search configurations: %w", err)
+	}
+
+	var uris []string
+	for _, cfg := range doc.Configurations {
+		for _, l := range cfg.Links {
+			id := l.Href[strings.LastIndex(l.Href, "/")+1:]
+			if id == "" || strings.ContainsAny(id, "?&=") {
+				continue
+			}
+			uris = append(uris, transportSearchConfigsPath+"/"+id)
+			break
+		}
+	}
+	return uris, nil
+}
+
+// parseSearchConfiguration reads one configuration document.
+func parseSearchConfiguration(data []byte) (TransportSearchConfiguration, error) {
+	type property struct {
+		Key   string `xml:"key,attr"`
+		Value string `xml:",chardata"`
+	}
+	var doc struct {
+		CreatedBy  string     `xml:"createdBy,attr"`
+		ChangedAt  string     `xml:"changedAt,attr"`
+		Properties []property `xml:"properties>property"`
+	}
+	if err := xml.Unmarshal(data, &doc); err != nil {
+		return TransportSearchConfiguration{}, err
+	}
+	cfg := TransportSearchConfiguration{
+		CreatedBy:  doc.CreatedBy,
+		ChangedAt:  doc.ChangedAt,
+		Properties: map[string]string{},
+	}
+	for _, p := range doc.Properties {
+		cfg.Properties[p.Key] = strings.TrimSpace(p.Value)
+	}
+	cfg.User = strings.ToUpper(cfg.Properties["User"])
+	cfg.Workbench = cfg.Properties["WorkbenchRequests"] == "true"
+	cfg.Customizing = cfg.Properties["CustomizingRequests"] == "true"
+	cfg.Copies = cfg.Properties["TransportOfCopies"] == "true"
+	cfg.Modifiable = cfg.Properties["Modifiable"] == "true"
+	cfg.Released = cfg.Properties["Released"] == "true"
+	cfg.DateFilter = cfg.Properties["DateFilter"]
+	cfg.FromDate = cfg.Properties["FromDate"]
+	cfg.ToDate = cfg.Properties["ToDate"]
+	return cfg, nil
+}
+
+// summariesToUserTransports groups flat rows the way the organizer tree would.
+func summariesToUserTransports(rows []TransportSummary) *UserTransports {
+	result := &UserTransports{}
+	for _, row := range rows {
+		tr := TransportRequest{
+			Number:      row.Number,
+			Owner:       row.Owner,
+			Description: row.Description,
+			Status:      row.Status,
+			Target:      row.Target,
+			Bucket:      bucketForStatus(row.Status),
+		}
+		if row.Type == "W" {
+			tr.Type = "customizing"
+			result.Customizing = append(result.Customizing, tr)
+		} else {
+			tr.Type = "workbench"
+			result.Workbench = append(result.Workbench, tr)
+		}
+	}
+	return result
+}
+
+// FlattenTransports turns a grouped listing into the flat rows ListTransports
+// returns.
+func FlattenTransports(t *UserTransports) []TransportSummary {
+	if t == nil {
+		return nil
+	}
+	var out []TransportSummary
+	add := func(reqs []TransportRequest, typ string) {
+		for _, r := range reqs {
+			out = append(out, TransportSummary{
+				Number:      r.Number,
+				Owner:       r.Owner,
+				Description: r.Description,
+				Type:        typ,
+				Status:      r.Status,
+				StatusText:  transportStatusText(r.Status),
+				Target:      r.Target,
+				Bucket:      r.Bucket,
+				Project:     r.Project,
+			})
+		}
+	}
+	add(t.Workbench, "K")
+	add(t.Customizing, "W")
+	return out
+}
+
+func bucketForStatus(status string) string {
+	switch status {
+	case "D", "L":
+		return "modifiable"
+	case "R", "N", "O":
+		return "released"
+	}
+	return ""
+}
+
+func transportStatusText(status string) string {
+	switch status {
+	case "D":
+		return "Modifiable"
+	case "L":
+		return "Modifiable, protected"
+	case "R":
+		return "Released"
+	case "N":
+		return "Released (import started)"
+	case "O":
+		return "Release started"
+	}
+	return ""
+}
+
+// sapLanguageKey maps a session language (ISO code or SAP key) to the
+// one-character key E07T stores.
+func sapLanguageKey(lang string) string {
+	l := strings.ToUpper(strings.TrimSpace(lang))
+	switch l {
+	case "":
+		return "E"
+	case "DE":
+		return "D"
+	case "EN":
+		return "E"
+	case "FR":
+		return "F"
+	case "IT":
+		return "I"
+	case "ES":
+		return "S"
+	case "NL":
+		return "N"
+	case "PT":
+		return "P"
+	case "RU":
+		return "R"
+	case "JA":
+		return "J"
+	case "ZH":
+		return "1"
+	}
+	if len(l) == 1 {
+		return l
+	}
+	return l[:1]
+}

--- a/pkg/adt/transport_query_test.go
+++ b/pkg/adt/transport_query_test.go
@@ -1,0 +1,319 @@
+package adt
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+// The organizer tree as ABAP 7.57 renders it with targets: a tm:project level
+// between target and bucket, both buckets present, workbench and customizing.
+const treeWithProjects = `<?xml version="1.0" encoding="utf-8"?>
+<tm:root xmlns:tm="http://www.sap.com/cts/adt/tm" xmlns:adtcore="http://www.sap.com/adt/core" adtcore:name="DEVELOPER">
+  <tm:workbench tm:category="Workbench">
+    <tm:target tm:name="/TARGET/" tm:desc="Target group">
+      <tm:project tm:projectId="PRJ1" tm:name="PROJECT_1" tm:desc="First project">
+        <tm:modifiable tm:status="Modifiable">
+          <tm:request tm:number="TR-MOD-1" tm:owner="DEVELOPER" tm:desc="Modifiable one" tm:type="K" tm:status="D">
+            <tm:task tm:number="TR-MOD-1-T" tm:parent="TR-MOD-1" tm:owner="DEVELOPER" tm:desc="Task" tm:type="Development" tm:status="D">
+              <tm:abap_object tm:pgmid="R3TR" tm:type="PROG" tm:name="ZPROG" tm:wbtype="PROG/P"/>
+            </tm:task>
+          </tm:request>
+        </tm:modifiable>
+        <tm:released tm:status="Released (last 2 weeks)">
+          <tm:request tm:number="TR-REL-1" tm:owner="OTHER" tm:desc="Released one" tm:type="K" tm:status="R"/>
+        </tm:released>
+      </tm:project>
+      <tm:project tm:projectId="Not_assigned_to_a_project" tm:name="" tm:desc="Requests not assigned to any project">
+        <tm:modifiable tm:status="Modifiable">
+          <tm:request tm:number="TR-MOD-2" tm:owner="DEVELOPER" tm:desc="Modifiable two" tm:type="K" tm:status="D"/>
+        </tm:modifiable>
+      </tm:project>
+    </tm:target>
+  </tm:workbench>
+  <tm:customizing tm:category="Customizing">
+    <tm:target tm:name="/TARGET/" tm:desc="Target group">
+      <tm:project tm:projectId="PRJ1" tm:name="PROJECT_1" tm:desc="First project">
+        <tm:modifiable tm:status="Modifiable">
+          <tm:request tm:number="TR-CUS-1" tm:owner="OTHER" tm:desc="Customizing one" tm:type="W" tm:status="D"/>
+        </tm:modifiable>
+      </tm:project>
+    </tm:target>
+  </tm:customizing>
+</tm:root>`
+
+const emptyTree = `<?xml version="1.0" encoding="utf-8"?>
+<tm:root xmlns:tm="http://www.sap.com/cts/adt/tm"></tm:root>`
+
+const configurationsList = `<?xml version="1.0" encoding="utf-8"?>
+<configurations:configurations xmlns:configurations="http://www.sap.com/adt/configurations">
+  <configuration:configuration createdBy="DEVELOPER" xmlns:configuration="http://www.sap.com/adt/configuration">
+    <atom:link href="/sap/bc/adt/cts/transportrequests/searchconfiguration/configurations?sap-client=001&amp;sap-language=EN/CFG-DEVELOPER" rel="http://www.sap.com/adt/categories/configurations" type="application/vnd.sap.adt.configuration.v1+xml" xmlns:atom="http://www.w3.org/2005/Atom"/>
+  </configuration:configuration>
+  <configuration:configuration createdBy="OTHER" xmlns:configuration="http://www.sap.com/adt/configuration">
+    <atom:link href="/sap/bc/adt/cts/transportrequests/searchconfiguration/configurations/CFG-OTHER" rel="http://www.sap.com/adt/categories/configurations" type="application/vnd.sap.adt.configuration.v1+xml" xmlns:atom="http://www.w3.org/2005/Atom"/>
+  </configuration:configuration>
+</configurations:configurations>`
+
+func configurationFor(user string) string {
+	return `<?xml version="1.0" encoding="utf-8"?>
+<configuration:configuration createdBy="` + user + `" changedAt="2025-03-21T06:46:52Z" client="001" xmlns:configuration="http://www.sap.com/adt/configuration">
+  <configuration:properties>
+    <configuration:property key="WorkbenchRequests" isMandatory="true">true</configuration:property>
+    <configuration:property key="CustomizingRequests" isMandatory="true">true</configuration:property>
+    <configuration:property key="TransportOfCopies" isMandatory="true">true</configuration:property>
+    <configuration:property key="Modifiable" isMandatory="true">true</configuration:property>
+    <configuration:property key="Released" isMandatory="true">false</configuration:property>
+    <configuration:property key="User" isMandatory="true">` + user + `</configuration:property>
+    <configuration:property key="DateFilter" isMandatory="true">1</configuration:property>
+  </configuration:properties>
+</configuration:configuration>`
+}
+
+// sequencedClient answers by path and query, one canned response per call,
+// so a fallback chain can be scripted request by request.
+type sequencedClient struct {
+	t        *testing.T
+	answers  map[string][]string // key: path, or path + "?" + a query substring
+	requests []*http.Request
+}
+
+func (m *sequencedClient) Do(req *http.Request) (*http.Response, error) {
+	m.requests = append(m.requests, req)
+	key := req.URL.Path
+	for k := range m.answers {
+		if strings.HasPrefix(k, key+"?") && strings.Contains(req.URL.RawQuery, strings.TrimPrefix(k, key+"?")) {
+			key = k
+			break
+		}
+	}
+	bodies, ok := m.answers[key]
+	if !ok || len(bodies) == 0 {
+		m.t.Logf("no canned answer for %s?%s", req.URL.Path, req.URL.RawQuery)
+		return &http.Response{StatusCode: http.StatusNotFound, Body: io.NopCloser(strings.NewReader("")), Header: http.Header{}}, nil
+	}
+	body := bodies[0]
+	m.answers[key] = bodies[1:]
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Body:       io.NopCloser(strings.NewReader(body)),
+		Header:     http.Header{"X-CSRF-Token": []string{"token"}, "Content-Type": []string{"application/xml"}},
+	}, nil
+}
+
+func newTransportTestClient(t *testing.T, answers map[string][]string) (*Client, *sequencedClient) {
+	mock := &sequencedClient{t: t, answers: answers}
+	cfg := NewConfig("https://sap.example.com", "developer", "secret")
+	cfg.Safety.EnableTransports = true
+	tr := NewTransportWithClient(cfg, mock)
+	return NewClientWithTransport(cfg, tr), mock
+}
+
+func TestParseUserTransportsProjectLevel(t *testing.T) {
+	result, err := parseUserTransports([]byte(treeWithProjects))
+	if err != nil {
+		t.Fatalf("parseUserTransports: %v", err)
+	}
+	if len(result.Workbench) != 3 {
+		t.Fatalf("workbench requests = %d, want 3", len(result.Workbench))
+	}
+	if len(result.Customizing) != 1 {
+		t.Fatalf("customizing requests = %d, want 1", len(result.Customizing))
+	}
+	byNumber := map[string]TransportRequest{}
+	for _, r := range append(result.Workbench, result.Customizing...) {
+		byNumber[r.Number] = r
+	}
+	if got := byNumber["TR-MOD-1"]; got.Bucket != "modifiable" || got.Project != "PROJECT_1" || got.ProjectID != "PRJ1" {
+		t.Errorf("TR-MOD-1 = bucket %q project %q/%q, want modifiable PROJECT_1/PRJ1", got.Bucket, got.Project, got.ProjectID)
+	}
+	if got := byNumber["TR-REL-1"]; got.Bucket != "released" || got.Status != "R" {
+		t.Errorf("TR-REL-1 = bucket %q status %q, want released R", got.Bucket, got.Status)
+	}
+	if got := byNumber["TR-MOD-2"]; got.Bucket != "modifiable" || got.ProjectID != "Not_assigned_to_a_project" {
+		t.Errorf("TR-MOD-2 = bucket %q projectId %q", got.Bucket, got.ProjectID)
+	}
+	if got := byNumber["TR-MOD-1"]; len(got.Tasks) != 1 || len(got.Tasks[0].Objects) != 1 {
+		t.Errorf("TR-MOD-1 tasks/objects not carried through the project level: %+v", got.Tasks)
+	}
+}
+
+func TestTransportQueryDefaults(t *testing.T) {
+	q, err := TransportQuery{}.normalized("developer")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if q.User != "DEVELOPER" || q.RequestTypes != "KWT" || q.RequestStatuses != "DR" || q.Source != TransportSourceAuto {
+		t.Errorf("defaults = %+v", q)
+	}
+
+	q, err = TransportQuery{ConfigURI: "/sap/bc/adt/cts/transportrequests/searchconfiguration/configurations/X"}.normalized("developer")
+	if err != nil || q.Source != TransportSourceConfig {
+		t.Errorf("config_uri alone should select source config, got %q (%v)", q.Source, err)
+	}
+
+	for _, bad := range []TransportQuery{
+		{RequestTypes: "KX"},
+		{RequestStatuses: "Q"},
+		{ReleasedFrom: "2026-01-01", ReleasedTo: "20261231"},
+		{ReleasedFrom: "20260101"},
+		{Source: "eclipse"},
+	} {
+		if _, err := bad.normalized("developer"); err == nil {
+			t.Errorf("%+v should be rejected", bad)
+		}
+	}
+}
+
+func TestQueryTransportsParamsSendsTypeAndStatus(t *testing.T) {
+	client, mock := newTransportTestClient(t, map[string][]string{
+		transportRequestsPath: {treeWithProjects},
+	})
+
+	res, err := client.QueryTransports(context.Background(), TransportQuery{
+		User: "developer", Targets: true, Source: TransportSourceParams,
+		RequestStatuses: "D", ReleasedFrom: "20260101", ReleasedTo: "20261231",
+	})
+	if err != nil {
+		t.Fatalf("QueryTransports: %v", err)
+	}
+	if res.Source != TransportSourceParams {
+		t.Errorf("source = %q, want params", res.Source)
+	}
+
+	query := mock.requests[len(mock.requests)-1].URL.Query()
+	for key, want := range map[string]string{
+		"user": "DEVELOPER", "targets": "true", "requestType": "KWT", "requestStatus": "D",
+		"releasedFromDate": "20260101", "releasedToDate": "20261231",
+	} {
+		if got := query.Get(key); got != want {
+			t.Errorf("query %s = %q, want %q", key, got, want)
+		}
+	}
+	if query.Has("configUri") {
+		t.Errorf("params source must not send configUri")
+	}
+}
+
+func TestQueryTransportsAutoFallsBackToConfigThenSQL(t *testing.T) {
+	// The tree answers nothing for the explicit parameters, the saved
+	// configuration of another user answers the full tree.
+	client, mock := newTransportTestClient(t, map[string][]string{
+		transportRequestsPath + "?requestStatus":      {emptyTree},
+		transportRequestsPath + "?configUri":          {treeWithProjects},
+		transportSearchConfigsPath:                    {configurationsList},
+		transportSearchConfigsPath + "/CFG-DEVELOPER": {configurationFor("DEVELOPER")},
+		transportSearchConfigsPath + "/CFG-OTHER":     {configurationFor("OTHER")},
+	})
+
+	res, err := client.QueryTransports(context.Background(), TransportQuery{User: "SOMEONE", Targets: true})
+	if err != nil {
+		t.Fatalf("QueryTransports: %v", err)
+	}
+	if res.Source != TransportSourceConfig {
+		t.Fatalf("source = %q, want config (notes: %v)", res.Source, res.Notes)
+	}
+	if res.ConfigURI != transportSearchConfigsPath+"/CFG-DEVELOPER" {
+		t.Errorf("configUri = %q, want the first configuration rebuilt from its id", res.ConfigURI)
+	}
+	if len(res.Transports.Workbench) != 3 {
+		t.Errorf("workbench = %d, want 3", len(res.Transports.Workbench))
+	}
+
+	var sawParams, sawConfig bool
+	for _, r := range mock.requests {
+		if r.URL.Path != transportRequestsPath {
+			continue
+		}
+		if r.URL.Query().Get("requestStatus") == "DR" {
+			sawParams = true
+		}
+		if r.URL.Query().Get("configUri") != "" {
+			sawConfig = true
+		}
+	}
+	if !sawParams || !sawConfig {
+		t.Errorf("expected the tree to be asked with parameters first and via configUri second (params=%v config=%v)", sawParams, sawConfig)
+	}
+
+	joined := strings.Join(res.Notes, "\n")
+	for _, want := range []string{"returned no requests", "no search configuration names user SOMEONE", "excludes released requests", "were not applied"} {
+		if !strings.Contains(joined, want) {
+			t.Errorf("notes should mention %q, got:\n%s", want, joined)
+		}
+	}
+}
+
+func TestQueryTransportsConfigMatchesUser(t *testing.T) {
+	client, _ := newTransportTestClient(t, map[string][]string{
+		transportRequestsPath + "?configUri":          {treeWithProjects},
+		transportSearchConfigsPath:                    {configurationsList},
+		transportSearchConfigsPath + "/CFG-DEVELOPER": {configurationFor("DEVELOPER")},
+		transportSearchConfigsPath + "/CFG-OTHER":     {configurationFor("OTHER")},
+	})
+
+	res, err := client.QueryTransports(context.Background(), TransportQuery{User: "other", Source: TransportSourceConfig, Targets: true})
+	if err != nil {
+		t.Fatalf("QueryTransports: %v", err)
+	}
+	if res.ConfigURI != transportSearchConfigsPath+"/CFG-OTHER" {
+		t.Errorf("configUri = %q, want the configuration saved for OTHER", res.ConfigURI)
+	}
+	for _, n := range res.Notes {
+		if strings.Contains(n, "no search configuration names user") {
+			t.Errorf("a matching configuration must not be reported as foreign: %s", n)
+		}
+	}
+}
+
+func TestQueryTransportsConfigWithoutAnyConfiguration(t *testing.T) {
+	client, _ := newTransportTestClient(t, map[string][]string{
+		transportSearchConfigsPath: {`<?xml version="1.0"?><configurations:configurations xmlns:configurations="http://www.sap.com/adt/configurations"/>`},
+	})
+	_, err := client.QueryTransports(context.Background(), TransportQuery{Source: TransportSourceConfig, Targets: true})
+	if err == nil || !strings.Contains(err.Error(), "Configure Tree") {
+		t.Errorf("expected an error pointing at Eclipse's Configure Tree, got %v", err)
+	}
+}
+
+func TestListTransportsKeepsReleasedRows(t *testing.T) {
+	client, _ := newTransportTestClient(t, map[string][]string{
+		transportRequestsPath: {treeWithProjects},
+	})
+	rows, err := client.ListTransports(context.Background(), "developer")
+	if err != nil {
+		t.Fatalf("ListTransports: %v", err)
+	}
+	buckets := make([]string, 0, len(rows))
+	for _, r := range rows {
+		buckets = append(buckets, r.Number+"="+r.Bucket)
+	}
+	if len(rows) != 4 {
+		t.Fatalf("rows = %d (%v), want 4 incl. the released one", len(rows), buckets)
+	}
+	for _, r := range rows {
+		if r.Number == "TR-REL-1" && (r.Bucket != "released" || r.StatusText != "Released") {
+			t.Errorf("released row not marked: %+v", r)
+		}
+		if r.Number == "TR-CUS-1" && r.Type != "W" {
+			t.Errorf("customizing row type = %q, want W", r.Type)
+		}
+	}
+}
+
+func TestSQLLetterList(t *testing.T) {
+	if got := sqlLetterList("KW", nil); got != "'K', 'W'" {
+		t.Errorf("got %q", got)
+	}
+	if got := sqlLetterList("DR", map[string]string{"D": "'D', 'L'", "R": "'R', 'N'"}); got != "'D', 'L', 'R', 'N'" {
+		t.Errorf("got %q", got)
+	}
+	if got := sapLanguageKey("DE"); got != "D" {
+		t.Errorf("DE -> %q", got)
+	}
+	if got := sapLanguageKey(""); got != "E" {
+		t.Errorf("empty -> %q", got)
+	}
+}

--- a/pkg/adt/transport_tree.go
+++ b/pkg/adt/transport_tree.go
@@ -84,6 +84,10 @@ type ctsRequest struct {
 	// separate the two. Bucket is "modifiable", "released", or "".
 	Section string
 	Bucket  string
+	// Project and ProjectID come from the tm:project level the organizer
+	// inserts between target and bucket when requests carry a CTS project.
+	Project   string
+	ProjectID string
 
 	Tasks   []ctsRequest
 	Objects []ctsObject
@@ -94,6 +98,8 @@ type ctsScope struct {
 	section    string
 	target     string
 	targetDesc string
+	project    string
+	projectID  string
 	bucket     string
 }
 
@@ -121,6 +127,9 @@ func collectCTSRequests(n ctsNode, sc ctsScope, out *[]ctsRequest) {
 		if v := n.attr("desc"); v != "" {
 			sc.targetDesc = v
 		}
+	case "project":
+		sc.project = n.attr("name")
+		sc.projectID = n.attr("projectId")
 	case "modifiable":
 		sc.bucket = "modifiable"
 	case "released":
@@ -153,6 +162,8 @@ func newCTSRequest(n ctsNode, sc ctsScope) ctsRequest {
 		LastChanged: n.attr("lastchanged_timestamp"),
 		Section:     sc.section,
 		Bucket:      sc.bucket,
+		Project:     sc.project,
+		ProjectID:   sc.projectID,
 	}
 
 	// The enclosing tm:target names the target when the request element does


### PR DESCRIPTION
Independent of the other two open PRs; branches from current `main`. It also applies cleanly on top of `feat/transport-merge-move` (checked with a three-way apply — different hunks in `handlers_transport.go` and `handlers_help.go`).

## The bug

`GET /sap/bc/adt/cts/transportrequests` answers with **released requests of the last two weeks only** unless `requestStatus` is sent. Read in the backend (`CL_CTS_ADT_TM_RES_COLL_CONT`, ABAP 7.57): the handler builds the selection criteria for modifiable requests, but processes the hits only inside a block that requires a `D` in the status list — with the list empty, the block is skipped. `GetUserTransports` and `ListTransports` sent `user` and `targets` alone, so a user with three modifiable requests saw one released request and none of their own. The E070/E07T fallback used to mask this: the old parser found nothing in a tree without a `modifiable` bucket and fell back to SQL; the generic tree parser (#111, #140) finds the released request, skips the fallback and exposes the gap.

ADT discovery advertises only `{?targets}`. What the handler actually reads: `requestType` (letters of K/W/T), `requestStatus` (letters of D/R), `user`, `targetuser`, `targets`, `releasedFromDate`/`releasedToDate` (YYYYMMDD) and the deprecated `req_cat`/`status` — or `configUri` pointing at a saved Transport Organizer search configuration, which is what Eclipse sends; the configuration then decides everything, including the user. All of it is written down as the package comment of `pkg/adt/transport_query.go`.

## What changes

- **`TransportQuery`** (user, request types with default `KWT`, statuses with default `DR`, released window, targets, source, configuration URI) drives `GetUserTransports`, `ListTransports` and `vsp transport list`; the old functions stay as wrappers.
- **`source`**: `auto` (default) asks the tree with explicit parameters, then through the saved search configuration, then E070/E07T — the first source with requests wins, and the answer names the source and every fallback in `notes`. `params`, `config` (the configuration whose `User` property matches is used; a mismatch is used anyway and reported) and `sql` select one path.
- Rows carry **`bucket`** (`modifiable`/`released`) and the **CTS project** the tree groups by (`tm:project`, a level the parser now knows).
- `ListTransports` lists released rows too by default; `request_status=D` restores the old listing. The SQL fallback filters by the requested types and statuses and reads `E07T` in the session language instead of `E` only.
- MCP: both tools take `request_type`, `request_status`, `released_from`, `released_to`, `targets`, `source` and `config_uri`; `get_user_transports` no longer requires `user_name`. CLI: `--type`, `--status`, `--released-from`, `--released-to`, `--source`, `--config-uri`, `--no-targets` and a BUCKET column.
- Docs: tool descriptions, the hyperfocused help, `MCP_USAGE.md` (new Transports section), `README_TOOLS.md`, `docs/cli-guide.md` and `docs/adr/006-transport-organizer-explicit-filters.md`.

## Tests

`transport_query_test.go`: a tree with the project level, defaults and validation, the parameters actually sent, `auto` falling back to `config` with the notes, a configuration matched by user, no configuration at all, released rows kept, the SQL helpers. `go build ./...`, `go vet` and `go test ./pkg/adt ./internal/mcp ./cmd/vsp` are green.

Live on ABAP 7.57: the defaults return five requests (three modifiable workbench, one released, one customizing) where 2.56.0 returned one; `source=config` returns the same five through the saved configuration; a released window over a full year returns twelve; `source=sql` for another user returns that user's four with descriptions in the session language.
