### PR TITLE
fix(adt): guard against session-holding proxy chains injecting a stale sap-contextid

### DIFF
--- a/pkg/adt/config.go
+++ b/pkg/adt/config.go
@@ -67,6 +67,24 @@ type Config struct {
 	// stop to ask a human something — a browser sign-in with a second factor
 	// takes far longer than any machine-to-machine handshake.
 	ReauthTimeout time.Duration
+
+	// ProxyContextIDGuard enables a workaround for session-holding proxy
+	// chains such as the SAP Business Application Studio destination proxy
+	// (HTTP_PROXY=127.0.0.1:8887 → secure-outbound-connectivity → BTP
+	// destination → Cloud Connector). Verified against BAS: the chain keeps
+	// the SAP sap-contextid itself — a live Set-Cookie for it never reaches
+	// the client, deletion cookies do — and injects the stored context into
+	// every request that carries no Cookie header. A stateless request served
+	// in that context ends it on the SAP side, after which every following
+	// request fails with ICMENOSESSION and the chain never recovers on its
+	// own. The ICM honours the first sap-contextid in the Cookie header, so an
+	// explicit empty "sap-contextid=" suppresses the injection. When enabled:
+	// stateless requests carry that empty cookie (the stateful context
+	// survives), the CSRF probe and every LOCK open a fresh stateful context
+	// with it (the chain re-learns the live one from the response), and after
+	// UNLOCK a stateless probe without the cookie retires the context.
+	// Also enabled via SAP_PROXY_CONTEXTID_GUARD=true.
+	ProxyContextIDGuard bool
 }
 
 // Option is a functional option for configuring the ADT client.
@@ -108,6 +126,14 @@ func WithLanguage(lang string) Option {
 func WithInsecureSkipVerify() Option {
 	return func(c *Config) {
 		c.InsecureSkipVerify = true
+	}
+}
+
+// WithProxyContextIDGuard enables the session-holding-proxy workaround
+// (see Config.ProxyContextIDGuard).
+func WithProxyContextIDGuard() Option {
+	return func(c *Config) {
+		c.ProxyContextIDGuard = true
 	}
 }
 

--- a/pkg/adt/config.go
+++ b/pkg/adt/config.go
@@ -290,17 +290,37 @@ func (c *Config) NewHTTPClient() *http.Client {
 		Timeout:   c.Timeout,
 	}
 
-	// Preserve Authorization header across redirects.
-	// Go's default strips it per RFC 7235 §4.2, but SAP BTP/Cloud
-	// authentication flows require it to survive redirects.
-	// Without this, BTP users get 401 even though curl works (issue #90).
+	// Preserve ADT-critical headers across redirects.
+	//
+	// Go's default strips Authorization / WWW-Authenticate / Cookie / Cookie2
+	// on cross-origin redirects per RFC 7235 §4.2 — SAP BTP/Cloud SAML flows
+	// need Authorization back, otherwise the IdP dance drops it and the user
+	// gets 401 even though curl works (issue #90).
+	//
+	// Custom headers like X-CSRF-Token and X-sap-adt-sessiontype are *not*
+	// in Go's sensitive-headers list, so Go technically forwards them by
+	// default. We re-set them explicitly anyway for two reasons:
+	//   - defensive: guards against any Go version or middleware tweak that
+	//     decides to strip custom headers on its own;
+	//   - intent: makes it obvious in the code that these two headers are
+	//     load-bearing for the lock→write→unlock ADT sequence. If either
+	//     goes missing across a redirect, the second hop hits SAP with a
+	//     fresh (stateless) session-type or a missing CSRF token, and the
+	//     lock handle / mutation is rejected.
 	client.CheckRedirect = func(req *http.Request, via []*http.Request) error {
 		if len(via) >= 10 {
 			return fmt.Errorf("too many redirects")
 		}
 		if len(via) > 0 {
-			if auth := via[0].Header.Get("Authorization"); auth != "" {
+			first := via[0]
+			if auth := first.Header.Get("Authorization"); auth != "" {
 				req.Header.Set("Authorization", auth)
+			}
+			if csrf := first.Header.Get("X-CSRF-Token"); csrf != "" {
+				req.Header.Set("X-CSRF-Token", csrf)
+			}
+			if st := first.Header.Get("X-sap-adt-sessiontype"); st != "" {
+				req.Header.Set("X-sap-adt-sessiontype", st)
 			}
 		}
 		return nil

--- a/pkg/adt/config_test.go
+++ b/pkg/adt/config_test.go
@@ -1,6 +1,7 @@
 package adt
 
 import (
+	"context"
 	"net/http"
 	"testing"
 	"time"
@@ -200,5 +201,83 @@ func TestSessionTypes(t *testing.T) {
 	}
 	if SessionKeep != "keep" {
 		t.Errorf("SessionKeep = %v, want keep", SessionKeep)
+	}
+}
+
+// TestNewHTTPClient_CheckRedirectPreservesADTHeaders verifies that the
+// HTTP client's CheckRedirect callback re-sets headers that are
+// load-bearing for the ADT lock→write→unlock sequence across redirects:
+//   - Authorization: Go strips this by default on cross-origin redirects
+//     (sensitive header per RFC 7235). Without restoration, SAML flows get
+//     401 even when curl works (issue #90).
+//   - X-CSRF-Token: mutation requests are rejected as CSRF-violating if
+//     this disappears mid-sequence.
+//   - X-sap-adt-sessiontype: the lock handle is bound to a stateful
+//     session; if a redirect hop lands stateless, the subsequent PUT
+//     can't find the lock and gets HTTP 423.
+//
+// Go's default forwards custom headers on same-origin redirects, but this
+// test pins the behaviour explicitly so future refactors can't silently
+// drop them.
+func TestNewHTTPClient_CheckRedirectPreservesADTHeaders(t *testing.T) {
+	cfg := NewConfig("https://sap.example.com:44300", "user", "pass")
+	client := cfg.NewHTTPClient()
+
+	if client.CheckRedirect == nil {
+		t.Fatal("CheckRedirect must be set")
+	}
+
+	// Build the "via" chain: the original request that carries the ADT
+	// headers we expect to be re-set on the redirect target.
+	orig, err := http.NewRequestWithContext(context.Background(), http.MethodPost,
+		"https://sap.example.com:44300/sap/bc/adt/oo/classes/ZFOO?_action=LOCK", nil)
+	if err != nil {
+		t.Fatalf("NewRequest(orig): %v", err)
+	}
+	orig.Header.Set("Authorization", "Basic dXNlcjpwYXNz")
+	orig.Header.Set("X-CSRF-Token", "ABC123==")
+	orig.Header.Set("X-sap-adt-sessiontype", "stateful")
+
+	// The redirect target that Go would follow — initially without any
+	// of the ADT headers (simulating Go having stripped them cross-origin).
+	next, err := http.NewRequestWithContext(context.Background(), http.MethodPost,
+		"https://sap.example.com:44300/sap/bc/adt/follow", nil)
+	if err != nil {
+		t.Fatalf("NewRequest(next): %v", err)
+	}
+
+	if err := client.CheckRedirect(next, []*http.Request{orig}); err != nil {
+		t.Fatalf("CheckRedirect returned error: %v", err)
+	}
+
+	if got := next.Header.Get("Authorization"); got != "Basic dXNlcjpwYXNz" {
+		t.Errorf("Authorization = %q, want preserved from initial request (issue #90)", got)
+	}
+	if got := next.Header.Get("X-CSRF-Token"); got != "ABC123==" {
+		t.Errorf("X-CSRF-Token = %q, want preserved — mutation requests need it to survive redirect hops", got)
+	}
+	if got := next.Header.Get("X-sap-adt-sessiontype"); got != "stateful" {
+		t.Errorf("X-sap-adt-sessiontype = %q, want preserved — lock handles are bound to a stateful session (issue #88)", got)
+	}
+}
+
+// TestNewHTTPClient_CheckRedirectHonoursLimit guards the 10-redirect cap
+// that CheckRedirect enforces to prevent infinite loops.
+func TestNewHTTPClient_CheckRedirectHonoursLimit(t *testing.T) {
+	cfg := NewConfig("https://sap.example.com:44300", "user", "pass")
+	client := cfg.NewHTTPClient()
+
+	if client.CheckRedirect == nil {
+		t.Fatal("CheckRedirect must be set")
+	}
+
+	next, _ := http.NewRequestWithContext(context.Background(), http.MethodGet, "https://sap.example.com:44300/", nil)
+	via := make([]*http.Request, 10)
+	for i := range via {
+		via[i], _ = http.NewRequestWithContext(context.Background(), http.MethodGet, "https://sap.example.com:44300/", nil)
+	}
+
+	if err := client.CheckRedirect(next, via); err == nil {
+		t.Error("CheckRedirect must return an error on the 10th redirect")
 	}
 }

--- a/pkg/adt/crud.go
+++ b/pkg/adt/crud.go
@@ -48,6 +48,9 @@ func (c *Client) LockObject(ctx context.Context, objectURL string, accessMode st
 		Query:    params,
 		Accept:   "application/vnd.sap.as+xml;charset=UTF-8;dataname=com.sap.adt.lock.result",
 		Stateful: true, // Lock handles are session-specific — force stateful (issue #88)
+		// Behind a session-holding proxy, every chain starts in its own context:
+		// one reused across chains loses the activation worklist entry.
+		FreshContext: true,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("locking object: %w", err)
@@ -167,6 +170,10 @@ func (c *Client) UnlockObject(ctx context.Context, objectURL string, lockHandle 
 	// Only a *successful* unlock ends the window. A failed one may have left
 	// the lock held, and suppressing a ping is the cheaper mistake.
 	c.noteLockClosed(lockHandle)
+
+	// The chain is done with its stateful context; behind a session-holding
+	// proxy, retire it rather than leave it to the session timeout.
+	c.transport.ReleaseProxyContext(ctx)
 
 	return nil
 }

--- a/pkg/adt/http.go
+++ b/pkg/adt/http.go
@@ -145,6 +145,7 @@ func NewTransport(cfg *Config) *Transport {
 // NewTransportWithClient creates a new Transport with a custom HTTP client.
 // This is useful for testing with mock HTTP clients.
 func NewTransportWithClient(cfg *Config, client HTTPDoer) *Transport {
+	applyProxyContextIDGuardEnv(cfg)
 	t := &Transport{
 		config:     cfg,
 		httpClient: client,
@@ -175,6 +176,23 @@ type RequestOptions struct {
 	// where the lock handle is bound to a specific server-side session.
 	// When set, X-sap-adt-sessiontype header is set to "stateful" for this request.
 	Stateful bool
+
+	// FreshContext asks for a brand-new stateful context for this request when
+	// Config.ProxyContextIDGuard is on. LOCK sets it: a lock→write→unlock chain
+	// that runs inside a context another chain already used — the proxy keeps
+	// injecting the same live context — writes its inactive version but the
+	// object never reaches the activation worklist, and the activation that
+	// follows is refused with activationExecuted="false" and no message. The
+	// empty "sap-contextid=" cookie makes SAP open a new context, and the proxy
+	// re-learns it from the response.
+	FreshContext bool
+
+	// ReleaseContext lets the proxy inject its stored stateful context into a
+	// stateless request when Config.ProxyContextIDGuard is on — the one case
+	// where the guard cookie is deliberately left off. A stateless request
+	// ends the context it arrives in, which is how a finished lock chain's
+	// context is retired instead of lingering until the session timeout.
+	ReleaseContext bool
 }
 
 // Response wraps an HTTP response with convenience methods.
@@ -272,6 +290,9 @@ func (t *Transport) request(ctx context.Context, path string, opts *RequestOptio
 	// the cookies of the session it replaced is exactly the mismatch the server
 	// rejects as a CSRF failure.
 	t.addCookies(req)
+	// The proxy guard goes on after the cookies: it only steps in when no
+	// cookie of our own is on the request.
+	t.applyProxyContextIDGuard(req, opts)
 
 	// Execute request
 	traceHTTPRequest(req, opts.Body)
@@ -412,6 +433,7 @@ func (t *Transport) retryRequest(ctx context.Context, path string, opts *Request
 	if t.config.SessionType == SessionStateful {
 		req.Header.Set("X-sap-adt-sessiontype", "stateful")
 	}
+	t.applyProxyContextIDGuard(req, opts)
 
 	traceHTTPRequest(req, opts.Body)
 	resp, err := t.httpClient.Do(req)
@@ -557,6 +579,17 @@ func (t *Transport) probeCSRFToken(ctx context.Context, method string, stateful 
 		req.Header.Set("X-sap-adt-sessiontype", "stateful")
 	}
 
+	// Session-holding proxy chain: open a fresh stateful context with an
+	// empty contextid so the chain replaces its (possibly dead) stored
+	// context with the live one from this response. Verified against SAP
+	// BAS: HEAD + stateful + "Cookie: sap-contextid=" heals ICMENOSESSION
+	// for all follow-up requests; without the stateful header the chain
+	// keeps the dead one.
+	if t.config.ProxyContextIDGuard && !t.hasJarCookies(req) && req.Header.Get("Cookie") == "" {
+		req.Header.Set("X-sap-adt-sessiontype", "stateful")
+		req.Header.Set("Cookie", "sap-contextid=")
+	}
+
 	traceHTTPRequest(req, nil)
 	resp, err := t.httpClient.Do(req)
 	if err != nil {
@@ -676,6 +709,94 @@ func (t *Transport) extractSessionID(resp *http.Response) string {
 		}
 	}
 	return ""
+}
+
+// applyProxyContextIDGuardEnv switches Config.ProxyContextIDGuard on when
+// SAP_PROXY_CONTEXTID_GUARD=true is set in the environment.
+func applyProxyContextIDGuardEnv(cfg *Config) {
+	if cfg == nil || cfg.ProxyContextIDGuard {
+		return
+	}
+	if strings.EqualFold(strings.TrimSpace(os.Getenv("SAP_PROXY_CONTEXTID_GUARD")), "true") {
+		cfg.ProxyContextIDGuard = true
+	}
+}
+
+// hasJarCookies reports whether the cookie jar holds cookies for the
+// request URL (i.e. we talk to SAP directly and manage the session
+// ourselves). Behind a session-holding proxy chain the jar stays empty for
+// sap-contextid: the chain absorbs the live Set-Cookie and only deletion
+// cookies (which the jar does not keep) get through.
+func (t *Transport) hasJarCookies(req *http.Request) bool {
+	client, ok := t.httpClient.(*http.Client)
+	if !ok || client.Jar == nil || req.URL == nil {
+		return false
+	}
+	return len(client.Jar.Cookies(req.URL)) > 0
+}
+
+// applyProxyContextIDGuard sends an explicit empty "sap-contextid=" cookie
+// on stateless requests when Config.ProxyContextIDGuard is enabled and no
+// cookie (jar or user-provided) is present. The ICM honours the first
+// sap-contextid in the header, so the empty value wins over whatever the
+// session-holding chain appends, and the stateless request no longer ends
+// the stateful context the chain keeps — which would leave every following
+// request in ICMENOSESSION. Stateful requests are left alone so the chain
+// keeps injecting the live context that lock handles are bound to — except
+// when the request asks for a fresh context (RequestOptions.FreshContext),
+// where the same empty cookie makes SAP open a new one and the chain
+// re-learns it. RequestOptions.ReleaseContext leaves a stateless request
+// without the cookie on purpose, so the injected context is ended.
+func (t *Transport) applyProxyContextIDGuard(req *http.Request, opts *RequestOptions) {
+	if !t.config.ProxyContextIDGuard {
+		return
+	}
+	if req.Header.Get("Cookie") != "" || t.hasJarCookies(req) {
+		return
+	}
+	if opts != nil && opts.ReleaseContext {
+		return
+	}
+	if req.Header.Get("X-sap-adt-sessiontype") == "stateful" && (opts == nil || !opts.FreshContext) {
+		return
+	}
+	req.Header.Set("Cookie", "sap-contextid=")
+}
+
+// ReleaseProxyContext retires the stateful context a session-holding proxy
+// chain currently injects, once a lock chain is finished with it. Without
+// the guard there is nothing to retire and the call is a no-op. The request
+// is a cheap stateless HEAD that carries no guard cookie, so the chain
+// injects its stored context and SAP ends it (verified: SM04 shows no
+// lingering ADT sessions afterwards). Failures are ignored: an already-dead
+// context answers ICMENOSESSION, which is the state this call wants anyway,
+// and the next LOCK opens a fresh context regardless.
+func (t *Transport) ReleaseProxyContext(ctx context.Context) {
+	if !t.config.ProxyContextIDGuard {
+		return
+	}
+	reqURL, err := t.buildURL("/sap/bc/adt/core/discovery", nil)
+	if err != nil {
+		return
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodHead, reqURL, nil)
+	if err != nil {
+		return
+	}
+	if t.config.HasBasicAuth() {
+		req.SetBasicAuth(t.config.Username, t.config.Password)
+	}
+	t.addCookies(req)
+	req.Header.Set("Accept", "*/*")
+	req.Header.Set("X-sap-adt-sessiontype", "stateless")
+	traceHTTPRequest(req, nil)
+	resp, err := t.httpClient.Do(req)
+	if err != nil {
+		return
+	}
+	defer resp.Body.Close()
+	_, _ = io.Copy(io.Discard, resp.Body)
+	traceHTTPResponse(resp, nil)
 }
 
 // CSRF token accessors with mutex protection

--- a/pkg/adt/http.go
+++ b/pkg/adt/http.go
@@ -15,6 +15,97 @@ import (
 	"time"
 )
 
+// httpTraceEnabled reports whether the VSP_HTTP_TRACE env var requests raw
+// HTTP request/response dumps to stderr. Diagnostic-only — never leaves the
+// binary switched on by default, and Authorization / Cookie values are
+// redacted so the dump is safe to paste.
+func httpTraceEnabled() bool {
+	v := os.Getenv("VSP_HTTP_TRACE")
+	return v == "1" || strings.EqualFold(v, "true")
+}
+
+const httpTraceBodyLimit = 4096
+
+var (
+	traceOutMu sync.Mutex
+	traceOut   io.Writer
+)
+
+// traceWriter returns where HTTP trace lines go: the file named by
+// VSP_TRACE_LOG (appended, created on first use), otherwise stderr. An MCP
+// server's stderr is rarely visible, so the file is what makes the trace
+// readable there.
+func traceWriter() io.Writer {
+	traceOutMu.Lock()
+	defer traceOutMu.Unlock()
+	if traceOut != nil {
+		return traceOut
+	}
+	if path := strings.TrimSpace(os.Getenv("VSP_TRACE_LOG")); path != "" {
+		if f, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o600); err == nil {
+			traceOut = f
+			return traceOut
+		}
+	}
+	traceOut = os.Stderr
+	return traceOut
+}
+
+func traceHTTPRequest(req *http.Request, body []byte) {
+	if !httpTraceEnabled() {
+		return
+	}
+	w := traceWriter()
+	fmt.Fprintf(w, "\n>>> HTTP %s %s %s\n", time.Now().UTC().Format(time.RFC3339Nano), req.Method, req.URL.String())
+	for k, vs := range req.Header {
+		for _, v := range vs {
+			if strings.EqualFold(k, "Authorization") || strings.EqualFold(k, "Cookie") {
+				v = "[REDACTED]"
+			}
+			fmt.Fprintf(w, ">>> %s: %s\n", k, v)
+		}
+	}
+	if len(body) > 0 {
+		trunc := body
+		if len(trunc) > httpTraceBodyLimit {
+			trunc = trunc[:httpTraceBodyLimit]
+		}
+		fmt.Fprintf(w, ">>> body (%d bytes):\n%s\n", len(body), string(trunc))
+		if len(body) > httpTraceBodyLimit {
+			fmt.Fprintf(w, ">>> ... (truncated)\n")
+		}
+	}
+}
+
+func traceHTTPResponse(resp *http.Response, body []byte) {
+	if !httpTraceEnabled() || resp == nil {
+		return
+	}
+	w := traceWriter()
+	fmt.Fprintf(w, "<<< HTTP %d %s\n", resp.StatusCode, resp.Status)
+	for k, vs := range resp.Header {
+		for _, v := range vs {
+			if strings.EqualFold(k, "Set-Cookie") {
+				if i := strings.Index(v, "="); i > 0 {
+					v = v[:i] + "=[REDACTED]"
+				}
+			}
+			fmt.Fprintf(w, "<<< %s: %s\n", k, v)
+		}
+	}
+	if len(body) > 0 {
+		trunc := body
+		if len(trunc) > httpTraceBodyLimit {
+			trunc = trunc[:httpTraceBodyLimit]
+		}
+		fmt.Fprintf(w, "<<< body (%d bytes):\n%s\n", len(body), string(trunc))
+		if len(body) > httpTraceBodyLimit {
+			fmt.Fprintf(w, "<<< ... (truncated)\n")
+		}
+	}
+	fmt.Fprintln(w)
+}
+
 // HTTPDoer is an interface for executing HTTP requests.
 // This abstraction allows for easy testing with mock implementations.
 type HTTPDoer interface {
@@ -183,6 +274,7 @@ func (t *Transport) request(ctx context.Context, path string, opts *RequestOptio
 	t.addCookies(req)
 
 	// Execute request
+	traceHTTPRequest(req, opts.Body)
 	resp, err := t.httpClient.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("executing request: %w", err)
@@ -194,6 +286,7 @@ func (t *Transport) request(ctx context.Context, path string, opts *RequestOptio
 	if err != nil {
 		return nil, fmt.Errorf("reading response body: %w", err)
 	}
+	traceHTTPResponse(resp, body)
 	t.adoptServerCookies(resp)
 
 	// The same expiry reaches a plain read as a successful-looking response that
@@ -245,6 +338,12 @@ func (t *Transport) request(ctx context.Context, path string, opts *RequestOptio
 			// Clear cached CSRF token and session ID
 			t.setCSRFToken("")
 			t.setSessionID("")
+			// Drop the stale sap-contextid / SAP_SESSIONID cookies too: the
+			// stateless activation that ended the context on the SAP side left
+			// them in the jar, and every retry that re-sends them is answered
+			// with ICMENOSESSION again — including the /core/discovery probe
+			// that is supposed to open the fresh session.
+			t.resetCookieJar()
 			// Fetch new CSRF token (this establishes a new session)
 			if err := t.fetchCSRFTokenFor(ctx, opts.Stateful); err != nil {
 				return nil, fmt.Errorf("refreshing session after timeout: %w", err)
@@ -314,6 +413,7 @@ func (t *Transport) retryRequest(ctx context.Context, path string, opts *Request
 		req.Header.Set("X-sap-adt-sessiontype", "stateful")
 	}
 
+	traceHTTPRequest(req, opts.Body)
 	resp, err := t.httpClient.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("executing retry request: %w", err)
@@ -324,6 +424,7 @@ func (t *Transport) retryRequest(ctx context.Context, path string, opts *Request
 	if err != nil {
 		return nil, fmt.Errorf("reading response body: %w", err)
 	}
+	traceHTTPResponse(resp, body)
 
 	if resp.StatusCode >= 400 {
 		return nil, &APIError{
@@ -456,6 +557,7 @@ func (t *Transport) probeCSRFToken(ctx context.Context, method string, stateful 
 		req.Header.Set("X-sap-adt-sessiontype", "stateful")
 	}
 
+	traceHTTPRequest(req, nil)
 	resp, err := t.httpClient.Do(req)
 	if err != nil {
 		return "", 0, false, fmt.Errorf("executing request: %w", err)
@@ -463,6 +565,7 @@ func (t *Transport) probeCSRFToken(ctx context.Context, method string, stateful 
 	defer resp.Body.Close()
 	// Drain the body so the connection can be reused.
 	_, _ = io.Copy(io.Discard, resp.Body)
+	traceHTTPResponse(resp, nil)
 	t.adoptServerCookies(resp)
 
 	return resp.Header.Get("X-CSRF-Token"), resp.StatusCode, t.redirectedAwayFromSAP(resp), nil

--- a/pkg/adt/http_proxy_contextid_test.go
+++ b/pkg/adt/http_proxy_contextid_test.go
@@ -1,0 +1,190 @@
+package adt
+
+import (
+	"context"
+	"net/http"
+	"net/http/cookiejar"
+	"net/url"
+	"testing"
+)
+
+// Session-holding proxies (SAP BAS destination proxy) strip Set-Cookie and
+// inject their stored sap-contextid into every request without a Cookie
+// header. These tests pin the guard behaviour: stateless requests get an
+// explicit empty sap-contextid, stateful ones don't, the CSRF fetch heals
+// with stateful + empty contextid, and nothing changes when the guard is
+// off or when a real cookie jar is in play.
+
+func TestProxyContextIDGuard_StatelessGetsEmptyContextID(t *testing.T) {
+	mock := &mockHTTPClient{responses: []*http.Response{
+		newMockResponse(200, "OK", nil), //nolint:bodyclose // mock response; Transport.Request drains and closes it
+	}}
+	cfg := NewConfig("https://sap.example.com", "u", "p", WithProxyContextIDGuard())
+	tr := NewTransportWithClient(cfg, mock)
+
+	if _, err := tr.Request(context.Background(), "/sap/bc/adt/x", nil); err != nil {
+		t.Fatalf("Request: %v", err)
+	}
+	req := mock.requests[0]
+	if got := req.Header.Get("X-sap-adt-sessiontype"); got != "stateless" {
+		t.Fatalf("sessiontype = %q, want stateless", got)
+	}
+	if got := req.Header.Get("Cookie"); got != "sap-contextid=" {
+		t.Errorf("Cookie = %q, want sap-contextid=", got)
+	}
+}
+
+func TestProxyContextIDGuard_StatefulUntouched(t *testing.T) {
+	mock := &mockHTTPClient{responses: []*http.Response{
+		newMockResponse(200, "OK", nil), //nolint:bodyclose // mock response; Transport.Request drains and closes it
+	}}
+	cfg := NewConfig("https://sap.example.com", "u", "p", WithProxyContextIDGuard())
+	tr := NewTransportWithClient(cfg, mock)
+
+	if _, err := tr.Request(context.Background(), "/sap/bc/adt/x", &RequestOptions{Stateful: true}); err != nil {
+		t.Fatalf("Request: %v", err)
+	}
+	req := mock.requests[0]
+	if got := req.Header.Get("X-sap-adt-sessiontype"); got != "stateful" {
+		t.Fatalf("sessiontype = %q, want stateful", got)
+	}
+	if got := req.Header.Get("Cookie"); got != "" {
+		t.Errorf("Cookie = %q, want empty (proxy must inject its live context)", got)
+	}
+}
+
+func TestProxyContextIDGuard_DisabledByDefault(t *testing.T) {
+	t.Setenv("SAP_PROXY_CONTEXTID_GUARD", "")
+	mock := &mockHTTPClient{responses: []*http.Response{
+		newMockResponse(200, "OK", nil), //nolint:bodyclose // mock response; Transport.Request drains and closes it
+	}}
+	cfg := NewConfig("https://sap.example.com", "u", "p")
+	tr := NewTransportWithClient(cfg, mock)
+
+	if _, err := tr.Request(context.Background(), "/sap/bc/adt/x", nil); err != nil {
+		t.Fatalf("Request: %v", err)
+	}
+	if got := mock.requests[0].Header.Get("Cookie"); got != "" {
+		t.Errorf("Cookie = %q, want none when guard disabled", got)
+	}
+}
+
+func TestProxyContextIDGuard_EnabledByEnv(t *testing.T) {
+	t.Setenv("SAP_PROXY_CONTEXTID_GUARD", "true")
+	mock := &mockHTTPClient{responses: []*http.Response{
+		newMockResponse(200, "OK", nil), //nolint:bodyclose // mock response; Transport.Request drains and closes it
+	}}
+	cfg := NewConfig("https://sap.example.com", "u", "p")
+	tr := NewTransportWithClient(cfg, mock)
+
+	if _, err := tr.Request(context.Background(), "/sap/bc/adt/x", nil); err != nil {
+		t.Fatalf("Request: %v", err)
+	}
+	if got := mock.requests[0].Header.Get("Cookie"); got != "sap-contextid=" {
+		t.Errorf("Cookie = %q, want sap-contextid= (env-enabled)", got)
+	}
+}
+
+func TestProxyContextIDGuard_SkippedWhenJarHasCookies(t *testing.T) {
+	jar, _ := cookiejar.New(nil)
+	u, _ := url.Parse("https://sap.example.com/sap/bc/adt/x")
+	jar.SetCookies(u, []*http.Cookie{{Name: "sap-contextid", Value: "live", Path: "/"}})
+	hc := &http.Client{Jar: jar, Transport: nil}
+
+	cfg := NewConfig("https://sap.example.com", "u", "p", WithProxyContextIDGuard())
+	tr := NewTransportWithClient(cfg, hc)
+
+	req, _ := http.NewRequestWithContext(context.Background(), http.MethodGet, "https://sap.example.com/sap/bc/adt/x", nil)
+	req.Header.Set("X-sap-adt-sessiontype", "stateless")
+	tr.applyProxyContextIDGuard(req, nil)
+	if got := req.Header.Get("Cookie"); got != "" {
+		t.Errorf("Cookie = %q, want none when the jar manages the session", got)
+	}
+}
+
+func TestProxyContextIDGuard_CSRFFetchHealsWithStatefulEmptyContext(t *testing.T) {
+	mock := &mockHTTPClient{responses: []*http.Response{
+		newMockResponse(400, "", map[string]string{"X-CSRF-Token": "tok"}), //nolint:bodyclose // HEAD /core/discovery; mock response, drained and closed by Transport.Request
+		newMockResponse(200, "OK", nil),                                    //nolint:bodyclose // POST; mock response, drained and closed by Transport.Request
+	}}
+	cfg := NewConfig("https://sap.example.com", "u", "p", WithProxyContextIDGuard())
+	tr := NewTransportWithClient(cfg, mock)
+
+	if _, err := tr.Request(context.Background(), "/sap/bc/adt/x", &RequestOptions{Method: http.MethodPost, Body: []byte("<x/>")}); err != nil {
+		t.Fatalf("Request: %v", err)
+	}
+	if len(mock.requests) != 2 {
+		t.Fatalf("requests = %d, want 2 (CSRF fetch + POST)", len(mock.requests))
+	}
+	head := mock.requests[0]
+	if head.Method != http.MethodHead {
+		t.Fatalf("first request method = %s, want HEAD", head.Method)
+	}
+	if got := head.Header.Get("X-sap-adt-sessiontype"); got != "stateful" {
+		t.Errorf("CSRF fetch sessiontype = %q, want stateful", got)
+	}
+	if got := head.Header.Get("Cookie"); got != "sap-contextid=" {
+		t.Errorf("CSRF fetch Cookie = %q, want sap-contextid=", got)
+	}
+	if got := mock.requests[1].Header.Get("X-CSRF-Token"); got != "tok" {
+		t.Errorf("POST token = %q, want tok", got)
+	}
+}
+
+func TestProxyContextIDGuard_ICMENOSESSIONRecovery(t *testing.T) {
+	mock := &mockHTTPClient{responses: []*http.Response{
+		newMockResponse(400, "ICMENOSESSION", nil),                          //nolint:bodyclose // stateless GET → dead context (proxy); mock response, drained and closed by Transport.Request
+		newMockResponse(400, "", map[string]string{"X-CSRF-Token": "tok2"}), //nolint:bodyclose // heal: HEAD stateful + empty; mock response, drained and closed by Transport.Request
+		newMockResponse(200, "OK", nil),                                     //nolint:bodyclose // retry; mock response, drained and closed by Transport.Request
+	}}
+	cfg := NewConfig("https://sap.example.com", "u", "p", WithProxyContextIDGuard())
+	tr := NewTransportWithClient(cfg, mock)
+
+	if _, err := tr.Request(context.Background(), "/sap/bc/adt/x", nil); err != nil {
+		t.Fatalf("Request: %v", err)
+	}
+	if len(mock.requests) != 3 {
+		t.Fatalf("requests = %d, want 3", len(mock.requests))
+	}
+	heal := mock.requests[1]
+	if heal.Header.Get("X-sap-adt-sessiontype") != "stateful" || heal.Header.Get("Cookie") != "sap-contextid=" {
+		t.Errorf("heal request headers = %v", heal.Header)
+	}
+	if got := mock.requests[2].Header.Get("Cookie"); got != "sap-contextid=" {
+		t.Errorf("retry (stateless) Cookie = %q, want sap-contextid=", got)
+	}
+}
+
+func TestProxyContextIDGuard_FreshContextOnStatefulLock(t *testing.T) {
+	cfg := NewConfig("https://sap.example.com", "u", "p", WithProxyContextIDGuard())
+	tr := NewTransportWithClient(cfg, &mockHTTPClient{})
+
+	req, _ := http.NewRequestWithContext(context.Background(), http.MethodPost, "https://sap.example.com/sap/bc/adt/x?_action=LOCK", nil)
+	req.Header.Set("X-sap-adt-sessiontype", "stateful")
+	tr.applyProxyContextIDGuard(req, &RequestOptions{Stateful: true, FreshContext: true})
+	if got := req.Header.Get("Cookie"); got != "sap-contextid=" {
+		t.Errorf("Cookie = %q, want sap-contextid= so the LOCK opens a fresh context", got)
+	}
+}
+
+func TestProxyContextIDGuard_ReleaseContextLeavesCookieOff(t *testing.T) {
+	cfg := NewConfig("https://sap.example.com", "u", "p", WithProxyContextIDGuard())
+	tr := NewTransportWithClient(cfg, &mockHTTPClient{})
+
+	req, _ := http.NewRequestWithContext(context.Background(), http.MethodHead, "https://sap.example.com/sap/bc/adt/core/discovery", nil)
+	req.Header.Set("X-sap-adt-sessiontype", "stateless")
+	tr.applyProxyContextIDGuard(req, &RequestOptions{ReleaseContext: true})
+	if got := req.Header.Get("Cookie"); got != "" {
+		t.Errorf("Cookie = %q, want none so the proxy injects the context to be released", got)
+	}
+}
+
+func TestProxyContextIDGuard_ReleaseProxyContextIsNoopWithoutGuard(t *testing.T) {
+	mock := &mockHTTPClient{}
+	cfg := NewConfig("https://sap.example.com", "u", "p")
+	tr := NewTransportWithClient(cfg, mock)
+	tr.ReleaseProxyContext(context.Background())
+	if len(mock.requests) != 0 {
+		t.Errorf("ReleaseProxyContext sent %d request(s) without the guard, want 0", len(mock.requests))
+	}
+}

--- a/pkg/adt/workflows_edit.go
+++ b/pkg/adt/workflows_edit.go
@@ -442,6 +442,13 @@ func (c *Client) EditSourceWithOptions(ctx context.Context, objectURL, oldString
 		return result, nil
 	}
 	result.Activation = activation
+	if !activation.Success {
+		// The write went through, the activation did not: say so instead of
+		// reporting an activated object that is still inactive.
+		result.Message = fmt.Sprintf("Source updated but activation failed: %s",
+			strings.Join(activation.ProblemLines(), "; "))
+		return result, nil
+	}
 
 	result.Success = true
 	// Warnings no longer stop the write, so the message has to carry them —


### PR DESCRIPTION
> **Stacked on #207** (`fix/redirect-headers-and-icmenosession-reset`). The first commit of this PR is that PR; please review **only the second commit**. Once #PR207 is merged, this PR shows a single commit. GitHub does not accept a fork branch as base, which is why it targets `main`.

## The environment

SAP Business Application Studio dev spaces reach on-premise systems through a proxy chain: a local Go proxy sidecar (the `HTTP_PROXY` of the dev space) → the BAS connectivity service → BTP destination → Cloud Connector → SAP. Verified with curl against an ABAP 7.57 system:

- the chain **keeps the SAP `sap-contextid` itself**: a live `Set-Cookie` for it never reaches the client, deletion cookies do;
- every request that carries **no `Cookie` header gets the stored context injected**;
- a **stateless request served in that context ends it** on the SAP side — after which every request answers `ICMENOSESSION` and the chain never recovers on its own;
- the ICM honours the **first** `sap-contextid` in the `Cookie` header, so an explicit empty `sap-contextid=` suppresses the injection;
- Cookie headers the client sends are forwarded unchanged (a made-up id produces the ICMENOSESSION deletion cookies).

vsp 2.56.0 without this guard cannot complete a single call behind that chain (`no CSRF token in response (HEAD 400, GET 400)`). `--cookie-string sap-contextid=` gets reads working but breaks the lock chain: UNLOCK lands in a different context and the lock stays.

## What the guard does

`Config.ProxyContextIDGuard` / `SAP_PROXY_CONTEXTID_GUARD=true` — off by default, and without effect when a cookie jar or user-supplied cookies manage the session:

| request | cookie sent | effect |
|---|---|---|
| stateless | `sap-contextid=` | the stateful context the chain keeps survives |
| CSRF probe | `sap-contextid=`, stateful | opens a fresh context that the chain learns from the response — heals a dead one |
| LOCK (`RequestOptions.FreshContext`) | `sap-contextid=` | every lock/write/unlock chain runs in its own context |
| PUT, UNLOCK | none | the chain injects the live context the lock handle is bound to |
| after UNLOCK (`ReleaseProxyContext`, `RequestOptions.ReleaseContext`) | none, stateless | the chain injects the context and SAP retires it — no ADT sessions linger in SM04 |

**Why LOCK needs a fresh context** (found with the trace from #207): a chain that ran inside a context another chain had already used got the same lock handle as before, wrote its inactive version, but the object never reached the activation worklist (`DWINACTIV` stayed empty). The activation that followed answered `checkExecuted="false" activationExecuted="false"` with no message. The first cycle per process worked, every later one did not.

**EditSource message**: when the activation it ran was refused, the result no longer says "Successfully edited and activated". It reports `Source updated but activation failed: …` with `success=false`.

## Tests

`http_proxy_contextid_test.go`: stateless requests get the empty cookie, stateful ones are untouched, the environment switch, jar cookies win, the CSRF probe heals with a stateful empty context, ICMENOSESSION recovery, fresh context on LOCK, release leaves the cookie off, release is a no-op without the guard. `go build ./...`, `go vet` and `go test ./pkg/adt ./internal/mcp ./cmd/vsp` are green.

Live: three consecutive edit/activate cycles on one report behind the BAS proxy chain, three distinct lock handles, `activationExecuted="true"` each time, and no lingering ADT session in SM04 afterwards.
