### PR TITLE
test(adt): pin the pre-auth client's proxy wiring

### DIFF
--- a/pkg/adt/websocket_base.go
+++ b/pkg/adt/websocket_base.go
@@ -138,14 +138,7 @@ func (c *BaseWebSocketClient) Connect(ctx context.Context) error {
 	// but accept it on regular HTTP to issue session cookies.
 	if err != nil && resp != nil && resp.StatusCode == http.StatusUnauthorized && !c.hasCookieAuth() {
 		jar, _ := cookiejar.New(nil)
-		preAuthClient := &http.Client{
-			Jar: jar,
-			Transport: &http.Transport{
-				TLSClientConfig: tlsConfig,
-				Proxy:           http.ProxyFromEnvironment,
-			},
-			Timeout: 30 * time.Second,
-		}
+		preAuthClient := newPreAuthHTTPClient(jar, tlsConfig)
 
 		authURL := fmt.Sprintf("%s/sap/bc/adt/core/discovery?sap-client=%s", c.baseURL, c.client)
 		authReq, authErr := http.NewRequestWithContext(ctx, http.MethodGet, authURL, nil)
@@ -450,6 +443,22 @@ func base64Encode(data []byte) string {
 		}
 	}
 	return string(result)
+}
+
+// newPreAuthHTTPClient builds the transient client that fetches SAP session
+// cookies when the WebSocket upgrade answers 401. It drives its own jar so the
+// cookies can be handed to the dialer's retry, and it resolves a proxy from the
+// environment the way the dialer and the ADT HTTP client do — behind a
+// corporate proxy the pre-auth request used to be the one leg that bypassed it.
+func newPreAuthHTTPClient(jar http.CookieJar, tlsConfig *tls.Config) *http.Client {
+	return &http.Client{
+		Jar: jar,
+		Transport: &http.Transport{
+			TLSClientConfig: tlsConfig,
+			Proxy:           http.ProxyFromEnvironment,
+		},
+		Timeout: 30 * time.Second,
+	}
 }
 
 // newWebSocketDialer builds the dialer used for the ZADT_VSP upgrade. It honours

--- a/pkg/adt/websocket_proxy_test.go
+++ b/pkg/adt/websocket_proxy_test.go
@@ -2,6 +2,8 @@ package adt
 
 import (
 	"crypto/tls"
+	"net/http"
+	"net/http/cookiejar"
 	"testing"
 )
 
@@ -19,5 +21,36 @@ func TestWebSocketDialerHonoursProxyEnv(t *testing.T) {
 	}
 	if d.HandshakeTimeout == 0 {
 		t.Fatal("the dialer must keep its handshake timeout")
+	}
+}
+
+// TestPreAuthClientHonoursProxyEnv pins the same wiring on the pre-auth client:
+// the request that fetches session cookies after a 401 on the upgrade must go
+// through the same proxy as the upgrade itself, keep the jar it was given (the
+// retry dials with those cookies) and carry the TLS config and a timeout.
+func TestPreAuthClientHonoursProxyEnv(t *testing.T) {
+	jar, err := cookiejar.New(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	tlsCfg := &tls.Config{} //nolint:gosec // test config, no handshake
+
+	client := newPreAuthHTTPClient(jar, tlsCfg)
+
+	if client.Jar != jar {
+		t.Fatal("the pre-auth client must use the jar it was given, so the cookies reach the dialer's retry")
+	}
+	transport, ok := client.Transport.(*http.Transport)
+	if !ok {
+		t.Fatalf("the pre-auth client's transport must be an *http.Transport, got %T", client.Transport)
+	}
+	if transport.Proxy == nil {
+		t.Fatal("the pre-auth client must resolve a proxy from the environment")
+	}
+	if transport.TLSClientConfig != tlsCfg {
+		t.Fatal("the pre-auth client must carry the TLS config it was given")
+	}
+	if client.Timeout == 0 {
+		t.Fatal("the pre-auth client must have a timeout")
 	}
 }


### PR DESCRIPTION
Follow-up to the note under #107: `main` has the proxy-aware WebSocket dialing from 6b136b7, but no test on the pre-auth client's proxy wiring. This is that test.

## What

- The pre-auth client — the one that fetches session cookies when the WebSocket upgrade answers 401 — moves out of the connect path into `newPreAuthHTTPClient(jar, tlsConfig)`. No behaviour change: same jar, same transport with `http.ProxyFromEnvironment`, same TLS config, same 30 s timeout.
- `TestPreAuthClientHonoursProxyEnv` in `websocket_proxy_test.go` asserts the wiring the way `TestWebSocketDialerHonoursProxyEnv` already does for the dialer: proxy resolver set, the jar it was given kept (the retry dials with those cookies), TLS config carried, timeout in place. It checks the wiring rather than a resolution, for the same reason as the existing test — `http.ProxyFromEnvironment` reads the environment once per process.

## Why the extraction

An inline block cannot be tested; a change that drops the proxy resolver there would go unnoticed until someone behind a corporate proxy sees the pre-auth request fail while every plain HTTP call works.

## Tests

`go build ./...`, `go vet` and `go test ./pkg/adt ./internal/mcp ./cmd/vsp` are green; golangci-lint reports no new issues. Independent of #207, #208 and #209.
