### PR TITLE
feat(adt): read Enhancement Framework (ENHO) implementations

### DIFF
--- a/internal/mcp/handlers_source.go
+++ b/internal/mcp/handlers_source.go
@@ -17,9 +17,9 @@ import (
 // routeSourceAction routes "read" for GetSource and "edit" for WriteSource/EditSource.
 func (s *Server) routeSourceAction(ctx context.Context, action, objectType, objectName string, params map[string]any) (*mcp.CallToolResult, bool, error) {
 	if action == "read" {
-		// GetSource covers: CLAS, PROG, INTF, FUNC, FUGR, INCL, DDLS, BDEF, SRVD, SRVB, MSAG, VIEW
+		// GetSource covers: CLAS, PROG, INTF, FUNC, FUGR, INCL, DDLS, BDEF, SRVD, SRVB, MSAG, VIEW, ENHO
 		switch objectType {
-		case "CLAS", "PROG", "INTF", "FUNC", "FUGR", "INCL", "DDLS", "BDEF", "SRVD", "SRVB", "MSAG", "VIEW":
+		case "CLAS", "PROG", "INTF", "FUNC", "FUGR", "INCL", "DDLS", "BDEF", "SRVD", "SRVB", "MSAG", "VIEW", "ENHO":
 			args := map[string]any{
 				"object_type": objectType,
 				"name":        objectName,

--- a/pkg/adt/client.go
+++ b/pkg/adt/client.go
@@ -29,6 +29,12 @@ type Client struct {
 	// Lock handles believed outstanding, so the keep-alive ping does not
 	// retire the session one of them is bound to. See lock_window.go.
 	locks lockWindow
+
+	// rfcFetcherFactory, when non-nil, overrides the default WebSocket-backed
+	// RFC source fetcher used by GetEnhancement's fallback path. Production
+	// callers leave this nil; tests inject a stub to avoid opening a real
+	// WebSocket. See enhancements.go.
+	rfcFetcherFactory func(ctx context.Context) (rfcSourceFetcher, error)
 }
 
 // NewClient creates a new ADT client with the given configuration.

--- a/pkg/adt/enhancements.go
+++ b/pkg/adt/enhancements.go
@@ -1,0 +1,624 @@
+// Package adt — enhancement-framework (ENHO / ENHS) support.
+//
+// SAP's modern enhancement framework stores implementations as independent
+// ADT objects of type ENHO with a subtype: XH (source-code plug-in), XC
+// (class), XFB (function module), XD (interface), XBD (BAdI). SE80 merges
+// these into the host include's displayed source at render time; the raw
+// source endpoint never returns them. This file adds read-side support so
+// the MCP surface can see what a developer sees in the GUI.
+package adt
+
+import (
+	"context"
+	"encoding/xml"
+	"fmt"
+	"net/http"
+	"net/url"
+	"sort"
+	"strings"
+)
+
+// rfcSourceFetcher is the boundary used by GetEnhancement's RFC fallback path.
+// Production wiring opens a fresh DebugWebSocketClient per call (see
+// defaultRFCSourceFetcher); tests substitute a stub so the unit suite never
+// touches a real WebSocket.
+//
+// CallRFC is retained for callers that legitimately need a generic FM
+// dispatch; ReadSource is the preferred path for source bodies because it
+// uses native `READ REPORT` server-side and works for SUBC=I includes
+// (enhancement plug-in source) where RPY_PROGRAM_READ raises CANCELLED.
+type rfcSourceFetcher interface {
+	CallRFC(ctx context.Context, function string, params map[string]any) (*RFCResult, error)
+	ReadSource(ctx context.Context, program string) ([]string, error)
+	Close() error
+}
+
+// EnhancementKind is the ENHO subtype code returned by ADT search (e.g. XH).
+type EnhancementKind string
+
+// Subtype path segments used by the ADT enhancement endpoints. The search
+// API returns URIs such as `/sap/bc/adt/enhancements/enhoxh/<name>` — singular
+// in the URI but plural in some source/main variants. Callers that already
+// have a URI from search should use it verbatim; this map is only for
+// fallback when only the name+kind are known.
+var enhoSubtypePath = map[EnhancementKind]string{
+	"XH":  "enhoxhs",
+	"XC":  "enhoxcs",
+	"XFB": "enhoxfbs",
+	"XD":  "enhoxds",
+	"XBD": "enhoxbds",
+}
+
+// EnhancementRef is a lightweight view over a SearchResult hit that is
+// known to be an ENHO entry. Carried separately so callers don't have to
+// re-parse the ADT type string.
+type EnhancementRef struct {
+	Name        string          `json:"name"`
+	Kind        EnhancementKind `json:"kind"` // XH / XC / XFB / XD / XBD
+	URI         string          `json:"uri"`
+	PackageName string          `json:"packageName,omitempty"`
+	Description string          `json:"description,omitempty"`
+	// FullName is the XPath-style anchor location reported by ENHINCINX for
+	// HOOK_IMPL plug-ins, e.g. "\PR:SAPLVKMP\FO:BEDINGUNG_PRUEFEN_901\SE:BEGIN\EI".
+	// Empty unless the ENHO was discovered via the table-based fallback.
+	FullName string `json:"fullName,omitempty"`
+	// HostProgram is the main program (function-group main, executable program)
+	// the enhancement attaches to — ENHINCINX.PROGRAMNAME. Empty for ENHOs
+	// discovered only via the REST surface.
+	HostProgram string `json:"hostProgram,omitempty"`
+	// EnhInclude is the REPOSRC entry holding the plug-in source; conventionally
+	// ENHNAME with an "E" suffix. Useful for SE80 navigation.
+	EnhInclude string `json:"enhInclude,omitempty"`
+}
+
+// GetEnhancement returns the ABAP source of an enhancement implementation
+// (ENHO) resolved by name. The ADT subtype (XH/XC/...) is discovered via
+// SearchObject so callers don't have to pass it.
+//
+// Errors:
+//   - not-found: no ENHO/* hit matches the name.
+//   - ambiguous: more than one ENHO/* hit with the same name (rare; a name
+//     plus a subtype is the unique key, so collisions across subtypes are
+//     technically legal).
+//
+// When you already have an EnhancementRef (e.g. from ListEnhancementsForInclude)
+// prefer GetEnhancementByRef — it preserves table-discovered fields like
+// EnhInclude that the SearchObject-based resolver drops, which is what lets
+// the RFC fallback find HOOK_IMPL plug-in sources whose REPOSRC names use
+// `=`-padding rather than the simple <NAME>E convention.
+func (c *Client) GetEnhancement(ctx context.Context, name string) (string, error) {
+	name = strings.ToUpper(strings.TrimSpace(name))
+	if name == "" {
+		return "", fmt.Errorf("enhancement name is required")
+	}
+
+	ref, err := c.resolveEnhancement(ctx, name)
+	if err != nil {
+		return "", err
+	}
+
+	return c.GetEnhancementByRef(ctx, ref)
+}
+
+// GetEnhancementByRef returns the ABAP source for an already-resolved ENHO
+// reference. Walks the same 3-step resolver as GetEnhancement (REST singular
+// → REST plural → RFC) but skips the SearchObject re-resolution that
+// GetEnhancement performs.
+//
+// The point of bypassing re-resolution: callers that obtained the ref via
+// ListEnhancementsForInclude's table fallback already have ref.EnhInclude
+// populated with the real REPOSRC entry name (e.g.
+// "ISM_SAPLVKMP==================E" with `=`-padding). Going back through
+// SearchObject would discard that and force the RFC step to fall back to
+// the <NAME>E convention, which doesn't exist as an entry on classic ECC for
+// most non-company HOOK_IMPL plug-ins.
+//
+// Returns the same step-4 metadata-only error as GetEnhancement when no path
+// resolves the body.
+func (c *Client) GetEnhancementByRef(ctx context.Context, ref *EnhancementRef) (string, error) {
+	if ref == nil || strings.TrimSpace(ref.Name) == "" {
+		return "", fmt.Errorf("enhancement ref is required")
+	}
+
+	// 1) Modern REST: try the URL the search/browser returned ("singular" form).
+	if uri := strings.TrimSpace(ref.URI); uri != "" {
+		if src, ok := c.tryFetchEnhancementSource(ctx, strings.TrimRight(uri, "/")+"/source/main"); ok {
+			return src, nil
+		}
+	}
+
+	// 2) Newer plural form some NetWeaver releases use.
+	if plural, ok := enhoSubtypePath[ref.Kind]; ok {
+		alt := fmt.Sprintf("/sap/bc/adt/enhancements/%s/%s/source/main",
+			plural, strings.ToLower(ref.Name))
+		if src, ok := c.tryFetchEnhancementSource(ctx, alt); ok {
+			return src, nil
+		}
+	}
+
+	// 3) RFC fallback via ZADT_VSP WebSocket. Classic ECC walls off ENHO
+	// bodies behind RPY_PROGRAM_READ — the only reliable way to read the
+	// plug-in source on those releases. ref.EnhInclude (from ENHINCINX) is
+	// the authoritative REPOSRC entry name when populated; otherwise the
+	// `<name>E` convention is used as a best-effort guess.
+	if src, ok := c.tryFetchEnhancementSourceViaRFC(ctx, ref); ok {
+		return src, nil
+	}
+
+	// 4) No reachable source-body endpoint on this server. Surface a structured
+	// error with metadata so the caller (and ultimately the user) can navigate
+	// to the object in SE80 even though we can't return the body inline.
+	hint := ref.EnhInclude
+	if hint == "" {
+		hint = ref.Name + "E"
+	}
+	return "", fmt.Errorf(
+		"enhancement %s (%s, package %s): source body unavailable on this server "+
+			"— ADT REST does not expose HOOK_IMPL plug-ins on this NetWeaver release "+
+			"(SE80: see include %s). Install ZADT_VSP or grant the vsp cookie write "+
+			"scope to enable inline retrieval.",
+		ref.Name, ref.Kind, ref.PackageName, hint)
+}
+
+// tryFetchEnhancementSourceViaRFC opens a one-shot WebSocket to ZADT_VSP and
+// reads the plug-in's REPOSRC entry via the rfc/readSource action (native
+// READ REPORT on the server side). Returns ("", false) — without surfacing
+// the error — when the bridge is missing, the program doesn't exist, or
+// the response shape is unexpected. Step 4 (the metadata-only error)
+// handles the user-facing fallback message.
+//
+// The program name is taken from ref.EnhInclude when populated by the
+// ENHINCINX table fallback; otherwise the "<ENHNAME>E" REPOSRC convention
+// is used as a best-effort guess.
+//
+// We deliberately avoid RPY_PROGRAM_READ: on classic ECC it raises CANCELLED
+// (subrc=99 via OTHERS) inside RFC contexts because of an authorization
+// dialog the framework can't render. The readSource action wraps native
+// READ REPORT instead, which has none of that machinery.
+func (c *Client) tryFetchEnhancementSourceViaRFC(ctx context.Context, ref *EnhancementRef) (string, bool) {
+	programName := ref.EnhInclude
+	if programName == "" {
+		programName = ref.Name + "E"
+	}
+	programName = strings.ToUpper(strings.TrimSpace(programName))
+	if programName == "E" {
+		return "", false
+	}
+
+	factory := c.rfcFetcherFactory
+	if factory == nil {
+		factory = c.defaultRFCSourceFetcher
+	}
+
+	fetcher, err := factory(ctx)
+	if err != nil {
+		return "", false
+	}
+	defer fetcher.Close()
+
+	lines, err := fetcher.ReadSource(ctx, programName)
+	if err != nil || len(lines) == 0 {
+		return "", false
+	}
+	return strings.Join(lines, "\n"), true
+}
+
+// defaultRFCSourceFetcher is the production fallback fetcher. The WebSocket
+// `readSource` path this originally opened depends on a server-side ZADT_VSP
+// action and WebSocket-client internals that are not part of this build, so the
+// fallback reports itself unavailable and callers fall through to the ADT REST
+// enhancement path (which covers the common case). Tests inject their own
+// fetcher via rfcFetcherFactory and never reach this. The fallback can be
+// restored once the WebSocket readSource path is re-landed against the current
+// client API and the ZADT_VSP service.
+func (c *Client) defaultRFCSourceFetcher(_ context.Context) (rfcSourceFetcher, error) {
+	return nil, fmt.Errorf("RFC/WebSocket enhancement-source fallback is not wired in this build; using the ADT REST path")
+}
+
+// tryFetchEnhancementSource issues a single GET; returns (body, true) on 2xx.
+// Any 4xx/5xx returns ("", false) without surfacing the error so the caller
+// can fall through to the next attempt.
+func (c *Client) tryFetchEnhancementSource(ctx context.Context, path string) (string, bool) {
+	resp, err := c.transport.Request(ctx, path, &RequestOptions{
+		Method: http.MethodGet,
+		Accept: "text/plain",
+	})
+	if err != nil {
+		return "", false
+	}
+	if len(resp.Body) == 0 {
+		return "", false
+	}
+	body := string(resp.Body)
+	// ADT error responses are XML even on 200 from some upstream proxies; sniff
+	// for the exception namespace as a safety net.
+	if strings.Contains(body[:min(len(body), 256)], "exc:exception") {
+		return "", false
+	}
+	return body, true
+}
+
+// resolveEnhancement finds exactly one ENHO/* match for name via SearchObject.
+func (c *Client) resolveEnhancement(ctx context.Context, name string) (*EnhancementRef, error) {
+	results, err := c.SearchObject(ctx, name, 25)
+	if err != nil {
+		return nil, fmt.Errorf("resolving enhancement %s: %w", name, err)
+	}
+
+	var hits []EnhancementRef
+	for _, r := range results {
+		if !strings.HasPrefix(strings.ToUpper(r.Type), "ENHO/") {
+			continue
+		}
+		if !strings.EqualFold(r.Name, name) {
+			continue
+		}
+		kind := strings.TrimPrefix(strings.ToUpper(r.Type), "ENHO/")
+		hits = append(hits, EnhancementRef{
+			Name:        r.Name,
+			Kind:        EnhancementKind(kind),
+			URI:         r.URI,
+			PackageName: r.PackageName,
+			Description: r.Description,
+		})
+	}
+
+	switch len(hits) {
+	case 0:
+		return nil, fmt.Errorf("enhancement %s not found (no ENHO/* match)", name)
+	case 1:
+		return &hits[0], nil
+	default:
+		kinds := make([]string, 0, len(hits))
+		for _, h := range hits {
+			kinds = append(kinds, string(h.Kind))
+		}
+		sort.Strings(kinds)
+		return nil, fmt.Errorf("enhancement %s is ambiguous across subtypes: %s", name, strings.Join(kinds, ", "))
+	}
+}
+
+// enhancementBrowserResponse matches the XML shape returned by
+// /sap/bc/adt/enhancements/enhoxhs — the enhancement browser's list endpoint.
+// It is structurally identical to adtcore:objectReferences, so we reuse the
+// SearchResult shape.
+type enhancementBrowserResponse struct {
+	XMLName xml.Name       `xml:"objectReferences"`
+	Results []SearchResult `xml:"objectReference"`
+}
+
+// ListEnhancementsForInclude returns all ENHO implementations whose enhanced
+// object is the named include. Returns an empty slice (not an error) when
+// the include has no enhancements.
+//
+// Three back-ends are tried in order until one returns rows:
+//  1. Modern enhancement-browser REST: GET /sap/bc/adt/enhancements/enhoxhs?enhancedObjectUri=…
+//  2. Generic object-references REST: GET /sap/bc/adt/repository/informationsystem/objectreferences
+//  3. Table-based fallback (D010INC ⨝ ENHINCINX) for ECC / older NetWeaver
+//     systems where the REST surface is missing for HOOK_IMPL.
+//
+// (3) is the only path that works on classic ECC; both REST endpoints 404 on
+// those systems for HOOK_IMPL plug-ins.
+func (c *Client) ListEnhancementsForInclude(ctx context.Context, includeName string) ([]EnhancementRef, error) {
+	includeName = strings.ToUpper(strings.TrimSpace(includeName))
+	if includeName == "" {
+		return nil, fmt.Errorf("include name is required")
+	}
+
+	includeURI := "/sap/bc/adt/programs/includes/" + url.PathEscape(includeName)
+
+	// 1) Modern enhancement browser.
+	if refs, err := c.queryEnhancementBrowser(ctx, includeURI); err == nil && len(refs) > 0 {
+		return refs, nil
+	}
+
+	// 2) Generic object-references fallback.
+	if refs, err := c.queryObjectReferencesForEnhancements(ctx, includeURI); err == nil && len(refs) > 0 {
+		return refs, nil
+	}
+
+	// 3) Table-based fallback. Returns its own error (or empty slice) so
+	// callers can distinguish "no enhancements attached" from "lookup failed".
+	return c.listEnhancementsForIncludeViaTable(ctx, includeName)
+}
+
+func (c *Client) queryEnhancementBrowser(ctx context.Context, enhancedURI string) ([]EnhancementRef, error) {
+	params := url.Values{}
+	params.Set("enhancedObjectUri", enhancedURI)
+
+	resp, err := c.transport.Request(ctx, "/sap/bc/adt/enhancements/enhoxhs", &RequestOptions{
+		Method: http.MethodGet,
+		Query:  params,
+		Accept: "application/xml",
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	var parsed enhancementBrowserResponse
+	if xmlErr := xml.Unmarshal(resp.Body, &parsed); xmlErr != nil {
+		// Try the SearchResults shape as a secondary parse — some releases
+		// wrap in <adtcore:objectReferences>.
+		if results, parseErr := ParseSearchResults(resp.Body); parseErr == nil {
+			parsed.Results = results
+		} else {
+			return nil, fmt.Errorf("parsing enhancement browser response: %w", xmlErr)
+		}
+	}
+
+	return filterENHO(parsed.Results), nil
+}
+
+func (c *Client) queryObjectReferencesForEnhancements(ctx context.Context, enhancedURI string) ([]EnhancementRef, error) {
+	params := url.Values{}
+	params.Set("uri", enhancedURI)
+	params.Set("facet", "package")
+
+	resp, err := c.transport.Request(ctx, "/sap/bc/adt/repository/informationsystem/objectreferences", &RequestOptions{
+		Method: http.MethodGet,
+		Query:  params,
+		Accept: "application/xml",
+	})
+	if err != nil {
+		return nil, fmt.Errorf("fallback objectreferences query: %w", err)
+	}
+
+	results, err := ParseSearchResults(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("parsing objectreferences response: %w", err)
+	}
+	return filterENHO(results), nil
+}
+
+func filterENHO(results []SearchResult) []EnhancementRef {
+	refs := make([]EnhancementRef, 0, len(results))
+	for _, r := range results {
+		t := strings.ToUpper(r.Type)
+		if !strings.HasPrefix(t, "ENHO/") {
+			continue
+		}
+		refs = append(refs, EnhancementRef{
+			Name:        r.Name,
+			Kind:        EnhancementKind(strings.TrimPrefix(t, "ENHO/")),
+			URI:         r.URI,
+			PackageName: r.PackageName,
+			Description: r.Description,
+		})
+	}
+	return refs
+}
+
+// listEnhancementsForIncludeViaTable is the table-driven fallback used when
+// the ADT enhancement-browser REST surface is missing (classic ECC / older
+// NetWeaver). It joins:
+//
+//   - D010INC.INCLUDE = <name>            → MASTER (host main program)
+//   - ENHINCINX.PROGRAMNAME IN (masters)  → ENHO rows
+//   - ENHHEADER (optional enrichment)     → description, version, ENHTOOLTYPE
+//
+// Then narrows to rows whose FULL_NAME mentions a FORM that is defined in
+// includeName. When the FORM-in-include check is inconclusive (we cannot tell
+// for sure), the row is returned anyway — false positives are far less harmful
+// than false negatives for the footer use case.
+//
+// Only HOOK_IMPL (Kind XH) plug-ins live in ENHINCINX; other ENHO subtypes are
+// not surfaced via this fallback. That matches v1 scope.
+func (c *Client) listEnhancementsForIncludeViaTable(ctx context.Context, includeName string) ([]EnhancementRef, error) {
+	// Step 1: include → host main program(s).
+	masters, err := c.queryD010INCMasters(ctx, includeName)
+	if err != nil {
+		return nil, fmt.Errorf("d010inc lookup for include %s: %w", includeName, err)
+	}
+	if len(masters) == 0 {
+		// Include has no host program — either it's an executable/standalone
+		// include with no function group, or the include name is invalid. Either
+		// way, the table fallback can't help.
+		return nil, nil
+	}
+
+	// Step 2: ENHINCINX rows for those host programs.
+	enhRows, err := c.queryENHINCINXForMasters(ctx, masters)
+	if err != nil {
+		return nil, fmt.Errorf("enhincinx lookup: %w", err)
+	}
+	if len(enhRows) == 0 {
+		return nil, nil
+	}
+
+	// Step 3: optional enrichment from ENHHEADER for descriptions / version.
+	// Best-effort — failures fall back to ENHINCINX-only fields.
+	descByName := c.fetchENHHEADERDescriptions(ctx, enhRows)
+
+	// Step 4: convert to EnhancementRef. The 30-char ENHNAME truncation is
+	// pragmatic-resolved by trying ENHHEADER first (its ENHNAME is the full
+	// 60-char identifier), falling back to the truncated name.
+	refs := make([]EnhancementRef, 0, len(enhRows))
+	for _, row := range enhRows {
+		fullName := descByName.fullName(row.ENHNAME)
+		desc := descByName.description(row.ENHNAME)
+		pkg := descByName.packageName(row.ENHNAME)
+
+		refs = append(refs, EnhancementRef{
+			Name:        fullName,
+			Kind:        EnhancementKind("XH"), // ENHINCINX = HOOK_IMPL only
+			URI:         "/sap/bc/adt/enhancements/enhoxh/" + strings.ToLower(fullName),
+			PackageName: pkg,
+			Description: desc,
+			FullName:    row.FULL_NAME,
+			HostProgram: row.PROGRAMNAME,
+			EnhInclude:  row.ENHINCLUDE,
+		})
+	}
+	return refs, nil
+}
+
+// enhincinxRow holds the ENHINCINX columns we read for HOOK_IMPL lookup.
+type enhincinxRow struct {
+	ENHNAME     string // 30-char truncated key
+	PROGRAMNAME string
+	FULL_NAME   string
+	ENHINCLUDE  string
+}
+
+func (c *Client) queryD010INCMasters(ctx context.Context, includeName string) ([]string, error) {
+	// /datapreview/ddic requires a full SELECT in the body — bare WHERE clauses
+	// fail with "Only SELECT statement is allowed".
+	sql := fmt.Sprintf("SELECT MASTER FROM D010INC WHERE INCLUDE = '%s'",
+		strings.ReplaceAll(includeName, "'", "''"))
+	res, err := c.GetTableContents(ctx, "D010INC", 100, sql)
+	if err != nil {
+		return nil, err
+	}
+	masters := make([]string, 0, len(res.Rows))
+	seen := make(map[string]struct{})
+	for _, r := range res.Rows {
+		m, _ := r["MASTER"].(string)
+		m = strings.TrimSpace(m)
+		if m == "" {
+			continue
+		}
+		if _, ok := seen[m]; ok {
+			continue
+		}
+		seen[m] = struct{}{}
+		masters = append(masters, m)
+	}
+	return masters, nil
+}
+
+func (c *Client) queryENHINCINXForMasters(ctx context.Context, masters []string) ([]enhincinxRow, error) {
+	if len(masters) == 0 {
+		return nil, nil
+	}
+	// Build "PROGRAMNAME IN ('A','B',…)" inside a full SELECT — /datapreview/ddic
+	// rejects bare WHERE clauses.
+	quoted := make([]string, 0, len(masters))
+	for _, m := range masters {
+		quoted = append(quoted, "'"+strings.ReplaceAll(m, "'", "''")+"'")
+	}
+	sql := fmt.Sprintf(
+		"SELECT ENHNAME, PROGRAMNAME, FULL_NAME, ENHINCLUDE FROM ENHINCINX WHERE PROGRAMNAME IN (%s)",
+		strings.Join(quoted, ","))
+
+	res, err := c.GetTableContents(ctx, "ENHINCINX", 200, sql)
+	if err != nil {
+		return nil, err
+	}
+	rows := make([]enhincinxRow, 0, len(res.Rows))
+	for _, r := range res.Rows {
+		row := enhincinxRow{
+			ENHNAME:     strings.TrimSpace(asString(r["ENHNAME"])),
+			PROGRAMNAME: strings.TrimSpace(asString(r["PROGRAMNAME"])),
+			FULL_NAME:   strings.TrimSpace(asString(r["FULL_NAME"])),
+			ENHINCLUDE:  strings.TrimSpace(asString(r["ENHINCLUDE"])),
+		}
+		if row.ENHNAME == "" {
+			continue
+		}
+		rows = append(rows, row)
+	}
+	return rows, nil
+}
+
+// enhHeaderInfo carries enrichment data resolved from ENHHEADER, keyed by the
+// 30-char ENHINCINX name (which is what the caller has).
+type enhHeaderInfo struct {
+	byTruncated map[string]enhHeaderHit
+}
+
+type enhHeaderHit struct {
+	FullName    string
+	Description string
+	PackageName string
+}
+
+func (e enhHeaderInfo) fullName(truncated string) string {
+	if h, ok := e.byTruncated[truncated]; ok && h.FullName != "" {
+		return h.FullName
+	}
+	return truncated
+}
+
+func (e enhHeaderInfo) description(truncated string) string {
+	if h, ok := e.byTruncated[truncated]; ok {
+		return h.Description
+	}
+	return ""
+}
+
+func (e enhHeaderInfo) packageName(truncated string) string {
+	if h, ok := e.byTruncated[truncated]; ok {
+		return h.PackageName
+	}
+	return ""
+}
+
+// fetchENHHEADERDescriptions enriches ENHINCINX rows with full ENHNAME (60 char)
+// and metadata from ENHHEADER + TADIR. Best-effort; returns an empty map on any
+// hard failure so the caller still produces useful refs.
+func (c *Client) fetchENHHEADERDescriptions(ctx context.Context, rows []enhincinxRow) enhHeaderInfo {
+	info := enhHeaderInfo{byTruncated: map[string]enhHeaderHit{}}
+	if len(rows) == 0 {
+		return info
+	}
+	// ENHHEADER.ENHNAME is the full key; ENHINCINX truncates to 30. Use a
+	// per-row LIKE prefix query — not the most efficient but bounded by the
+	// number of ENHOs targeting one function group, which is small in practice.
+	for _, row := range rows {
+		// ENHHEADER active version only — /datapreview/ddic requires a full SELECT.
+		sql := fmt.Sprintf("SELECT ENHNAME FROM ENHHEADER WHERE ENHNAME LIKE '%s%%' AND VERSION = 'A'",
+			strings.ReplaceAll(row.ENHNAME, "'", "''"))
+		res, err := c.GetTableContents(ctx, "ENHHEADER", 5, sql)
+		if err != nil || res == nil || len(res.Rows) == 0 {
+			continue
+		}
+		// Prefer the row whose ENHNAME starts with the truncated key; if
+		// multiple, take the first.
+		hit := res.Rows[0]
+		info.byTruncated[row.ENHNAME] = enhHeaderHit{
+			FullName:    strings.TrimSpace(asString(hit["ENHNAME"])),
+			Description: "", // ENHHEADER has SHORTTEXT_ID (a key into another table); descriptions come from search instead.
+			PackageName: "",
+		}
+	}
+	// Augment with package + description from a single ADT search per ENHO.
+	// The search endpoint is reliable on D03 even when the enhancement-browser
+	// REST is broken. Cap to first 25 rows to bound cost.
+	for i, row := range rows {
+		if i >= 25 {
+			break
+		}
+		full := info.fullName(row.ENHNAME)
+		results, err := c.SearchObject(ctx, full, 5)
+		if err != nil {
+			continue
+		}
+		for _, r := range results {
+			if !strings.HasPrefix(strings.ToUpper(r.Type), "ENHO/") {
+				continue
+			}
+			if !strings.EqualFold(r.Name, full) {
+				continue
+			}
+			h := info.byTruncated[row.ENHNAME]
+			h.FullName = r.Name
+			h.Description = r.Description
+			h.PackageName = r.PackageName
+			info.byTruncated[row.ENHNAME] = h
+			break
+		}
+	}
+	return info
+}
+
+// asString coerces a TableContentsResult cell to a string, returning "" if
+// the cell is missing or of an unexpected type.
+func asString(v interface{}) string {
+	if v == nil {
+		return ""
+	}
+	if s, ok := v.(string); ok {
+		return s
+	}
+	return fmt.Sprintf("%v", v)
+}

--- a/pkg/adt/enhancements_test.go
+++ b/pkg/adt/enhancements_test.go
@@ -1,0 +1,577 @@
+package adt
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+func newEnhancementSearchResponse(name, subtype, pkg string) *http.Response {
+	uri := "/sap/bc/adt/enhancements/enho" + strings.ToLower(subtype) + "/" + strings.ToLower(name)
+	xml := `<?xml version="1.0" encoding="UTF-8"?>
+<adtcore:objectReferences xmlns:adtcore="http://www.sap.com/adt/core">
+  <adtcore:objectReference adtcore:uri="` + uri + `" adtcore:type="ENHO/` + subtype + `" adtcore:name="` + name + `" adtcore:packageName="` + pkg + `" adtcore:description="demo"/>
+</adtcore:objectReferences>`
+	return newTestResponse(xml)
+}
+
+// newRoutedMockTransport returns a mock that dispatches by exact path. Useful
+// when a test needs different bodies at different URLs (e.g. search + then
+// source fetch).
+type routedMock struct {
+	byPath   map[string]*http.Response
+	requests []*http.Request
+}
+
+func (r *routedMock) Do(req *http.Request) (*http.Response, error) {
+	r.requests = append(r.requests, req)
+	if resp, ok := r.byPath[req.URL.Path]; ok {
+		return resp, nil
+	}
+	for key, resp := range r.byPath {
+		if strings.Contains(req.URL.Path, key) {
+			return resp, nil
+		}
+	}
+	return &http.Response{
+		StatusCode: http.StatusNotFound,
+		Body:       io.NopCloser(strings.NewReader("Not found")),
+		Header:     http.Header{},
+	}, nil
+}
+
+func newBody(s string) *http.Response {
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Body:       io.NopCloser(strings.NewReader(s)),
+		Header:     http.Header{"X-CSRF-Token": []string{"t"}},
+	}
+}
+
+func TestGetEnhancement_ResolvesSubtypeViaSearch(t *testing.T) {
+	sourceBody := `ENHANCEMENT 2 Y3EI_SKIP_BYPASS_CC_WITH_LIMIT.
+  LOOP AT lt_xfplt INTO DATA(ls_xfplt) WHERE fpltr < 900000.
+    lv_sum = lv_sum + ls_xfplt-fakwr.
+  ENDLOOP.
+ENDENHANCEMENT.`
+
+	searchResp := newEnhancementSearchResponse("Y3EI_SKIP_BYPASS_CC_WITH_LIMIT", "XH", "YSD")
+
+	mock := &routedMock{
+		byPath: map[string]*http.Response{
+			"/sap/bc/adt/repository/informationsystem/search":                            searchResp,
+			"/sap/bc/adt/enhancements/enhoxh/y3ei_skip_bypass_cc_with_limit/source/main": newBody(sourceBody),
+			"/sap/bc/adt/discovery": newBody("OK"),
+		},
+	}
+
+	cfg := NewConfig("https://sap.example.com:44300", "u", "p")
+	transport := NewTransportWithClient(cfg, mock)
+	client := NewClientWithTransport(cfg, transport)
+
+	got, err := client.GetEnhancement(context.Background(), "Y3EI_SKIP_BYPASS_CC_WITH_LIMIT")
+	if err != nil {
+		t.Fatalf("GetEnhancement failed: %v", err)
+	}
+	if !strings.Contains(got, "lv_sum = lv_sum + ls_xfplt-fakwr") {
+		t.Fatalf("expected spliced enhancement source, got:\n%s", got)
+	}
+}
+
+func TestGetEnhancement_NotFound(t *testing.T) {
+	emptySearch := `<?xml version="1.0" encoding="UTF-8"?>
+<adtcore:objectReferences xmlns:adtcore="http://www.sap.com/adt/core"></adtcore:objectReferences>`
+	mock := &mockTransportClient{
+		responses: map[string]*http.Response{
+			"search":    newTestResponse(emptySearch),
+			"discovery": newTestResponse("OK"),
+		},
+	}
+	cfg := NewConfig("https://sap.example.com:44300", "u", "p")
+	transport := NewTransportWithClient(cfg, mock)
+	client := NewClientWithTransport(cfg, transport)
+
+	_, err := client.GetEnhancement(context.Background(), "ZDOES_NOT_EXIST")
+	if err == nil {
+		t.Fatal("expected not-found error, got nil")
+	}
+	if !strings.Contains(err.Error(), "not found") {
+		t.Fatalf("expected not-found message, got: %v", err)
+	}
+}
+
+func TestGetEnhancement_AmbiguousAcrossSubtypes(t *testing.T) {
+	// Two ENHO hits with the same name, different subtypes.
+	ambiguousSearch := `<?xml version="1.0" encoding="UTF-8"?>
+<adtcore:objectReferences xmlns:adtcore="http://www.sap.com/adt/core">
+  <adtcore:objectReference adtcore:uri="/sap/bc/adt/enhancements/enhoxh/yzzz" adtcore:type="ENHO/XH" adtcore:name="YZZZ" adtcore:packageName="P1"/>
+  <adtcore:objectReference adtcore:uri="/sap/bc/adt/enhancements/enhoxc/yzzz" adtcore:type="ENHO/XC" adtcore:name="YZZZ" adtcore:packageName="P2"/>
+</adtcore:objectReferences>`
+	mock := &mockTransportClient{
+		responses: map[string]*http.Response{
+			"search":    newTestResponse(ambiguousSearch),
+			"discovery": newTestResponse("OK"),
+		},
+	}
+	cfg := NewConfig("https://sap.example.com:44300", "u", "p")
+	transport := NewTransportWithClient(cfg, mock)
+	client := NewClientWithTransport(cfg, transport)
+
+	_, err := client.GetEnhancement(context.Background(), "YZZZ")
+	if err == nil {
+		t.Fatal("expected ambiguity error, got nil")
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, "ambiguous") || !strings.Contains(msg, "XC") || !strings.Contains(msg, "XH") {
+		t.Fatalf("expected ambiguity message listing both subtypes, got: %v", err)
+	}
+}
+
+func TestListEnhancementsForInclude_ParsesResponse(t *testing.T) {
+	browserResp := `<?xml version="1.0" encoding="UTF-8"?>
+<adtcore:objectReferences xmlns:adtcore="http://www.sap.com/adt/core">
+  <adtcore:objectReference adtcore:uri="/sap/bc/adt/enhancements/enhoxh/y3ei_skip_bypass_cc_with_limit" adtcore:type="ENHO/XH" adtcore:name="Y3EI_SKIP_BYPASS_CC_WITH_LIMIT" adtcore:packageName="YSD" adtcore:description="Skip bypass when CC with limit-to"/>
+  <adtcore:objectReference adtcore:uri="/sap/bc/adt/programs/includes/rvkmp901" adtcore:type="PROG/I" adtcore:name="RVKMP901" adtcore:packageName="VKM"/>
+</adtcore:objectReferences>`
+
+	mock := &routedMock{
+		byPath: map[string]*http.Response{
+			"/sap/bc/adt/enhancements/enhoxhs": newBody(browserResp),
+			"/sap/bc/adt/discovery":            newBody("OK"),
+		},
+	}
+	cfg := NewConfig("https://sap.example.com:44300", "u", "p")
+	transport := NewTransportWithClient(cfg, mock)
+	client := NewClientWithTransport(cfg, transport)
+
+	refs, err := client.ListEnhancementsForInclude(context.Background(), "RVKMP901")
+	if err != nil {
+		t.Fatalf("ListEnhancementsForInclude failed: %v", err)
+	}
+	if len(refs) != 1 {
+		t.Fatalf("expected 1 ENHO match, got %d: %+v", len(refs), refs)
+	}
+	if refs[0].Name != "Y3EI_SKIP_BYPASS_CC_WITH_LIMIT" {
+		t.Errorf("wrong name: %s", refs[0].Name)
+	}
+	if refs[0].Kind != "XH" {
+		t.Errorf("wrong kind: %s", refs[0].Kind)
+	}
+}
+
+type stubRFCSourceFetcher struct {
+	sourceLines []string
+	err         error
+
+	readCalls []string // program names the prod code asked for
+	closeFn   func()
+}
+
+func (s *stubRFCSourceFetcher) CallRFC(ctx context.Context, function string, params map[string]any) (*RFCResult, error) {
+	// CallRFC is no longer the production path — kept on the stub purely so it
+	// satisfies the rfcSourceFetcher interface. Tests should set sourceLines
+	// and observe readCalls.
+	return nil, fmtError("stub.CallRFC: not used in tests")
+}
+
+func (s *stubRFCSourceFetcher) ReadSource(ctx context.Context, program string) ([]string, error) {
+	s.readCalls = append(s.readCalls, program)
+	return s.sourceLines, s.err
+}
+
+func (s *stubRFCSourceFetcher) Close() error {
+	if s.closeFn != nil {
+		s.closeFn()
+	}
+	return nil
+}
+
+// TestGetEnhancement_FallsBackToRFC: classic ECC, both REST source URLs 404,
+// the RPY_PROGRAM_READ bridge returns the body. GetEnhancement should return
+// the spliced source instead of the metadata-only error.
+func TestGetEnhancement_FallsBackToRFC(t *testing.T) {
+	searchResp := newEnhancementSearchResponse("Y3EI_SKIP_BYPASS_CC_WITH_LIMIT", "XH", "YSD")
+
+	mock := &routedMock{
+		byPath: map[string]*http.Response{
+			"/sap/bc/adt/repository/informationsystem/search": searchResp,
+			"/sap/bc/adt/discovery":                           newBody("OK"),
+			// No source/main endpoint registered — both candidate URLs 404.
+		},
+	}
+	cfg := NewConfig("https://sap.example.com:44300", "u", "p")
+	transport := NewTransportWithClient(cfg, mock)
+	client := NewClientWithTransport(cfg, transport)
+
+	stub := &stubRFCSourceFetcher{
+		sourceLines: []string{
+			"ENHANCEMENT 2 Y3EI_SKIP_BYPASS_CC_WITH_LIMIT.",
+			"  lv_sum = lv_sum + ls_xfplt-fakwr.",
+			"ENDENHANCEMENT.",
+		},
+	}
+	closed := false
+	stub.closeFn = func() { closed = true }
+	client.rfcFetcherFactory = func(ctx context.Context) (rfcSourceFetcher, error) {
+		return stub, nil
+	}
+
+	got, err := client.GetEnhancement(context.Background(), "Y3EI_SKIP_BYPASS_CC_WITH_LIMIT")
+	if err != nil {
+		t.Fatalf("GetEnhancement should fall through to RFC, got error: %v", err)
+	}
+	if !strings.Contains(got, "lv_sum = lv_sum + ls_xfplt-fakwr") {
+		t.Fatalf("expected RFC body in result, got: %q", got)
+	}
+	if !strings.Contains(got, "ENDENHANCEMENT.") {
+		t.Fatalf("expected RFC source lines joined with newline, got: %q", got)
+	}
+	if len(stub.readCalls) != 1 {
+		t.Fatalf("expected exactly one ReadSource call, got %d", len(stub.readCalls))
+	}
+	// Convention says <ENHNAME>E unless table fallback set ref.EnhInclude.
+	// Search-based discovery used here doesn't populate EnhInclude, so the
+	// derived program name is the convention-based fallback.
+	if got := stub.readCalls[0]; got != "Y3EI_SKIP_BYPASS_CC_WITH_LIMITE" {
+		t.Errorf("wrong ReadSource program: %q", got)
+	}
+	if !closed {
+		t.Errorf("Close() was not called on the RFC fetcher")
+	}
+}
+
+// TestGetEnhancementByRef_PreservesEnhInclude: when the caller already has
+// a table-discovered ref with EnhInclude populated (e.g. the include-footer
+// renderer for HOOK_IMPL ENHOs whose REPOSRC entry uses `=`-padding rather
+// than the simple <NAME>E convention), the RFC fallback must call ReadSource
+// with that exact entry name — not the resolver's guess.
+func TestGetEnhancementByRef_PreservesEnhInclude(t *testing.T) {
+	mock := &routedMock{
+		byPath: map[string]*http.Response{
+			// REST steps both fail: no source/main endpoint registered, and
+			// the URI on the ref is empty so step 1 is skipped entirely.
+			"/sap/bc/adt/discovery": newBody("OK"),
+		},
+	}
+	cfg := NewConfig("https://sap.example.com:44300", "u", "p")
+	transport := NewTransportWithClient(cfg, mock)
+	client := NewClientWithTransport(cfg, transport)
+
+	stub := &stubRFCSourceFetcher{
+		sourceLines: []string{
+			"ENHANCEMENT 1 ISM_SAPLVKMP.",
+			"  WRITE 'hi'.",
+			"ENDENHANCEMENT.",
+		},
+	}
+	client.rfcFetcherFactory = func(ctx context.Context) (rfcSourceFetcher, error) {
+		return stub, nil
+	}
+
+	// Synthetic ENHINCINX-discovered ref: short ENHNAME, padded ENHINCLUDE.
+	ref := &EnhancementRef{
+		Name:        "ISM_SAPLVKMP",
+		Kind:        "XH",
+		PackageName: "JAS_MODIF",
+		HostProgram: "SAPLVKMP",
+		EnhInclude:  "ISM_SAPLVKMP==================E",
+	}
+
+	got, err := client.GetEnhancementByRef(context.Background(), ref)
+	if err != nil {
+		t.Fatalf("GetEnhancementByRef should succeed via RFC, got error: %v", err)
+	}
+	if !strings.Contains(got, "WRITE 'hi'") {
+		t.Fatalf("expected RFC body in result, got: %q", got)
+	}
+	if len(stub.readCalls) != 1 {
+		t.Fatalf("expected exactly one ReadSource call, got %d", len(stub.readCalls))
+	}
+	// The whole point of the fix: the padded REPOSRC name from EnhInclude
+	// must reach the RFC fetcher verbatim. <NAME>E ("ISM_SAPLVKMPE") would
+	// be the pre-fix behaviour and is wrong.
+	if got := stub.readCalls[0]; got != "ISM_SAPLVKMP==================E" {
+		t.Errorf("RFC fetcher got wrong program name: %q (expected the padded EnhInclude verbatim)", got)
+	}
+}
+
+// TestGetEnhancementByRef_ErrorMessageUsesEnhInclude: when all source paths
+// fail and we fall back to the metadata-only error, the SE80 hint should
+// point at ref.EnhInclude when available, not the convention-based guess.
+func TestGetEnhancementByRef_ErrorMessageUsesEnhInclude(t *testing.T) {
+	mock := &routedMock{
+		byPath: map[string]*http.Response{
+			"/sap/bc/adt/discovery": newBody("OK"),
+		},
+	}
+	cfg := NewConfig("https://sap.example.com:44300", "u", "p")
+	transport := NewTransportWithClient(cfg, mock)
+	client := NewClientWithTransport(cfg, transport)
+
+	client.rfcFetcherFactory = func(ctx context.Context) (rfcSourceFetcher, error) {
+		return nil, fmtError("RFC unreachable")
+	}
+
+	ref := &EnhancementRef{
+		Name:        "ISM_SAPLVKMP",
+		Kind:        "XH",
+		PackageName: "JAS_MODIF",
+		EnhInclude:  "ISM_SAPLVKMP==================E",
+	}
+
+	_, err := client.GetEnhancementByRef(context.Background(), ref)
+	if err == nil {
+		t.Fatal("expected metadata-only error when all paths fail, got nil")
+	}
+	if !strings.Contains(err.Error(), "ISM_SAPLVKMP==================E") {
+		t.Errorf("expected SE80 hint to use EnhInclude verbatim, got: %v", err)
+	}
+}
+
+// TestGetEnhancement_RFCFails_FallsThroughToMetadataError: when the RFC path
+// errors (no ZADT_VSP installed, FM not remote-callable, etc.), the user
+// should still see the structured metadata-only error pointing at SE80,
+// not the raw RFC error.
+func TestGetEnhancement_RFCFails_FallsThroughToMetadataError(t *testing.T) {
+	searchResp := newEnhancementSearchResponse("Y3EI_SKIP_BYPASS_CC_WITH_LIMIT", "XH", "YSD")
+
+	mock := &routedMock{
+		byPath: map[string]*http.Response{
+			"/sap/bc/adt/repository/informationsystem/search": searchResp,
+			"/sap/bc/adt/discovery":                           newBody("OK"),
+		},
+	}
+	cfg := NewConfig("https://sap.example.com:44300", "u", "p")
+	transport := NewTransportWithClient(cfg, mock)
+	client := NewClientWithTransport(cfg, transport)
+
+	client.rfcFetcherFactory = func(ctx context.Context) (rfcSourceFetcher, error) {
+		// Simulate WebSocket 403 (ZADT_VSP not installed).
+		return nil, fmtError("WebSocket connection failed (HTTP 403)")
+	}
+
+	_, err := client.GetEnhancement(context.Background(), "Y3EI_SKIP_BYPASS_CC_WITH_LIMIT")
+	if err == nil {
+		t.Fatal("expected metadata error when RFC fallback fails, got nil")
+	}
+	for _, want := range []string{
+		"Y3EI_SKIP_BYPASS_CC_WITH_LIMIT",
+		"source body unavailable",
+		"SE80",
+	} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("expected metadata error to contain %q, got: %v", want, err)
+		}
+	}
+}
+
+// fmtError is a small helper to build an error with a fixed message —
+// avoids importing fmt just for one Errorf in the tests.
+func fmtError(msg string) error { return errString(msg) }
+
+type errString string
+
+func (e errString) Error() string { return string(e) }
+
+// TestGetEnhancement_NoSourceEndpoint_MetadataError: classic ECC behaviour.
+// Search returns the ENHO ref; both candidate source URLs (singular/plural)
+// 404. GetEnhancement should return a structured error that names the ENHO,
+// its kind/package, and points at SE80 — instead of the cryptic 404.
+func TestGetEnhancement_NoSourceEndpoint_MetadataError(t *testing.T) {
+	searchResp := newEnhancementSearchResponse("Y3EI_SKIP_BYPASS_CC_WITH_LIMIT", "XH", "YSD")
+
+	mock := &routedMock{
+		byPath: map[string]*http.Response{
+			"/sap/bc/adt/repository/informationsystem/search": searchResp,
+			"/sap/bc/adt/discovery":                           newBody("OK"),
+			// No source/main endpoint registered — both candidate URLs 404.
+		},
+	}
+	cfg := NewConfig("https://sap.example.com:44300", "u", "p")
+	transport := NewTransportWithClient(cfg, mock)
+	client := NewClientWithTransport(cfg, transport)
+	// Suppress the RFC fallback so the test doesn't open a real WebSocket
+	// against sap.example.com (would be a 30s handshake timeout).
+	client.rfcFetcherFactory = func(ctx context.Context) (rfcSourceFetcher, error) {
+		return nil, fmtError("RFC fallback disabled for this test")
+	}
+
+	_, err := client.GetEnhancement(context.Background(), "Y3EI_SKIP_BYPASS_CC_WITH_LIMIT")
+	if err == nil {
+		t.Fatal("expected error when source endpoint is missing, got nil")
+	}
+	msg := err.Error()
+	for _, want := range []string{
+		"Y3EI_SKIP_BYPASS_CC_WITH_LIMIT",
+		"XH",
+		"YSD",
+		"source body unavailable",
+		"SE80",
+	} {
+		if !strings.Contains(msg, want) {
+			t.Errorf("expected error to contain %q, got: %v", want, err)
+		}
+	}
+}
+
+// queryRoutedMock dispatches by path AND by ddicEntityName query parameter,
+// so a single endpoint (datapreview/ddic) can return different bodies for
+// different tables. Builds a fresh response per call so a path can be hit
+// multiple times (e.g. CSRF preflight + actual POST) without body exhaustion.
+type queryRoutedMock struct {
+	byPathBody          map[string]string // path → body template
+	byDdicEntityKeyBody map[string]string // ddicEntityName → body template
+	requests            []*http.Request
+}
+
+func freshResponse(body string) *http.Response {
+	h := http.Header{}
+	h.Set("X-CSRF-Token", "t")
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Body:       io.NopCloser(strings.NewReader(body)),
+		Header:     h,
+	}
+}
+
+func (q *queryRoutedMock) Do(req *http.Request) (*http.Response, error) {
+	q.requests = append(q.requests, req)
+	if entity := req.URL.Query().Get("ddicEntityName"); entity != "" {
+		if body, ok := q.byDdicEntityKeyBody[strings.ToUpper(entity)]; ok {
+			return freshResponse(body), nil
+		}
+	}
+	if body, ok := q.byPathBody[req.URL.Path]; ok {
+		return freshResponse(body), nil
+	}
+	for key, body := range q.byPathBody {
+		if strings.Contains(req.URL.Path, key) {
+			return freshResponse(body), nil
+		}
+	}
+	return &http.Response{
+		StatusCode: http.StatusNotFound,
+		Body:       io.NopCloser(strings.NewReader("Not found")),
+		Header:     http.Header{},
+	}, nil
+}
+
+// dataPreviewBody renders an XML body string in the shape parseTableContents
+// expects, given a list of columns and rows in declaration order.
+func dataPreviewBody(columns []string, rows [][]string) string {
+	var sb strings.Builder
+	sb.WriteString(`<?xml version="1.0" encoding="UTF-8"?>` + "\n")
+	sb.WriteString("<dataPreview>\n")
+	for ci, name := range columns {
+		sb.WriteString(`  <columns>` + "\n")
+		sb.WriteString(`    <metadata name="` + name + `" type="C" description="" length="30" keyAttribute="false"/>` + "\n")
+		sb.WriteString(`    <dataSet>` + "\n")
+		for _, row := range rows {
+			val := ""
+			if ci < len(row) {
+				val = row[ci]
+			}
+			sb.WriteString(`      <data>` + val + `</data>` + "\n")
+		}
+		sb.WriteString(`    </dataSet>` + "\n")
+		sb.WriteString(`  </columns>` + "\n")
+	}
+	sb.WriteString("</dataPreview>")
+	return sb.String()
+}
+
+// TestListEnhancementsForInclude_TablePathFallback: both REST endpoints fail;
+// the D010INC ⨝ ENHINCINX fallback joins the data and returns the ENHO ref.
+func TestListEnhancementsForInclude_TablePathFallback(t *testing.T) {
+	d010Body := dataPreviewBody(
+		[]string{"MASTER", "INCLUDE"},
+		[][]string{{"SAPLVKMP", "RVKMP901"}},
+	)
+	enhincinxBody := dataPreviewBody(
+		[]string{"ENHNAME", "PROGRAMNAME", "FULL_NAME", "ENHINCLUDE"},
+		[][]string{
+			{
+				"Y3EI_SKIP_BYPASS_CC_WITH_LIMIT",
+				"SAPLVKMP",
+				`\PR:SAPLVKMP\FO:BEDINGUNG_PRUEFEN_901\SE:BEGIN\EI`,
+				"Y3EI_SKIP_BYPASS_CC_WITH_LIMITE",
+			},
+		},
+	)
+	enhheaderBody := dataPreviewBody(
+		[]string{"ENHNAME", "VERSION"},
+		[][]string{{"Y3EI_SKIP_BYPASS_CC_WITH_LIMIT", "A"}},
+	)
+	searchBody := `<?xml version="1.0" encoding="UTF-8"?>
+<adtcore:objectReferences xmlns:adtcore="http://www.sap.com/adt/core">
+  <adtcore:objectReference adtcore:uri="/sap/bc/adt/enhancements/enhoxh/y3ei_skip_bypass_cc_with_limit" adtcore:type="ENHO/XH" adtcore:name="Y3EI_SKIP_BYPASS_CC_WITH_LIMIT" adtcore:packageName="YSD" adtcore:description="Skip bypass when CC with limit-to"/>
+</adtcore:objectReferences>`
+
+	mock := &queryRoutedMock{
+		byPathBody: map[string]string{
+			"/sap/bc/adt/repository/informationsystem/search": searchBody,
+			"/sap/bc/adt/discovery":                           "OK",
+			"/sap/bc/adt/core/discovery":                      "OK",
+		},
+		byDdicEntityKeyBody: map[string]string{
+			"D010INC":   d010Body,
+			"ENHINCINX": enhincinxBody,
+			"ENHHEADER": enhheaderBody,
+		},
+	}
+	cfg := NewConfig("https://sap.example.com:44300", "u", "p")
+	transport := NewTransportWithClient(cfg, mock)
+	client := NewClientWithTransport(cfg, transport)
+
+	refs, err := client.ListEnhancementsForInclude(context.Background(), "RVKMP901")
+	if err != nil {
+		t.Fatalf("ListEnhancementsForInclude (table fallback) failed: %v", err)
+	}
+	if len(refs) != 1 {
+		t.Fatalf("expected 1 ENHO match via table fallback, got %d: %+v", len(refs), refs)
+	}
+	got := refs[0]
+	if got.Name != "Y3EI_SKIP_BYPASS_CC_WITH_LIMIT" {
+		t.Errorf("wrong Name: %q", got.Name)
+	}
+	if got.Kind != "XH" {
+		t.Errorf("wrong Kind: %q", got.Kind)
+	}
+	if got.HostProgram != "SAPLVKMP" {
+		t.Errorf("wrong HostProgram: %q", got.HostProgram)
+	}
+	if got.EnhInclude != "Y3EI_SKIP_BYPASS_CC_WITH_LIMITE" {
+		t.Errorf("wrong EnhInclude: %q", got.EnhInclude)
+	}
+	if !strings.Contains(got.FullName, "BEDINGUNG_PRUEFEN_901") {
+		t.Errorf("expected FullName to mention the FORM, got: %q", got.FullName)
+	}
+}
+
+func TestGetSource_DispatchesENHO(t *testing.T) {
+	// End-to-end: GetSource(ctx, "ENHO", name) must take the ENHO branch.
+	sourceBody := `ENHANCEMENT 2 Y_TEST.
+ENDENHANCEMENT.`
+	searchResp := newEnhancementSearchResponse("Y_TEST", "XH", "YSD")
+
+	mock := &routedMock{
+		byPath: map[string]*http.Response{
+			"/sap/bc/adt/repository/informationsystem/search":    searchResp,
+			"/sap/bc/adt/enhancements/enhoxh/y_test/source/main": newBody(sourceBody),
+			"/sap/bc/adt/discovery":                              newBody("OK"),
+		},
+	}
+	cfg := NewConfig("https://sap.example.com:44300", "u", "p")
+	transport := NewTransportWithClient(cfg, mock)
+	client := NewClientWithTransport(cfg, transport)
+
+	got, err := client.GetSource(context.Background(), "ENHO", "Y_TEST", nil)
+	if err != nil {
+		t.Fatalf("GetSource(ENHO) failed: %v", err)
+	}
+	if !strings.Contains(got, "ENHANCEMENT 2 Y_TEST") {
+		t.Fatalf("GetSource(ENHO) did not return enhancement body, got: %q", got)
+	}
+}

--- a/pkg/adt/workflows_source.go
+++ b/pkg/adt/workflows_source.go
@@ -134,8 +134,13 @@ func (c *Client) GetSource(ctx context.Context, objectType, name string, opts *G
 		}
 		return string(data), nil
 
+	case "ENHO":
+		// Enhancement Framework implementation — read via the ADT enhancement
+		// endpoints (see enhancements.go).
+		return c.GetEnhancement(ctx, name)
+
 	default:
-		return "", fmt.Errorf("unsupported object type: %s (supported: PROG, CLAS, INTF, FUNC, FUGR, INCL, DDLS, VIEW, BDEF, SRVD, SRVB, MSAG)", objectType)
+		return "", fmt.Errorf("unsupported object type: %s (supported: PROG, CLAS, INTF, FUNC, FUGR, INCL, DDLS, VIEW, BDEF, SRVD, SRVB, MSAG, ENHO)", objectType)
 	}
 }
 


### PR DESCRIPTION
Reimplements the **core** of #130 (thank you @barkow15! 🙏) onto current `main`.

## What
- `GetEnhancement(name)` — resolves the ENHO subtype via ADT search, then reads the implementation source from the enhancement endpoints.
- `ListEnhancementsForInclude(include)` — the enhancements referencing a given include.
- Wired into `GetSource` dispatch **and** the MCP `read` handler, so `read ENHO <name>` works end-to-end.
- Ports `enhancements.go` + `enhancements_test.go` and the minimal `Client` hook.

## Scope (and why)
Scoped to the **REST path** — the common case, and self-contained. Two parts of the original PR are intentionally deferred, because `main` moved under them:
- **RFC/WebSocket source fallback** (for `SUBC=I` includes on classic ECC where `RPY_PROGRAM_READ` raises `CANCELLED`) leaned on WebSocket-client internals (`IsConnected`/`GenerateID`/`SendRawRequest`) and a `ZADT_VSP` `readSource` action that have since diverged/relanded differently on `main`. `defaultRFCSourceFetcher` now reports itself unavailable and callers fall through to REST.
- The **SE80-style merged-include view** (`GetIncludeMerged`) is left out.

Both are good and can be re-landed against the current APIs — @barkow15, your original PR remains the reference for them.

The PR's grep-workflow and websocket-rfc pieces already landed on `main` independently, so they're not re-included.

## Validation
`go build ./...`, `go test ./...` → 22 packages ok. Tests use mocked ADT transports (no live system).

🤖 Generated with [Claude Code](https://claude.com/claude-code)