### PR TITLE
fix(mcp): normalize object_url to lowercase in EDITSOURCE (#118)

### DIFF
--- a/internal/mcp/handlers_fileio.go
+++ b/internal/mcp/handlers_fileio.go
@@ -210,6 +210,7 @@ func (s *Server) handleEditSource(ctx context.Context, request mcp.CallToolReque
 	if !ok || objectURL == "" {
 		return newToolResultError("object_url is required"), nil
 	}
+	objectURL = strings.ToLower(objectURL) // ADT paths are always lowercase; normalize defensively
 
 	oldString, ok := request.GetArguments()["old_string"].(string)
 	if !ok || oldString == "" {

--- a/pkg/adt/edit_source_case_test.go
+++ b/pkg/adt/edit_source_case_test.go
@@ -1,0 +1,48 @@
+package adt
+
+import (
+	"context"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+// TestEditSourceWithOptions_UppercaseClassIncludeURL_DetectedCorrectly pins
+// issue #118: EditSourceWithOptions classifies a class include by matching
+// lowercase literals ("/oo/classes/", "/includes/") against objectURL. An
+// uppercase caller (MCP tool arguments can arrive this way — e.g. copied
+// verbatim from a search/create result) used to misclassify the include as a
+// plain class source and append /source/main to a URL that must not have it,
+// breaking the source read before the edit itself is ever attempted.
+func TestEditSourceWithOptions_UppercaseClassIncludeURL_DetectedCorrectly(t *testing.T) {
+	rec := &adtRecorder{}
+	client := newStubbedClient(t, rec, func(w http.ResponseWriter, r *http.Request) {
+		// Any body that will not contain oldString is enough — the function
+		// hits its "old_string not found" early return right after the GET,
+		// so only that GET's path matters for this test.
+		_, _ = w.Write([]byte("some source that will not match"))
+	})
+
+	_, err := client.EditSourceWithOptions(context.Background(),
+		"/SAP/BC/ADT/OO/CLASSES/ZCL_FOO/INCLUDES/TESTCLASSES",
+		"this string is not present", "replacement",
+		&EditSourceOptions{SyntaxCheck: false})
+	if err != nil {
+		t.Fatalf("EditSourceWithOptions: %v", err)
+	}
+
+	calls := rec.snapshot()
+	if len(calls) != 1 {
+		t.Fatalf("expected exactly one request (the source GET); got %d: %v", len(calls), calls)
+	}
+
+	got := calls[0].path
+	if strings.HasSuffix(got, "/source/main") {
+		t.Errorf("class include GET must not have /source/main appended, got %q — "+
+			"an uppercase objectURL made isClassInclude misdetect it as a plain class (#118)", got)
+	}
+	want := "/sap/bc/adt/oo/classes/zcl_foo/includes/testclasses"
+	if got != want {
+		t.Errorf("GET path = %q, want %q (objectURL must be lowercased before use)", got, want)
+	}
+}

--- a/pkg/adt/workflows_edit.go
+++ b/pkg/adt/workflows_edit.go
@@ -162,6 +162,11 @@ func (c *Client) EditSourceWithOptions(ctx context.Context, objectURL, oldString
 	if opts == nil {
 		opts = &EditSourceOptions{SyntaxCheck: true}
 	}
+	// ADT paths are always lowercase; the class/include detection below matches
+	// on lowercase literals ("/oo/classes/", "/includes/"), so an uppercase
+	// caller would silently misclassify a class include as a plain class
+	// source and append /source/main to a URL that must not have it (#118).
+	objectURL = strings.ToLower(objectURL)
 	ctx = withExpectedSourceHash(ctx, opts.ExpectedSourceHash)
 
 	// Unified mutation policy gate (op type + package + transport). The mark


### PR DESCRIPTION
## Summary

Fixes the case-sensitivity issue reported as "Issue 1" in #118: `handleEditSource` routed `object_url` as-is, but ADT paths SAP returns are always lowercase. `EditSourceWithOptions` classifies the target (plain class vs. class include) by matching lowercase literals (`/oo/classes/`, `/includes/`) against `object_url` — so an uppercase URL (e.g. copied verbatim from a `search`/`create` result) would either fail to route with a misleading "No handler found", or worse, misclassify a class include as a plain class source and append `/source/main` to a URL that must not have it, breaking the source read before the edit is ever attempted.

## Fix

Normalize `object_url` to lowercase in two places:
- `internal/mcp/handlers_fileio.go`'s `handleEditSource`, immediately after reading and validating `object_url` from the MCP tool arguments.
- `pkg/adt/workflows_edit.go`'s `EditSourceWithOptions`, defensively, so any other caller of the public Go API is protected too — not just the MCP handler.

## Test

New `pkg/adt/edit_source_case_test.go` — `TestEditSourceWithOptions_UppercaseClassIncludeURL_DetectedCorrectly` drives `EditSourceWithOptions` with an all-uppercase class-include URL against a recording stub and asserts the source GET does not get `/source/main` appended. Confirmed it fails without the `pkg/adt` fix (misclassifies as a plain class, appends the suffix) and passes with it.

## Verification

- `go build ./...`, `go vet ./...` clean.
- `go test ./internal/mcp/... ./pkg/adt/...` green, aside from 3 pre-existing, unrelated flaky tests on `main` (Windows file-permission assumptions in `sso_test.go`, a recording-ID timing collision in `history_test.go`) — both untouched by this change and reproducible on unmodified `main`.
- No SAP system access needed for this specific fix — pure string normalization, already running in production for months in a downstream fork without issues.

## Scope

This addresses only "Issue 1" of the 5 bugs bundled in #118 (URL casing). The other 4 — UPDATE_SOURCE payload size limit, FUGR/FF creation, transport-lock reuse in EDITSOURCE, and method-level edit on transported classes — are separate, more invasive problems, not touched by this PR. See the follow-up comment on #118 for a breakdown.

## Credit

Root cause and fix originally identified and verified against a real SAP system by the issue reporter (see the comment history on #118). This PR ports that fix cleanly against current `main`, plus the `pkg/adt`-level hardening and the regression test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
