### PR TITLE
fix(adt): retire the proxy context after DELETE, not only after UNLOCK

### DIFF
--- a/pkg/adt/config.go
+++ b/pkg/adt/config.go
@@ -82,7 +82,7 @@ type Config struct {
 	// stateless requests carry that empty cookie (the stateful context
 	// survives), the CSRF probe and every LOCK open a fresh stateful context
 	// with it (the chain re-learns the live one from the response), and after
-	// UNLOCK a stateless probe without the cookie retires the context.
+	// UNLOCK or DELETE a stateless probe without the cookie retires the context.
 	// Also enabled via SAP_PROXY_CONTEXTID_GUARD=true.
 	ProxyContextIDGuard bool
 }

--- a/pkg/adt/crud.go
+++ b/pkg/adt/crud.go
@@ -973,6 +973,12 @@ func (c *Client) DeleteObject(ctx context.Context, objectURL string, lockHandle 
 	// how a lock-window counter ends up permanently non-zero.
 	c.noteLockClosed(lockHandle)
 
+	// The DELETE consumed the handle, but the ENQUEUE the LOCK took lives on
+	// with the stateful context. Behind a session-holding proxy that context
+	// outlives the chain, and SM12 keeps showing a lock on an object that no
+	// longer exists. Retire the context the way UnlockObject does.
+	c.transport.ReleaseProxyContext(ctx)
+
 	return nil
 }
 

--- a/pkg/adt/crud_reconcile_test.go
+++ b/pkg/adt/crud_reconcile_test.go
@@ -351,6 +351,7 @@ type capturedReq struct {
 	method      string
 	path        string
 	sessionType string
+	cookie      string
 }
 
 func (h *headerCaptureMock) Do(req *http.Request) (*http.Response, error) {
@@ -358,6 +359,7 @@ func (h *headerCaptureMock) Do(req *http.Request) (*http.Response, error) {
 		method:      req.Method,
 		path:        req.URL.Path,
 		sessionType: req.Header.Get("X-sap-adt-sessiontype"),
+		cookie:      req.Header.Get("Cookie"),
 	})
 	return h.inner.Do(req)
 }
@@ -734,5 +736,76 @@ func TestLockObject_AllowsNoModificationOnReadLock(t *testing.T) {
 	}
 	if result.LockHandle != "HANDLE-X" {
 		t.Errorf("LockHandle = %q, want HANDLE-X", result.LockHandle)
+	}
+}
+
+// TestDeleteObject_ReleasesProxyContext pins the tail of a delete chain
+// behind a session-holding proxy: a DELETE consumes the lock handle but never
+// sends an UNLOCK, so the ENQUEUE stays with the stateful context until the
+// proxy times the session out. With the guard on, DeleteObject must retire the
+// context after the DELETE the same way UnlockObject does — a stateless HEAD
+// on discovery without a Cookie, so the proxy injects the context to end.
+func TestDeleteObject_ReleasesProxyContext(t *testing.T) {
+	for _, tc := range []struct {
+		name        string
+		guard       bool
+		wantRelease bool
+	}{
+		{name: "guard on retires the context", guard: true, wantRelease: true},
+		{name: "guard off sends nothing extra", guard: false, wantRelease: false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			mock := &methodPathMock{
+				routes: []routedResponse{
+					resp("", "discovery", 200, "ok"),
+					resp("", "informationsystem/search", 200, searchZTESTInTmpXML),
+					resp(http.MethodDelete, "/programs/programs/ZTEST", 200, ""),
+				},
+			}
+			tracker := &headerCaptureMock{inner: mock}
+			opts := []Option{WithAllowedPackages("$TMP")}
+			if tc.guard {
+				opts = append(opts, WithProxyContextIDGuard())
+			}
+			cfg := NewConfig("https://sap.example.com:44300", "user", "pass", opts...)
+			client := NewClientWithTransport(cfg, NewTransportWithClient(cfg, tracker))
+
+			err := client.DeleteObject(context.Background(), "/sap/bc/adt/programs/programs/ZTEST", "TESTHANDLE", "")
+			if err != nil {
+				t.Fatalf("DeleteObject failed: %v", err)
+			}
+
+			deleteAt := -1
+			for i, c := range tracker.captured {
+				if c.method == http.MethodDelete {
+					deleteAt = i
+				}
+			}
+			if deleteAt < 0 {
+				t.Fatal("no DELETE request was sent")
+			}
+			var release *capturedReq
+			for i := deleteAt + 1; i < len(tracker.captured); i++ {
+				c := tracker.captured[i]
+				if c.method == http.MethodHead && strings.HasSuffix(c.path, "/core/discovery") {
+					release = &tracker.captured[i]
+				}
+			}
+			if !tc.wantRelease {
+				if release != nil {
+					t.Fatalf("DELETE was followed by a HEAD on discovery although the guard is off: %+v", tracker.captured)
+				}
+				return
+			}
+			if release == nil {
+				t.Fatalf("DELETE was not followed by the stateless HEAD that retires the proxy context: %+v", tracker.captured)
+			}
+			if release.sessionType != "stateless" {
+				t.Errorf("release X-sap-adt-sessiontype = %q, want \"stateless\"", release.sessionType)
+			}
+			if release.cookie != "" {
+				t.Errorf("release Cookie = %q, want none so the proxy injects the context to be released", release.cookie)
+			}
+		})
 	}
 }


### PR DESCRIPTION

Follow-up to #209.

### What was wrong

#209 retires the stateful context a session-holding proxy chain injects once a lock chain is done: `UnlockObject` sends a stateless `HEAD` on discovery without the guard cookie, the proxy injects its stored `sap-contextid`, SAP ends that context, and the ENQUEUE goes with it.

A delete chain never reaches that point. `DeleteObject` consumes the lock handle with the `DELETE` itself and no `UNLOCK` follows, so the context — and the ENQUEUE the `LOCK` took — live on until the proxy times the session out. On the system this shows as a `TRDIR` lock (mode `X`, own user) on an object that no longer exists.

The most visible victim is `execute_abap`: every run creates `ZTEMP_EXEC_<n>`, runs it, locks it and deletes it, and leaves exactly one such lock behind. Reproduced with v2.57.0 behind the SAP Business Application Studio destination proxy (`SAP_PROXY_CONTEXTID_GUARD=true`): two runs at 12:07:17 and 12:07:25, two locks in SM12, both on programs that were already gone; the same runs an hour earlier had expired with the proxy session. The chain itself is fine — nothing fails, the object is deleted — it is only the leftover ENQUEUE.

### What changes

`DeleteObject` now calls `c.transport.ReleaseProxyContext(ctx)` after the `DELETE`, exactly where `UnlockObject` already does it after the `UNLOCK`. One line plus comment; the `Config.ProxyContextIDGuard` doc comment names DELETE next to UNLOCK. Without the guard `ReleaseProxyContext` is a no-op, so nothing changes for anyone not behind such a proxy.

### Test

`TestDeleteObject_ReleasesProxyContext` (pkg/adt/crud_reconcile_test.go) runs `DeleteObject` through the existing header-capturing mock, once with the guard and once without: with the guard the `DELETE` is followed by a `HEAD` on `/core/discovery` that is stateless and carries no `Cookie`; without the guard nothing follows the `DELETE`. The capture helper now also records the `Cookie` header.

`go build ./...`, `go vet`, `go test ./pkg/adt ./internal/mcp ./cmd/vsp -short` and `golangci-lint run --new-from-rev=origin/main` are clean.

### Live check

Built from this branch and run behind the BAS proxy (`SAP_PROXY_CONTEXTID_GUARD=true`): two `execute_abap` runs (`ZTEMP_EXEC_23226943`, `ZTEMP_EXEC_23233969`, both cleaned up), then a third run calling `ENQUEUE_READ` on `TRDIR ZTEMP_EXEC*` — zero locks. The same sequence on the v2.57.0 release binary an hour earlier left one `X` lock per run.