### PR TITLE
dumps: --explain reads the whole ST22 document (message, source, variables)

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,10 @@ S/4, AMDP needs HANA, and some ADT resources present on S/4 are absent on ERP.
 >   BALDAT, INDX, STXL — every table an `EXPORT ... TO DATABASE` ever wrote — read over
 >   plain ADT and decoded here: SAP's LZH and LZC decompressed in Go, the cluster format
 >   walked, the fields named from DD03L. What only `IMPORT` could read, without a line of ABAP.
+> - **[A dump's own why](#post-mortem-from-a-dump-to-what-was-logged-around-it)** — `dumps --explain`
+>   now reads the whole ST22 document, not just the stack: the message it raised with its
+>   variables, the system fields, the failing source line, and the runtime's chosen variables
+>   per frame — so a stale handle or an unresolved pointer is on screen, not dug out by hand.
 > - **[The application log with its messages](#post-mortem-from-a-dump-to-what-was-logged-around-it)**,
 >   by object and date range, and the same log from a bare SE16H export of two tables.
 > - **[Spool and jobs](#jobs-and-spool--sm37-and-sp01-as-tables)** — SP01's list decoded
@@ -214,9 +218,19 @@ happen again.
 ```bash
 vsp -s a4h dumps --group                          # what keeps failing, not what failed once
 vsp -s a4h dumps --similar latest                 # what else looks like this one, and how closely
-vsp -s a4h dumps --explain latest --tolerance 10m # one dump, its stack, and the log around it
+vsp -s a4h dumps --explain latest --tolerance 10m # the why: message, failing line, stack, and the log around it
 vsp -s a4h applog --program ZCL_ORDER_POST        # who logged what, and from where
 ```
+
+`--explain` reads the one formatted document ST22 keeps and pulls the causal
+detail out of it — no extra round trips. Before the stack it prints the message
+the dump raised with its own variables (`message SY 373 (type X) with -1`), the
+system fields that frame it (`SUBRC`, `FDPOS`, `PFKEY`, `TITLE`), and the source
+line it died on with a line either side, the failing one marked. `--json` adds
+a `detail` object with the full `systemFields`, `source`, and the runtime's
+`variables` per stack frame — where a stale handle or an unresolved pointer
+shows up as its value. So the answer to "why" is on screen, not reconstructed by
+hand from the raw dump.
 
 `--group` collapses dumps by runtime error and terminated program, which is
 structural. Grouping by "the same afternoon" would make a busy hour look like

--- a/cmd/vsp/dumps.go
+++ b/cmd/vsp/dumps.go
@@ -140,15 +140,17 @@ func explainDump(ctx context.Context, client *adt.Client, cmd *cobra.Command, du
 	if err != nil {
 		return err
 	}
-	// Read separately for display; the correlation already used it for ranking.
-	stack, stackErr := client.DumpStack(ctx, dump.ID)
+	// One document carries the stack, the system fields, the source extract and
+	// the chosen variables; read it once and show the causal detail, not just
+	// the stack.
+	detail, detailErr := client.DumpDetail(ctx, dump.ID)
 
 	if asJSON {
 		return emitJSON(struct {
 			Dump    adt.Dump        `json:"dump"`
-			Stack   []adt.DumpFrame `json:"stack,omitempty"`
+			Detail  *adt.DumpDetail `json:"detail,omitempty"`
 			Matches []adt.LogMatch  `json:"matches"`
-		}{dump, stack, matches})
+		}{dump, detail, matches})
 	}
 
 	fmt.Printf("%s  %s\n", stamp(dump.At), dump.ErrorType)
@@ -159,24 +161,27 @@ func explainDump(ctx context.Context, client *adt.Client, cmd *cobra.Command, du
 	fmt.Println()
 
 	switch {
-	case errors.Is(stackErr, adt.ErrDumpDetailUnavailable):
+	case errors.Is(detailErr, adt.ErrDumpDetailUnavailable):
 		// Not a fault: the release has the feed and not the detail resource.
-		fmt.Fprintf(os.Stderr, "%v\n\n", stackErr)
-	case stackErr != nil:
-		fmt.Fprintf(os.Stderr, "the call stack could not be read: %v\n\n", stackErr)
-	case len(stack) > 0:
-		fmt.Println("Call stack at the failure:")
-		for _, f := range stack {
-			where := f.Program
-			if f.Include != "" && f.Include != f.Program {
-				where += "/" + f.Include
+		fmt.Fprintf(os.Stderr, "%v\n\n", detailErr)
+	case detailErr != nil:
+		fmt.Fprintf(os.Stderr, "the dump detail could not be read: %v\n\n", detailErr)
+	case detail != nil:
+		printDumpTermination(detail)
+		if len(detail.Stack) > 0 {
+			fmt.Println("Call stack at the failure:")
+			for _, f := range detail.Stack {
+				where := f.Program
+				if f.Include != "" && f.Include != f.Program {
+					where += "/" + f.Include
+				}
+				fmt.Printf("  %3d %-12s %s:%d\n", f.Position, f.Type, where, f.Line)
+				if f.Name != "" {
+					fmt.Printf("      %s\n", f.Name)
+				}
 			}
-			fmt.Printf("  %3d %-12s %s:%d\n", f.Position, f.Type, where, f.Line)
-			if f.Name != "" {
-				fmt.Printf("      %s\n", f.Name)
-			}
+			fmt.Println()
 		}
-		fmt.Println()
 	}
 
 	if len(matches) == 0 {
@@ -199,6 +204,67 @@ func explainDump(ctx context.Context, client *adt.Client, cmd *cobra.Command, du
 			"(free SQL blocked, or no authorisation for CROSS), so \"written by something a stack frame calls\" was never asked.")
 	}
 	return nil
+}
+
+// printDumpTermination shows the causal core the enriched detail carries: the
+// message the dump raised (SY-MSGID/MSGNO and its variables), the key system
+// fields for context, and the source line it died on with a line either side.
+func printDumpTermination(d *adt.DumpDetail) {
+	printed := false
+	if sf := d.SystemFields; len(sf) > 0 {
+		if id, no := sf["SY-MSGID"], sf["SY-MSGNO"]; id != "" || no != "" {
+			line := fmt.Sprintf("  message %s %s", id, no)
+			if ty := sf["SY-MSGTY"]; ty != "" {
+				line += " (type " + ty + ")"
+			}
+			var vs []string
+			for _, k := range []string{"SY-MSGV1", "SY-MSGV2", "SY-MSGV3", "SY-MSGV4"} {
+				if v := sf[k]; v != "" {
+					vs = append(vs, v)
+				}
+			}
+			if len(vs) > 0 {
+				line += "  with " + strings.Join(vs, ", ")
+			}
+			fmt.Println(line)
+			printed = true
+		}
+		var context []string
+		for _, k := range []string{"SY-SUBRC", "SY-FDPOS", "SY-PFKEY", "SY-TCODE", "SY-TITLE"} {
+			if v := sf[k]; v != "" {
+				context = append(context, strings.TrimPrefix(k, "SY-")+"="+v)
+			}
+		}
+		if len(context) > 0 {
+			fmt.Printf("  %s\n", strings.Join(context, "  "))
+			printed = true
+		}
+	}
+	for i, s := range d.Source {
+		if !s.Failed {
+			continue
+		}
+		fmt.Println("  source:")
+		lo, hi := i-1, i+1
+		if lo < 0 {
+			lo = 0
+		}
+		if hi >= len(d.Source) {
+			hi = len(d.Source) - 1
+		}
+		for j := lo; j <= hi; j++ {
+			mark := "    "
+			if d.Source[j].Failed {
+				mark = "  > "
+			}
+			fmt.Printf("  %s%5d  %s\n", mark, d.Source[j].Line, strings.TrimSpace(d.Source[j].Text))
+		}
+		printed = true
+		break
+	}
+	if printed {
+		fmt.Println()
+	}
 }
 
 // similarDumps answers "what else looks like this dump", on a ladder.

--- a/pkg/adt/dumpdetail.go
+++ b/pkg/adt/dumpdetail.go
@@ -53,6 +53,44 @@ type DumpDetail struct {
 	MainProgram string `json:"mainProgram,omitempty"`
 	// Stack costs nothing extra: it is parsed out of the same document.
 	Stack []DumpFrame `json:"stack,omitempty"`
+
+	// The chapters below are the causal detail. They cost nothing extra either —
+	// the formatted document is fetched once and holds all of it — but they are
+	// what turns "which program failed where" into "why". None is present on a
+	// release that does not serve the detail, so all are omitempty.
+
+	// ShortText is the one-line human summary ("Short Text" chapter).
+	ShortText string `json:"shortText,omitempty"`
+	// SystemFields is the "Contents of system fields" table: SY-SUBRC, SY-MSGID,
+	// SY-MSGNO, SY-MSGV1..4, SY-FDPOS, SY-PFKEY, SY-TITLE and the rest. After the
+	// message itself this is the richest causal signal, keyed by SY field name.
+	SystemFields map[string]string `json:"systemFields,omitempty"`
+	// Source is the "Source Code Extract": the lines around the termination
+	// point, the failing one(s) flagged. Empty when the dump has no source.
+	Source []DumpSourceLine `json:"source,omitempty"`
+	// Variables is the "Selected Variables" chapter: the runtime's chosen
+	// variables per stack frame with their rendered contents — where a stale
+	// handle or an unresolved pointer shows up as a value.
+	Variables []DumpVariable `json:"variables,omitempty"`
+}
+
+// DumpSourceLine is one line of the Source Code Extract.
+type DumpSourceLine struct {
+	Line int    `json:"line"`
+	Text string `json:"text"`
+	// Failed marks the termination line — either the one SAP annotated with its
+	// "=====> Error" marker in the extract, or the one the header named.
+	Failed bool `json:"failed,omitempty"`
+}
+
+// DumpVariable is one entry of the Selected Variables chapter.
+type DumpVariable struct {
+	// Frame is the procedure whose variables these are, e.g. AC_FLUSH_CALL_INTERNAL.
+	Frame string `json:"frame,omitempty"`
+	Name  string `json:"name"`
+	// Value is the variable's rendered contents, value lines joined; long dumps
+	// (hex tables) are truncated, since the point here is the name and shape.
+	Value string `json:"value,omitempty"`
 }
 
 // DumpDetail reads one dump beyond what the feed carries.
@@ -82,7 +120,152 @@ func parseDumpDetail(formatted string) *DumpDetail {
 	where := parseDumpTermination(formatted)
 	detail.Include, detail.Line = where.include, where.line
 	detail.Procedure, detail.MainProgram = where.procedure, where.mainProgram
+	detail.ShortText = joinDumpChapter(formatted, "Short Text")
+	detail.SystemFields = parseDumpSystemFields(formatted)
+	detail.Source = parseDumpSource(formatted, detail.Line)
+	detail.Variables = parseDumpSelectedVariables(formatted)
 	return detail
+}
+
+// dumpChapterRows returns the fenced rows of one chapter, outer pipes stripped
+// but inner spacing kept — the Selected Variables chapter tells a variable name
+// (flush left) from its value lines (indented) only by that spacing. Rules of
+// dashes inside a chapter are skipped; the first blank line, which separates
+// every chapter from the next, ends it.
+func dumpChapterRows(formatted, title string) []string {
+	lines := strings.Split(formatted, "\n")
+	start := -1
+	for i, l := range lines {
+		if strings.HasPrefix(strings.TrimSpace(l), "|") && strings.Contains(l, title) {
+			start = i
+			break
+		}
+	}
+	if start < 0 {
+		return nil
+	}
+	var rows []string
+	pendingCont := false // the previous row ended with "\", a wrap to be joined
+	for i := start + 1; i < len(lines); i++ {
+		s := strings.TrimSpace(lines[i])
+		switch {
+		case s == "":
+			return rows // the blank line between chapters
+		case strings.HasPrefix(s, "|"):
+			inner := strings.TrimSuffix(strings.TrimPrefix(s, "|"), "|")
+			// A trailing "\" means the value wraps onto the next line; SAP breaks
+			// long hex dumps mid-token, and the continuation is flush left, so
+			// without joining it would read as a new variable name.
+			cont := strings.HasSuffix(inner, "\\")
+			inner = strings.TrimRight(strings.TrimSuffix(inner, "\\"), " ")
+			if pendingCont && len(rows) > 0 {
+				rows[len(rows)-1] += inner
+			} else {
+				rows = append(rows, inner)
+			}
+			pendingCont = cont
+		case strings.HasPrefix(s, "-"):
+			continue // a rule of dashes, inside the chapter or closing it
+		default:
+			return rows
+		}
+	}
+	return rows
+}
+
+// parseDumpSystemFields reads the "Contents of system fields" table, a plain
+// two-column |Name|Val.| grid, into a map keyed by the SY field name.
+func parseDumpSystemFields(formatted string) map[string]string {
+	rows := dumpChapterRows(formatted, "Contents of system fields")
+	if len(rows) == 0 {
+		return nil
+	}
+	fields := map[string]string{}
+	for _, r := range rows {
+		name, val, ok := strings.Cut(r, "|")
+		if !ok {
+			continue
+		}
+		name = strings.TrimSpace(name)
+		if name == "" || name == "Name" { // the column header
+			continue
+		}
+		fields[name] = strings.TrimSpace(val)
+	}
+	if len(fields) == 0 {
+		return nil
+	}
+	return fields
+}
+
+// parseDumpSource reads the "Source Code Extract", a |Line|Code| grid. failLine
+// (the header's termination line) flags the failing row in case the extract
+// carries no "=====> Error" marker of its own.
+func parseDumpSource(formatted string, failLine int) []DumpSourceLine {
+	rows := dumpChapterRows(formatted, "Source Code Extract")
+	var out []DumpSourceLine
+	for _, r := range rows {
+		num, code, ok := strings.Cut(r, "|")
+		if !ok {
+			continue
+		}
+		num = strings.TrimSpace(num)
+		if num == "Line" { // the column header
+			continue
+		}
+		n, err := strconv.Atoi(num)
+		if err != nil {
+			continue
+		}
+		out = append(out, DumpSourceLine{
+			Line:   n,
+			Text:   strings.TrimRight(code, " "),
+			Failed: strings.Contains(code, "> Error") || (failLine > 0 && n == failLine),
+		})
+	}
+	return out
+}
+
+const dumpVariableValueCap = 512
+
+// parseDumpSelectedVariables reads the "Selected Variables" chapter. Each stack
+// frame opens with a "No. n Ty. …" / "Name …" pair; within it a flush-left row
+// is a variable name and the indented rows under it are its value.
+func parseDumpSelectedVariables(formatted string) []DumpVariable {
+	rows := dumpChapterRows(formatted, "Selected Variables")
+	var out []DumpVariable
+	frame := ""
+	var cur *DumpVariable
+	flush := func() {
+		if cur != nil {
+			cur.Value = strings.TrimSpace(cur.Value)
+			out = append(out, *cur)
+			cur = nil
+		}
+	}
+	for _, r := range rows {
+		trimmed := strings.TrimSpace(r)
+		switch {
+		case trimmed == "" || trimmed == "Name" || trimmed == "Val.":
+			// column headers and empty rows carry no variable
+			continue
+		case strings.HasPrefix(trimmed, "No.") && strings.Contains(r, "Ty."):
+			flush()
+			frame = ""
+		case strings.HasPrefix(trimmed, "Name ") || strings.HasPrefix(trimmed, "Name\t"):
+			flush()
+			frame = strings.TrimSpace(strings.TrimPrefix(trimmed, "Name"))
+		case strings.HasPrefix(r, " "): // indented: a value line for the current variable
+			if cur != nil && len(cur.Value) < dumpVariableValueCap {
+				cur.Value += trimmed + " "
+			}
+		default: // flush left: a new variable name
+			flush()
+			cur = &DumpVariable{Frame: frame, Name: trimmed}
+		}
+	}
+	flush()
+	return out
 }
 
 // parseDumpHeader reads the table above the first chapter.

--- a/pkg/adt/dumpdetail_enrich_test.go
+++ b/pkg/adt/dumpdetail_enrich_test.go
@@ -1,0 +1,125 @@
+package adt
+
+import "testing"
+
+// Real ST22 chapter layout, synthetic names. The System fields grid, the Source
+// Code Extract with SAP's "=====> Error" marker, and the Selected Variables
+// chapter — including a value that wraps with a trailing "\" the way long hex
+// dumps do — are all taken structurally from a live dump and rewritten with
+// invented names. Chapters are separated by a blank line, as on the wire.
+const formattedDumpEnrichSample = `
+----------------------------------------------------------------------------------------------------
+Category               ABAP programming error
+Runtime Errors         MESSAGE_TYPE_X
+ABAP: Program          ZCL_DEMO_FLUSH===============CP
+Application Component   BC-FES-CTL
+Date and Time          10.09.2026 21:41:27 (UTC)
+----------------------------------------------------------------------------------------------------
+
+----------------------------------------------------------------------------------------------------
+|Short Text                                                                                        |
+|    The current application has intentionally triggered a termination.                            |
+----------------------------------------------------------------------------------------------------
+
+----------------------------------------------------------------------------------------------------
+|Source Code Extract                                                                               |
+----------------------------------------------------------------------------------------------------
+|Line |Code                                                                                        |
+----------------------------------------------------------------------------------------------------
+|  538|        IF SY-SUBRC <> 0.                                                                   |
+|  539|          MESSAGE X373 WITH SY-SUBRC."=================> Error                              |
+|  540|        ENDIF.                                                                              |
+----------------------------------------------------------------------------------------------------
+
+----------------------------------------------------------------------------------------------------
+|Contents of system fields                                                                         |
+----------------------------------------------------------------------------------------------------
+|Name    |Val.                                                                                     |
+----------------------------------------------------------------------------------------------------
+|SY-SUBRC|4                                                                                        |
+|SY-FDPOS|40                                                                                       |
+|SY-MSGID|SY                                                                                       |
+|SY-MSGNO|373                                                                                      |
+|SY-MSGV1|-1                                                                                       |
+|SY-PFKEY|SESSION_ADMIN                                                                            |
+|SY-TITLE|SAP Easy Access                                                                          |
+----------------------------------------------------------------------------------------------------
+
+----------------------------------------------------------------------------------------------------
+|Selected Variables                                                                                |
+----------------------------------------------------------------------------------------------------
+|Name                                                                                              |
+|    Val.                                                                                          |
+----------------------------------------------------------------------------------------------------
+|No.       6 Ty.          FUNCTION                                                                 |
+|Name  AC_FLUSH_CALL_INTERNAL                                                                      |
+----------------------------------------------------------------------------------------------------
+|SYSTEM_FLUSH                                                                                      |
+|    X                                                                                             |
+|    5800                                                                                          |
+|MESSAGE_TEXT                                                                                      |
+|    22222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222\|
+|00002222222222                                                                                    |
+|RESULT_VARS_WA                                                                                    |
+|    POINTER = 0x0000000000000000                                                                  |
+----------------------------------------------------------------------------------------------------
+
+----------------------------------------------------------------------------------------------------
+|Information About Memory Usage                                                                     |
+----------------------------------------------------------------------------------------------------
+`
+
+func TestDumpDetailReadsSystemFields(t *testing.T) {
+	d := parseDumpDetail(formattedDumpEnrichSample)
+	if d.SystemFields["SY-MSGNO"] != "373" {
+		t.Errorf("SY-MSGNO = %q", d.SystemFields["SY-MSGNO"])
+	}
+	if d.SystemFields["SY-MSGV1"] != "-1" {
+		t.Errorf("SY-MSGV1 = %q", d.SystemFields["SY-MSGV1"])
+	}
+	if d.SystemFields["SY-TITLE"] != "SAP Easy Access" {
+		t.Errorf("SY-TITLE = %q", d.SystemFields["SY-TITLE"])
+	}
+	if _, ok := d.SystemFields["Name"]; ok {
+		t.Error("the column header leaked in as a field")
+	}
+}
+
+func TestDumpDetailReadsSourceAndFlagsTheFailure(t *testing.T) {
+	d := parseDumpDetail(formattedDumpEnrichSample)
+	if len(d.Source) != 3 {
+		t.Fatalf("source lines = %d, want 3", len(d.Source))
+	}
+	var failed []int
+	for _, s := range d.Source {
+		if s.Failed {
+			failed = append(failed, s.Line)
+		}
+	}
+	if len(failed) != 1 || failed[0] != 539 {
+		t.Errorf("failed lines = %v, want [539]", failed)
+	}
+}
+
+func TestDumpDetailReadsSelectedVariablesAndJoinsWraps(t *testing.T) {
+	d := parseDumpDetail(formattedDumpEnrichSample)
+	byName := map[string]DumpVariable{}
+	for _, v := range d.Variables {
+		byName[v.Name] = v
+	}
+	if v, ok := byName["SYSTEM_FLUSH"]; !ok || v.Frame != "AC_FLUSH_CALL_INTERNAL" || v.Value != "X 5800" {
+		t.Errorf("SYSTEM_FLUSH = %+v", v)
+	}
+	// The wrapped hex continuation must fold into MESSAGE_TEXT, not appear as
+	// its own variable named after the second half of the hex.
+	if _, leaked := byName["00002222222222"]; leaked {
+		t.Error("a wrapped hex continuation leaked in as a variable name")
+	}
+	mt := byName["MESSAGE_TEXT"].Value
+	if len(mt) < 90 || mt[:6] != "222222" {
+		t.Errorf("MESSAGE_TEXT did not fold its wrap: %q", mt)
+	}
+	if _, ok := byName["RESULT_VARS_WA"]; !ok {
+		t.Error("RESULT_VARS_WA missing")
+	}
+}


### PR DESCRIPTION
## What

`vsp dumps --explain` now surfaces the **causal core** of a dump, not just the stack — all parsed from the one formatted ST22 document it already fetches (no extra round trips).

`DumpDetail` gains:
- **`SystemFields`** — the *Contents of system fields* table: `SY-SUBRC`, `SY-MSGID`, `SY-MSGNO`, `SY-MSGV1..4`, `SY-FDPOS`, `SY-PFKEY`, `SY-TITLE`, …
- **`Source`** — the *Source Code Extract*, the failing line(s) flagged (SAP's `=====> Error` marker, or the header's termination line).
- **`Variables`** — the *Selected Variables* chapter, per stack frame, with rendered values (where a stale handle / unresolved pointer shows up as its value). Wrapped hex continuations are folded.
- **`ShortText`** — the one-line summary.

CLI: `--explain` prints the message a dump raised with its variables (`message SY 373 (type X) with -1`), the framing system fields, and the failing source line with context, before the stack. `--json` adds a `detail` object with the full chapters.

## Why

The dump model was `{id, at, user, errorType, program, message}` (+ line/component). The "why" — the message coordinates, the failing statement, the variable that was wrong — was in the document but not the model, so it was reconstructed by hand. Now it's on screen.

## Validation

Parser validated against a **live A4H** `MESSAGE_TYPE_X` / `SAPLOLEA` dump (24 SY-fields, source with the `MESSAGE X373` fail line, 62 variables incl. `RESULT_VARS_WA … POINTER = 0x0`). Unit tests use a synthetic fixture (real ST22 layout, synthetic names — no live identifiers). Existing dump tests unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)