### PR TITLE
feat(adt): ActivateMultiple — dependency-aware batch activation

### DIFF
--- a/README.md
+++ b/README.md
@@ -722,7 +722,7 @@ The full version history is in [CHANGELOG.md](CHANGELOG.md).
 
 ### Hyperfocused Mode — 1 Tool to Rule Them All (Recommended)
 
-**Recommended for most setups.** Single `SAP(action, target, params)` tool covers most of what the 147 individual tools do — gCTS, revision history and i18n still need `--mode expert`. The same tool is now registered in focused and expert too, so an agent in either can reach the `analyze` surface. Minimal token overhead, maximum capability.
+**Recommended for most setups.** Single `SAP(action, target, params)` tool covers most of what the 148 individual tools do — gCTS, revision history and i18n still need `--mode expert`. The same tool is now registered in focused and expert too, so an agent in either can reach the `analyze` surface. Minimal token overhead, maximum capability.
 
 ```
 SAP(action="read",   target="CLAS ZCL_TRAVEL")
@@ -731,7 +731,7 @@ SAP(action="create", target="DEVC", params={"name": "$ZOZIK", "description": "Ne
 SAP(action="help",   target="debug")
 ```
 
-| Metric | Focused (100 tools) | Expert (147 tools) | Hyperfocused (1 tool) |
+| Metric | Focused (100 tools) | Expert (148 tools) | Hyperfocused (1 tool) |
 |--------|-------------------:|-------------------:|----------------------:|
 | MCP schema tokens | ~14,000 | ~40,000 | **~200** |
 | Reduction | — | — | **99.5%** |
@@ -952,7 +952,7 @@ See **[CLI Guide](docs/cli-guide.md)** for the complete reference with feature r
 | **API Surface** | `vsp api-surface` — Clean Core inventory: which standard APIs does your code use? |
 | **Graph Export** | 7 formats: mermaid, HTML, DOT (Graphviz), PlantUML, GraphML (Gephi), JSON, MD |
 | **Static Analysis** | `vsp analyze` — 13 lint rules in pure Go, no external dependencies |
-| **Hyperfocused Mode** | 1 universal SAP tool, **~200 tokens** vs ~40K for 147 tools |
+| **Hyperfocused Mode** | 1 universal SAP tool, **~200 tokens** vs ~40K for 148 tools |
 | **Context Compression** | Auto-compressed dependency contracts — 7–30x compression, built-in ABAP parser |
 | **Method-Level Surgery** | Read/edit individual methods — 95% token reduction vs full-class round-trips |
 | **ABAP LSP** | Built-in Language Server — real-time diagnostics, go-to-definition, context push |
@@ -1285,7 +1285,7 @@ recovery down with it.
 vsp --url https://host:44300 --user admin --password secret
 vsp --url https://host:44300 --cookie-file cookies.txt
 vsp --url https://host:44300 --sso --sso-system dev   # browser SSO, self-refreshing
-vsp --mode expert          # Enable all 147 tools
+vsp --mode expert          # Enable all 148 tools
 vsp --mode hyperfocused    # Single SAP tool (~200 tokens instead of ~40K)
 ```
 
@@ -1483,7 +1483,7 @@ One axis, three values — `--mode` or `SAP_MODE`:
 
 ```mermaid
 graph LR
-    F["focused<br/>100 tools<br/>~14K tokens"] --> E["expert<br/>147 tools<br/>~40K tokens"]
+    F["focused<br/>100 tools<br/>~14K tokens"] --> E["expert<br/>148 tools<br/>~40K tokens"]
     E --> H["hyperfocused<br/>1 tool<br/>~200 tokens<br/><i>recommended</i>"]
     style H fill:#2d6a4f,color:#fff,stroke:#4ade80,stroke-width:2px
     style F fill:#264653,color:#fff
@@ -1492,7 +1492,7 @@ graph LR
 
 | Aspect | Focused | Expert | Hyperfocused (recommended) |
 |--------|:-:|:-:|:-:|
-| **Tools** | 100 essential | 147 complete | 1 universal `SAP()` |
+| **Tools** | 100 essential | 148 complete | 1 universal `SAP()` |
 | **Schema tokens** | ~14K | ~40K | **~200** |
 | **How AI calls it** | `GetSource(type, name)` | Same, + granular tools | `SAP(action, target, params)` |
 | **Documentation** | In tool schemas | In tool schemas | `SAP(action="help")` |
@@ -1502,7 +1502,7 @@ graph LR
 ```bash
 vsp --mode hyperfocused  # recommended — single SAP(action, target, params) tool
 vsp --mode focused       # 100 curated tools (individual tool names)
-vsp --mode expert        # all 147 tools individually
+vsp --mode expert        # all 148 tools individually
 ```
 
 ## DSL & Automation
@@ -1778,7 +1778,7 @@ See [README_TOOLS.md](README_TOOLS.md) for complete tool documentation.
 
 **vsp** is a Go rewrite with:
 - Single binary, zero dependencies
-- 147 tools (vs 13 original)
+- 148 tools (vs 13 original)
 - ~50x faster startup
 
 ## Optional: WebSocket Handler (ZADT_VSP)
@@ -1878,7 +1878,7 @@ vibing-steampunk/
 
 | Metric | Value |
 |--------|-------|
-| **Tools** | 147 expert, 100 focused, 1 universal |
+| **Tools** | 148 expert, 100 focused, 1 universal |
 | **Unit Tests** | 1203 (`go test ./... -list '.*'`; integration tests excluded by build tag) |
 | **Platforms** | 9 (Linux, macOS, Windows × amd64/arm64/386) |
 

--- a/cmd/vsp/main.go
+++ b/cmd/vsp/main.go
@@ -37,7 +37,7 @@ Two modes of operation:
 
   MCP Server (default)  Connects Claude, Gemini CLI, Copilot, Codex, Qwen Code,
                         and other MCP-compatible agents to SAP systems.
-                        100 tools (focused), 147 (expert), or 1 universal tool (hyperfocused).
+                        100 tools (focused), 148 (expert), or 1 universal tool (hyperfocused).
 
   CLI Mode              Direct terminal access: search, source, export, debug.
                         Multi-system profiles. Useful for scripts and pipelines.
@@ -147,7 +147,7 @@ func init() {
 	rootCmd.Flags().StringVar(&cfg.TransportChoice, "transport-choice", "auto", "A write with no transport named: auto picks the object's own or an open request of yours that fits (and creates one with --enable-transports); off leaves it to SAP, which generates a request per write")
 
 	// Mode options
-	rootCmd.Flags().StringVar(&cfg.Mode, "mode", "hyperfocused", "Tool mode: hyperfocused (single universal SAP tool), focused (100 tools), or expert (147 tools)")
+	rootCmd.Flags().StringVar(&cfg.Mode, "mode", "hyperfocused", "Tool mode: hyperfocused (single universal SAP tool), focused (100 tools), or expert (148 tools)")
 	rootCmd.Flags().StringVar(&cfg.DisabledGroups, "disabled-groups", "", "Disable tool groups: 5/U=UI5, T=Tests, H=HANA, D=Debug, GC=gCTS, N=i18n")
 
 	// Transport options

--- a/internal/mcp/handlers_devtools.go
+++ b/internal/mcp/handlers_devtools.go
@@ -46,6 +46,8 @@ func (s *Server) routeDevToolsAction(ctx context.Context, action, objectType, ob
 		switch objectType {
 		case "ACTIVATE":
 			return s.callHandler(ctx, s.handleActivate, params)
+		case "ACTIVATE_MULTI":
+			return s.callHandler(ctx, s.handleActivateMultiple, params)
 		case "ACTIVATE_PACKAGE":
 			return s.callHandler(ctx, s.handleActivatePackage, params)
 		}
@@ -96,6 +98,51 @@ func (s *Server) handleActivate(ctx context.Context, request mcp.CallToolRequest
 		// are the diagnosis, and a verdict without them is not actionable.
 		payload, _ := json.MarshalIndent(result, "", "  ")
 		return newToolResultError(fmt.Sprintf("%v\n\n%s", err, payload)), nil
+	}
+
+	output, _ := json.MarshalIndent(result, "", "  ")
+	return mcp.NewToolResultText(string(output)), nil
+}
+
+// handleActivateMultiple activates multiple objects in a single ADT request.
+// params.objects: array of {"url": "...", "name": "..."} pairs, or
+//                 array of strings in "TYPE NAME" format (e.g. "INCL ZREP_F01").
+func (s *Server) handleActivateMultiple(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	raw, ok := request.GetArguments()["objects"]
+	if !ok {
+		return newToolResultError("objects is required (array of {url, name} or [\"TYPE NAME\", ...])"), nil
+	}
+
+	items, ok := raw.([]any)
+	if !ok || len(items) == 0 {
+		return newToolResultError("objects must be a non-empty array"), nil
+	}
+
+	refs := make([]adt.ObjectRef, 0, len(items))
+	for i, item := range items {
+		switch v := item.(type) {
+		case map[string]any:
+			u, _ := v["url"].(string)
+			n, _ := v["name"].(string)
+			if u == "" || n == "" {
+				return newToolResultError(fmt.Sprintf("objects[%d]: both 'url' and 'name' are required", i)), nil
+			}
+			refs = append(refs, adt.ObjectRef{URI: u, Name: n})
+		case string:
+			// "TYPE NAME" shorthand → resolve to ADT URL
+			u, n, err := s.adtClient.ResolveObjectRef(v)
+			if err != nil {
+				return newToolResultError(fmt.Sprintf("objects[%d]: cannot resolve %q: %v", i, v, err)), nil
+			}
+			refs = append(refs, adt.ObjectRef{URI: u, Name: n})
+		default:
+			return newToolResultError(fmt.Sprintf("objects[%d]: unsupported type %T", i, item)), nil
+		}
+	}
+
+	result, err := s.adtClient.ActivateMultiple(ctx, refs)
+	if err != nil {
+		return newToolResultError(fmt.Sprintf("Activation failed: %v", err)), nil
 	}
 
 	output, _ := json.MarshalIndent(result, "", "  ")

--- a/internal/mcp/tools_focused.go
+++ b/internal/mcp/tools_focused.go
@@ -47,7 +47,6 @@ func focusedToolSet() map[string]bool {
 		"RunUnitTests":       true,
 		"RunATCCheck":        true, // Code quality checks
 		"Activate":           true, // Re-activate objects without editing
-		"ActivateMultiple":   true, // Batch activation of specific objects (dependency-aware, like Eclipse)
 		"ActivatePackage":    true, // Batch activation of all inactive objects
 		"PrettyPrint":        true, // Format ABAP code
 		"GetInactiveObjects": true, // List pending activations

--- a/internal/mcp/tools_focused.go
+++ b/internal/mcp/tools_focused.go
@@ -47,6 +47,7 @@ func focusedToolSet() map[string]bool {
 		"RunUnitTests":       true,
 		"RunATCCheck":        true, // Code quality checks
 		"Activate":           true, // Re-activate objects without editing
+		"ActivateMultiple":   true, // Batch activation of specific objects (dependency-aware, like Eclipse)
 		"ActivatePackage":    true, // Batch activation of all inactive objects
 		"PrettyPrint":        true, // Format ABAP code
 		"GetInactiveObjects": true, // List pending activations

--- a/internal/mcp/tools_parity_test.go
+++ b/internal/mcp/tools_parity_test.go
@@ -17,7 +17,7 @@ import (
 const (
 	wantHyperfocusedTools = 1
 	wantFocusedTools      = 100
-	wantExpertTools       = 147
+	wantExpertTools       = 148
 )
 
 // serverForMode builds a server without touching a network. NewServer only

--- a/internal/mcp/tools_register.go
+++ b/internal/mcp/tools_register.go
@@ -828,6 +828,18 @@ func (s *Server) registerDevTools(shouldRegister func(string) bool) {
 		), s.handleActivate)
 	}
 
+	if shouldRegister("ActivateMultiple") {
+		s.mcpServer.AddTool(mcp.NewTool("ActivateMultiple",
+			mcp.WithDescription("Activate multiple ABAP objects in a single ADT request, resolving mutual dependencies between them (same behaviour as Eclipse ADT). Use when includes and their main program must be activated together."),
+			mcp.WithArray("objects",
+				mcp.Required(),
+				mcp.Description(`Objects to activate. Each item can be:
+  - {"url": "/sap/bc/adt/programs/programs/zprog", "name": "ZPROG"}
+  - "TYPE NAME" shorthand, e.g. "PROG ZPROG", "INCL ZPROG_TOP", "CLAS ZCL_X"`),
+			),
+		), s.handleActivateMultiple)
+	}
+
 	if shouldRegister("ActivatePackage") {
 		s.mcpServer.AddTool(mcp.NewTool("ActivatePackage",
 			mcp.WithDescription("Activate all inactive objects. Objects are sorted by dependency order (interfaces before classes). If no package specified, activates ALL inactive objects for current user."),

--- a/pkg/adt/client.go
+++ b/pkg/adt/client.go
@@ -366,6 +366,34 @@ func (c *Client) SearchObjectByType(ctx context.Context, query, objectType strin
 	return ParseSearchResults(resp.Body)
 }
 
+// ResolveObjectRef converts a "TYPE NAME" shorthand (e.g. "INCL ZREP_F01", "PROG ZREPORT")
+// into the (objectURL, objectName) pair needed for activation or other ADT operations.
+// The name is returned in UPPERCASE; the URL uses lowercase path encoding.
+func (c *Client) ResolveObjectRef(typeAndName string) (objectURL, objectName string, err error) {
+	parts := strings.Fields(strings.ToUpper(strings.TrimSpace(typeAndName)))
+	if len(parts) != 2 {
+		return "", "", fmt.Errorf("expected \"TYPE NAME\", got %q", typeAndName)
+	}
+	objType, name := parts[0], parts[1]
+	encoded := url.PathEscape(strings.ToLower(name))
+	switch objType {
+	case "PROG":
+		return "/sap/bc/adt/programs/programs/" + encoded, name, nil
+	case "INCL":
+		return "/sap/bc/adt/programs/includes/" + encoded, name, nil
+	case "CLAS":
+		return "/sap/bc/adt/oo/classes/" + encoded, name, nil
+	case "INTF":
+		return "/sap/bc/adt/oo/interfaces/" + encoded, name, nil
+	case "FUGR":
+		return "/sap/bc/adt/function/groups/" + encoded, name, nil
+	case "DDLS":
+		return "/sap/bc/adt/ddic/ddl/sources/" + encoded, name, nil
+	default:
+		return "", "", fmt.Errorf("unsupported object type %q (supported: PROG, INCL, CLAS, INTF, FUGR, DDLS)", objType)
+	}
+}
+
 // --- Program Operations ---
 
 // GetProgram retrieves the source code of an ABAP program.

--- a/pkg/adt/devtools.go
+++ b/pkg/adt/devtools.go
@@ -533,64 +533,34 @@ func (c *Client) ActivatePackage(ctx context.Context, packageName string, maxObj
 		Failed:    []ActivationFailed{},
 	}
 
-	if len(toActivate) == 0 {
-		result.Summary = "No inactive objects to activate"
-		return result, nil
-	}
-
-	// Build ObjectRef list and activate all in a single request so SAP can resolve
-	// mutual dependencies between objects (same behaviour as Eclipse ADT).
-	refs := make([]ObjectRef, 0, len(toActivate))
-	refMeta := make(map[string]InactiveObject, len(toActivate)) // URI → meta
+	// Activate each object
 	for _, rec := range toActivate {
 		if rec.Object == nil {
 			continue
 		}
-		refs = append(refs, ObjectRef{URI: rec.Object.URI, Name: rec.Object.Name})
-		refMeta[rec.Object.URI] = *rec.Object
-	}
-
-	activation, err := c.ActivateMultiple(ctx, refs)
-	if err != nil {
-		return nil, fmt.Errorf("batch activation failed: %w", err)
-	}
-
-	// Build per-object reason strings from activation messages (keyed by ObjDescr/name).
-	reasons := make(map[string]string)
-	for _, msg := range activation.Messages {
-		if strings.ContainsAny(msg.Type, "EAX") && msg.ObjDescr != "" {
-			if reasons[msg.ObjDescr] == "" {
-				reasons[msg.ObjDescr] = msg.ShortText
-			}
-		}
-	}
-
-	// Objects still inactive after the request → Failed; the rest → Activated.
-	// A refusing object answers 200 but stays inactive, so this post-state check
-	// is what keeps it out of the Activated count (preserves the earlier fix:
-	// the summary must not say "Activated 12" about eleven).
-	stillInactive := make(map[string]bool, len(activation.Inactive))
-	for _, obj := range activation.Inactive {
-		stillInactive[obj.URI] = true
-	}
-
-	for _, ref := range refs {
-		meta := refMeta[ref.URI]
-		if stillInactive[ref.URI] {
-			reason := reasons[ref.Name]
-			if reason == "" {
-				reason = "still inactive after activation attempt"
-			}
+		obj := rec.Object
+		activation, err := c.Activate(ctx, obj.URI, obj.Name)
+		switch {
+		case err != nil:
 			result.Failed = append(result.Failed, ActivationFailed{
-				Name:   ref.Name,
-				Type:   meta.Type,
-				Reason: reason,
+				Name:   obj.Name,
+				Type:   obj.Type,
+				Reason: err.Error(),
 			})
-		} else {
+		case !activation.Success:
+			// The object that refuses to activate answers 200 like the rest, so
+			// counting only transport errors put it in the Activated list and
+			// the summary then said "Activated 12 objects" about eleven.
+			result.Failed = append(result.Failed, ActivationFailed{
+				Name:   obj.Name,
+				Type:   obj.Type,
+				Reason: strings.Join(activation.ProblemLines(), "; "),
+			})
+		default:
 			result.Activated = append(result.Activated, ActivatedObject{
-				Name: ref.Name,
-				Type: meta.Type,
-				URI:  ref.URI,
+				Name: obj.Name,
+				Type: obj.Type,
+				URI:  obj.URI,
 			})
 		}
 	}

--- a/pkg/adt/devtools.go
+++ b/pkg/adt/devtools.go
@@ -405,6 +405,47 @@ func parseInactiveObjects(data []byte) ([]InactiveObjectRecord, error) {
 
 // --- Batch Activation ---
 
+// ObjectRef is a URI + name pair used to reference an ADT object in activation requests.
+type ObjectRef struct {
+	URI  string `json:"uri"`
+	Name string `json:"name"`
+}
+
+// ActivateMultiple activates multiple objects in a single ADT request, allowing SAP to
+// resolve mutual dependencies between them (e.g., a program and all its includes).
+// This is the correct approach when objects reference symbols defined in each other —
+// activating them one by one fails because the first object can't see the others.
+func (c *Client) ActivateMultiple(ctx context.Context, objects []ObjectRef) (*ActivationResult, error) {
+	if err := c.checkSafety(OpActivate, "ActivateMultiple"); err != nil {
+		return nil, err
+	}
+	if len(objects) == 0 {
+		return &ActivationResult{Success: true, Messages: []ActivationResultMessage{}, Inactive: []InactiveObject{}}, nil
+	}
+	if len(objects) == 1 {
+		return c.Activate(ctx, objects[0].URI, objects[0].Name)
+	}
+
+	var sb strings.Builder
+	sb.WriteString("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n")
+	sb.WriteString("<adtcore:objectReferences xmlns:adtcore=\"http://www.sap.com/adt/core\">\n")
+	for _, obj := range objects {
+		sb.WriteString(fmt.Sprintf("  <adtcore:objectReference adtcore:uri=\"%s\" adtcore:name=\"%s\"/>\n",
+			obj.URI, obj.Name))
+	}
+	sb.WriteString("</adtcore:objectReferences>")
+
+	resp, err := c.transport.Request(ctx, "/sap/bc/adt/activation?method=activate&preauditRequested=true", &RequestOptions{
+		Method:      http.MethodPost,
+		Body:        []byte(sb.String()),
+		ContentType: "application/xml",
+	})
+	if err != nil {
+		return nil, fmt.Errorf("batch activation failed: %w", err)
+	}
+	return parseActivationResult(resp.Body)
+}
+
 // ActivatePackageResult represents the result of batch activation.
 type ActivatePackageResult struct {
 	Activated []ActivatedObject  `json:"activated"`
@@ -492,34 +533,64 @@ func (c *Client) ActivatePackage(ctx context.Context, packageName string, maxObj
 		Failed:    []ActivationFailed{},
 	}
 
-	// Activate each object
+	if len(toActivate) == 0 {
+		result.Summary = "No inactive objects to activate"
+		return result, nil
+	}
+
+	// Build ObjectRef list and activate all in a single request so SAP can resolve
+	// mutual dependencies between objects (same behaviour as Eclipse ADT).
+	refs := make([]ObjectRef, 0, len(toActivate))
+	refMeta := make(map[string]InactiveObject, len(toActivate)) // URI → meta
 	for _, rec := range toActivate {
 		if rec.Object == nil {
 			continue
 		}
-		obj := rec.Object
-		activation, err := c.Activate(ctx, obj.URI, obj.Name)
-		switch {
-		case err != nil:
+		refs = append(refs, ObjectRef{URI: rec.Object.URI, Name: rec.Object.Name})
+		refMeta[rec.Object.URI] = *rec.Object
+	}
+
+	activation, err := c.ActivateMultiple(ctx, refs)
+	if err != nil {
+		return nil, fmt.Errorf("batch activation failed: %w", err)
+	}
+
+	// Build per-object reason strings from activation messages (keyed by ObjDescr/name).
+	reasons := make(map[string]string)
+	for _, msg := range activation.Messages {
+		if strings.ContainsAny(msg.Type, "EAX") && msg.ObjDescr != "" {
+			if reasons[msg.ObjDescr] == "" {
+				reasons[msg.ObjDescr] = msg.ShortText
+			}
+		}
+	}
+
+	// Objects still inactive after the request → Failed; the rest → Activated.
+	// A refusing object answers 200 but stays inactive, so this post-state check
+	// is what keeps it out of the Activated count (preserves the earlier fix:
+	// the summary must not say "Activated 12" about eleven).
+	stillInactive := make(map[string]bool, len(activation.Inactive))
+	for _, obj := range activation.Inactive {
+		stillInactive[obj.URI] = true
+	}
+
+	for _, ref := range refs {
+		meta := refMeta[ref.URI]
+		if stillInactive[ref.URI] {
+			reason := reasons[ref.Name]
+			if reason == "" {
+				reason = "still inactive after activation attempt"
+			}
 			result.Failed = append(result.Failed, ActivationFailed{
-				Name:   obj.Name,
-				Type:   obj.Type,
-				Reason: err.Error(),
+				Name:   ref.Name,
+				Type:   meta.Type,
+				Reason: reason,
 			})
-		case !activation.Success:
-			// The object that refuses to activate answers 200 like the rest, so
-			// counting only transport errors put it in the Activated list and
-			// the summary then said "Activated 12 objects" about eleven.
-			result.Failed = append(result.Failed, ActivationFailed{
-				Name:   obj.Name,
-				Type:   obj.Type,
-				Reason: strings.Join(activation.ProblemLines(), "; "),
-			})
-		default:
+		} else {
 			result.Activated = append(result.Activated, ActivatedObject{
-				Name: obj.Name,
-				Type: obj.Type,
-				URI:  obj.URI,
+				Name: ref.Name,
+				Type: meta.Type,
+				URI:  ref.URI,
 			})
 		}
 	}


### PR DESCRIPTION
Rebased & lands **#150** (thank you @txape10! 🙏) onto current `main`, closing #137.

## What
- `ActivateMultiple(refs)` / `ResolveObjectRef` / `ObjectRef` — activate several specific objects in **one** request so SAP resolves their mutual dependencies (the way Eclipse ADT does). New expert tool + MCP wiring.

## Rebase notes
- `ActivatePackage` is **kept at main's per-object version**: main's "a refusal counts as a failure" fix is verified by `activation_refusal_test.go` against that mechanism, and the original PR's batch rewrite of `ActivatePackage` reported refusals differently — so the rewrite is left out and the fix stays intact. The new batch capability ships as its own tool.
- Expert tool count 147 → **148** (parity test + published counts updated); `ActivateMultiple` is expert-only, focused stays at 100.

Validated: `go build ./...`, `go test ./...` → 22 packages ok.

🤖 Generated with [Claude Code](https://claude.com/claude-code)